### PR TITLE
Fix oversized AQE root planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-08-03
+
+### Fixed
+
+- Preserved an exact AQE crafting parent when one finished root already needs
+  an intermediate count above signed `long`, instead of discarding the proven
+  `BigInteger` plan and surfacing `CountOverflowException`.
+- Marked those parents as Exact Vector-only in persistent state and excluded
+  them from standard AE2 checked-`long` child-window scheduling. If a suitable
+  physical Exact Vector target is unavailable, the order now waits safely.
+- Added regression coverage for
+  `9 * 1,590,831,717,672,932,009 = 14,317,485,459,056,388,081`, persistence,
+  and prevention of unsafe long-window fallback.
+
 ## [1.6.0] - 2026-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ CPUs into BigInteger CPUs.
   their signature requires `long`.
 - Exact inventory, missing amounts, task progress, escrow, and receipts are
   never derived from that facade.
+- If one finished root already needs an intermediate count above signed
+  `long`, a compatible AQE host keeps it as an Exact Vector-only parent. It is
+  never narrowed into a standard AE2 child window and waits when no suitable
+  physical executor is available.
 
 AQE is an optional current host integration. AAC is an optional physical
 executor. ACO itself requires neither mod.

--- a/README_ja.md
+++ b/README_ja.md
@@ -128,6 +128,9 @@ BigInteger化しません。
 - NBTは10進文字列ではなく正規byte array
 - `long`しか受け取れないAE2 APIに限り表示・互換Facadeを`Long.MAX_VALUE`へ飽和
 - 在庫、材料不足、Task進捗、Escrow、ReceiptはFacadeから逆算しない
+- 完成品1個分だけで中間要求が`long`を超える場合、対応AQE HostではExact Vector
+  専用親Jobとして保持する。通常AE2の子Windowへ縮小せず、適合する物理Executorが
+  なければ安全に待機する
 
 AQEは任意のHost連携、AACは任意の物理Executorです。ACO本体の必須依存では
 ありません。

--- a/RELEASE_NOTES_1.6.1.md
+++ b/RELEASE_NOTES_1.6.1.md
@@ -1,0 +1,40 @@
+# AE2 Crafting Optimizer 1.6.1
+
+## English
+
+ACO 1.6.1 fixes AQE crafting plans whose intermediate count exceeds signed
+`long` even for a single finished root.
+
+The proven `BigInteger` plan is now retained as an AQE Exact Vector-only parent
+instead of being discarded. Such a parent is never sent through standard AE2
+checked-`long` child-window scheduling. When no compatible physical Exact
+Vector target is available, the order waits without truncating counts or
+throwing `CountOverflowException`.
+
+Regression coverage includes:
+
+```text
+9 * 1,590,831,717,672,932,009
+= 14,317,485,459,056,388,081
+```
+
+Install the same JAR on the server and every client.
+
+## 日本語
+
+ACO 1.6.1では、完成品1個分だけでも中間要求数が符号付き`long`を超えるAQE
+クラフト計画を修正しました。
+
+証明済みの`BigInteger`計画を破棄せず、AQE Exact Vector専用の親Jobとして保持
+します。この親Jobは通常AE2のchecked-`long`子Windowへ流れません。対応する物理
+Exact Vector設備がない場合は、個数を切り詰めたり`CountOverflowException`を出したり
+せず、安全に待機します。
+
+次の実報告値を回帰テストへ追加しています。
+
+```text
+9 * 1,590,831,717,672,932,009
+= 14,317,485,459,056,388,081
+```
+
+サーバーと全クライアントへ同じJARを導入してください。

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ minecraft_version=1.21.1
 neo_version=21.1.247
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.6.0
+mod_version=1.6.1
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingRuntime.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingRuntime.java
@@ -163,7 +163,8 @@ public final class BigCraftingRuntime<K> {
                         job.patternGeneration(),
                         job.recipeGeneration(),
                         job.planningEpoch(),
-                        job.programFingerprint()))
+                        job.programFingerprint(),
+                        job.exactVectorRequired()))
                 .toList();
     }
 
@@ -801,7 +802,8 @@ public final class BigCraftingRuntime<K> {
             long patternGeneration,
             long recipeGeneration,
             String planningEpoch,
-            String programFingerprint) {
+            String programFingerprint,
+            boolean exactVectorRequired) {
         public VectorCandidate {
             Objects.requireNonNull(runtimeId, "runtimeId");
             Objects.requireNonNull(jobId, "jobId");

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2BigCraftingPlanFactory.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2BigCraftingPlanFactory.java
@@ -164,9 +164,17 @@ public final class Ae2BigCraftingPlanFactory {
                 requestedAmount,
                 ACOConfig.getBigIntegerExecutionWindow(),
                 maximumBits);
-        // 一回分すらlong互換AE2計画へ写せないレシピは、値を丸めず明示的に対象外にする。
-        if (safeWindow <= 0L) {
+        boolean exactVectorRequired = safeWindow <= 0L;
+        /*
+         * A single finished root can itself require counters above long. AQE's exact job owns the full
+         * BigInteger vector and does not need an AE2 child window, so retain that plan when Exact Vector
+         * execution is enabled. The placeholder limit is never scheduled by BigCraftingCpuLedger.
+         */
+        if (exactVectorRequired && !ACOConfig.enableAqeBigIntegerVectorParents()) {
             return null;
+        }
+        if (exactVectorRequired) {
+            safeWindow = 1L;
         }
         BigCraftingJob<AEKey> job = BigCraftingJob.rootWindowed(
                 UUID.randomUUID(),
@@ -177,7 +185,8 @@ public final class Ae2BigCraftingPlanFactory {
                 recipeGeneration,
                 safeWindow,
                 PlanningRuntimeEpoch.current(),
-                programFingerprint(program));
+                programFingerprint(program),
+                exactVectorRequired);
         return new PreparedBigRootPlan(
                 job,
                 plan,

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigCraftingCpuLedger.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigCraftingCpuLedger.java
@@ -80,6 +80,7 @@ public final class BigCraftingCpuLedger<K> {
         List<BigCraftingJob<K>> runnable = jobs.values().stream()
                 .filter(job -> !job.terminal()
                         && !job.hasPreparedExecution()
+                        && !job.exactVectorRequired()
                         && job.hasRemainingTasks())
                 .toList();
         if (runnable.isEmpty()) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigCraftingJob.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigCraftingJob.java
@@ -15,7 +15,7 @@ import net.minecraft.nbt.Tag;
  * 保存上の残量はBigIntegerのまま維持し、機械へ渡す時だけ上限付きlong実行Windowとして貸し出す。
  */
 public final class BigCraftingJob<K> {
-    public static final int SCHEMA_VERSION = 7;
+    public static final int SCHEMA_VERSION = 8;
     public static final long MAX_EXECUTIONS_PER_WINDOW = 1_048_576L;
     /**
      * BigInteger注文を標準AE2 Jobへ分割する時だけ使う予約済みTask ID。
@@ -35,6 +35,8 @@ public final class BigCraftingJob<K> {
     private final long maximumExecutionsPerWindow;
     private final String planningEpoch;
     private final String programFingerprint;
+    /** One finished root already exceeds AE2's long counters and must stay on Exact Vector execution. */
+    private final boolean exactVectorRequired;
     private final Map<String, BigCraftingTaskProgress> tasks;
     private final BigCraftingInventory<K> waitingFor;
     private BigInteger remainingExecutionTotal;
@@ -66,7 +68,8 @@ public final class BigCraftingJob<K> {
                 -1L,
                 MAX_EXECUTIONS_PER_WINDOW,
                 "",
-                "");
+                "",
+                false);
     }
 
     /**
@@ -154,7 +157,40 @@ public final class BigCraftingJob<K> {
                 recipeGeneration,
                 maximumExecutionsPerWindow,
                 planningEpoch,
-                programFingerprint);
+                programFingerprint,
+                false);
+    }
+
+    public static <K> BigCraftingJob<K> rootWindowed(
+            UUID id,
+            K requestedKey,
+            BigInteger requestedAmount,
+            BigInteger reservedCapacity,
+            long patternGeneration,
+            long recipeGeneration,
+            long maximumExecutionsPerWindow,
+            String planningEpoch,
+            String programFingerprint,
+            boolean exactVectorRequired) {
+        if (patternGeneration < -1L || recipeGeneration < -1L) {
+            throw new IllegalArgumentException("planning generations must be -1 or non-negative");
+        }
+        return new BigCraftingJob<>(
+                id,
+                requestedKey,
+                requestedAmount,
+                reservedCapacity,
+                newTasks(Map.of(ROOT_WINDOW_TASK_ID, requestedAmount)),
+                new BigCraftingInventory<>(Map.of()),
+                State.PLANNED,
+                null,
+                null,
+                patternGeneration,
+                recipeGeneration,
+                maximumExecutionsPerWindow,
+                planningEpoch,
+                programFingerprint,
+                exactVectorRequired);
     }
 
     /** Lossless migration entry point for an add-on's existing signed-long job state. */
@@ -196,7 +232,8 @@ public final class BigCraftingJob<K> {
                 -1L,
                 MAX_EXECUTIONS_PER_WINDOW,
                 "",
-                "");
+                "",
+                false);
     }
 
     private BigCraftingJob(
@@ -213,7 +250,8 @@ public final class BigCraftingJob<K> {
             long recipeGeneration,
             long maximumExecutionsPerWindow,
             String planningEpoch,
-            String programFingerprint) {
+            String programFingerprint,
+            boolean exactVectorRequired) {
         this.id = Objects.requireNonNull(id, "id");
         this.requestedKey = Objects.requireNonNull(requestedKey, "requestedKey");
         this.requestedAmount = positive(requestedAmount, "requestedAmount");
@@ -237,6 +275,11 @@ public final class BigCraftingJob<K> {
             throw new IllegalArgumentException(
                     "planning epoch and program fingerprint must both be present or absent");
         }
+        if (exactVectorRequired && this.programFingerprint.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Exact Vector-only jobs require persistent planning metadata");
+        }
+        this.exactVectorRequired = exactVectorRequired;
         this.tasks = new LinkedHashMap<>(Objects.requireNonNull(tasks, "tasks"));
         if (this.tasks.size() > MAX_ENTRIES) {
             throw new IllegalArgumentException("too many BigInteger crafting tasks");
@@ -499,6 +542,9 @@ public final class BigCraftingJob<K> {
         tag.putLong("maximumExecutionsPerWindow", maximumExecutionsPerWindow);
         tag.putString("planningEpoch", planningEpoch);
         tag.putString("programFingerprint", programFingerprint);
+        if (exactVectorRequired) {
+            tag.putBoolean("exactVectorRequired", true);
+        }
         if (preparedExecution != null) {
             CompoundTag prepared = new CompoundTag();
             prepared.putUUID("transaction", preparedExecution.transactionId());
@@ -609,7 +655,8 @@ public final class BigCraftingJob<K> {
                 schema >= 3 ? tag.getLong("recipeGeneration") : -1L,
                 maximumExecutionsPerWindow,
                 planningEpoch,
-                programFingerprint);
+                programFingerprint,
+                schema >= 8 && tag.getBoolean("exactVectorRequired"));
     }
 
     public UUID id() {
@@ -646,6 +693,10 @@ public final class BigCraftingJob<K> {
 
     public String programFingerprint() {
         return programFingerprint;
+    }
+
+    public boolean exactVectorRequired() {
+        return exactVectorRequired;
     }
 
     public synchronized State state() {

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingRuntimeTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingRuntimeTest.java
@@ -58,6 +58,33 @@ class BigCraftingRuntimeTest {
     }
 
     @Test
+    void exactVectorOnlyParentNeverFallsBackToLongWindowScheduling() {
+        BigCraftingRuntime<String> runtime = new BigCraftingRuntime<>(
+                BigInteger.TEN.pow(64), STRINGS, 512, 4);
+        BigCraftingJob<String> vectorOnly = BigCraftingJob.rootWindowed(
+                UUID.randomUUID(),
+                "output",
+                BigInteger.ONE,
+                BigInteger.TEN.pow(32),
+                12L,
+                34L,
+                1L,
+                "runtime-epoch",
+                "0123456789abcdef",
+                true);
+
+        assertTrue(runtime.submit(vectorOnly));
+        assertTrue(runtime.schedule(4L).isEmpty());
+        assertEquals(1, runtime.vectorCandidates().size());
+        assertTrue(runtime.vectorCandidates().get(0).exactVectorRequired());
+
+        BigCraftingRuntime<String> restored = BigCraftingRuntime.load(
+                runtime.save(), STRINGS, 512, 4);
+        assertTrue(restored.schedule(4L).isEmpty());
+        assertTrue(restored.vectorCandidates().get(0).exactVectorRequired());
+    }
+
+    @Test
     void compatibilityFacadeSaturatesWithoutTruncation() {
         BigCraftingRuntime<String> runtime = new BigCraftingRuntime<>(
                 BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE), STRINGS, 128, 1);

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/BigCraftingJobTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/BigCraftingJobTest.java
@@ -36,6 +36,27 @@ class BigCraftingJobTest {
     }
 
     @Test
+    void exactVectorRequirementSurvivesPersistence() {
+        BigCraftingJob<String> job = BigCraftingJob.rootWindowed(
+                UUID.randomUUID(),
+                "output",
+                BigInteger.ONE,
+                BigInteger.TEN.pow(32),
+                456L,
+                789L,
+                1L,
+                "runtime-epoch",
+                "0123456789abcdef",
+                true);
+
+        BigCraftingJob<String> restored = BigCraftingJob.load(
+                job.save(STRINGS, 1024), STRINGS, 1024);
+
+        assertTrue(restored.exactVectorRequired());
+        assertTrue(restored.isRootWindowed());
+    }
+
+    @Test
     void recipeSpecificWindowLimitSurvivesPersistenceAndCapsDispatch() {
         long safeRecipeWindow = 3L;
         BigCraftingJob<String> job = BigCraftingJob.rootWindowed(

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/OverflowPromotingCraftingPlannerTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/OverflowPromotingCraftingPlannerTest.java
@@ -54,6 +54,21 @@ class OverflowPromotingCraftingPlannerTest {
     }
 
     @Test
+    void promotesReportedNineTimesIntermediateOverflowExactly() {
+        BigInteger request = new BigInteger("1590831717672932009");
+        var result = new OverflowPromotingCraftingPlanner<String>(256).plan(
+                graph(9L), "output", request, Map.of());
+
+        var plan = assertInstanceOf(
+                OverflowPromotingCraftingPlanner.BigResult.class, result).plan();
+
+        assertTrue(result.provenEquivalent());
+        assertEquals(
+                new BigInteger("14317485459056388081"),
+                plan.patternExecutions().get("input"));
+    }
+
+    @Test
     void keepsSixteenGasBoundaryProbeOnLongPathBeforeIndividualOverflow() {
         var result = new OverflowPromotingCraftingPlanner<String>(256).plan(
                 longBoundaryProbeGraph(),


### PR DESCRIPTION
## Summary

- retain proven BigInteger plans when one finished root already exceeds signed `long`
- persist an Exact Vector-only execution requirement and prevent standard AE2 long-window fallback
- add regression coverage for the reported multiplication, persistence, and scheduling boundary
- prepare the 1.6.1 release documentation

## Verification

- `./gradlew.bat clean check build -PacoLocalModsDir=C:\Users\newadmin\AppData\Roaming\PrismLauncher\instances\1.21.1\minecraft\mods --no-daemon`
- `BUILD SUCCESSFUL`

Minecraft runtime startup was intentionally not run.

Closes #3