### PR TITLE
Codex向けAGENTS.mdとCodebase Mapを追加して探索トークンを削減

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# AE2 Crafting Optimizer agent entrypoint
+
+このファイルはCodex・LLM・自動レビューが、巨大なcrafting engine・Mixin・integration群を毎回すべて読み込まずに作業範囲を決めるための入口です。
+
+## 最小読込手順
+
+1. 最初に本書と [`docs/CODEBASE_MAP.md`](docs/CODEBASE_MAP.md) だけを読む。
+2. MapのTask routeを1つ選び、そのrouteに書かれた文書・package・直近testだけを開く。
+3. Javaファイルは対象class/method/symbolを検索し、必要範囲だけを読む。
+4. compile error、test failure、実依存関係が示した場合だけ隣接packageへ範囲を広げる。
+5. `CHANGELOG.md`、全release notes、`TEAM_DEVELOPMENT_SPEC.md`、全engine、全Mixin、全testの一括読込を開始条件にしない。
+
+## 固定契約
+
+```text
+Minecraft                 1.21.1
+Loader                    NeoForge 21.1.247+
+Runtime Java              21
+Applied Energistics 2     19.2.17
+Advanced AE               optional 1.6.11-1.21.1
+Neo ECO AE Extension      optional 21.1.1
+GTCEu / Mekanism          optional integrations
+Sides                     client + server
+```
+
+AE2は通常recipe、provider、crafting job、storage、extraction、insertion、energy、task progress、output accountingのauthorityです。ACOのdeep pathは、完全なaccounting contractをinput mutation前に証明できる場合だけ使用します。
+
+Ambiguous substitution、cycle、dynamic output、unsupported remaining item、generation mismatch、overflow、unknown integrationはAE2通常経路へ戻します。性能目的でstorage mutation、Registry、network、save contractを推測変更しません。
+
+BigInteger pathはexact transaction modelを維持し、暗黙の`longValue()`、数量比例loop、未証明のwhole-tree collapseを入れません。Physical crafting treeではrecipe stepごとのdependency順、escrow、durable receipt、一度だけのcreditを維持します。
+
+## 安全規則
+
+- input移動前にcomplete proof、checked arithmetic、generation validationを終える。
+- AE2 authorityを維持できない場合はconservative fallbackする。
+- cancellation、stale result、duplicate receipt、partial transactionを安全に拒否・回収する。
+- machine intentは候補探索を助けるだけで、machine側のlive input、voltage、energy、tank、output validationを省略しない。
+- Mixin target/versionが不一致なら推測で適用しない。
+- build/test成功だけで大規模ME network、実Server MSPT、restart recoveryを検証済みと書かない。
+
+## 編集規則
+
+- source変更では同じpackageのtestと [`docs/TESTING.md`](docs/TESTING.md) を先に確認する。
+- API変更は [`docs/BATCH_API.md`](docs/BATCH_API.md) とpublic contractを同じ変更で更新する。
+- engine/transaction ownership変更は `IMPLEMENTATION.md`、`EXPERIMENTAL_ENGINE.md`、`FEATURE_OWNERSHIP.md` の該当箇所を更新する。
+- entrypoint、主要package、重要testの位置が変わる場合は `docs/CODEBASE_MAP.md` を更新する。
+- 大型engine/Mixin/transaction fileは対象symbol周辺だけを読む。
+
+## 検証順
+
+```text
+対象test class
+-> ./gradlew test --no-daemon
+-> ./gradlew clean test build --no-daemon
+-> 必要な場合だけNeoForge実環境でAE2 job / save / restart / performance確認
+```
+
+unit test、fixture、CIだけの結果をruntime verifiedやperformance verifiedとして扱いません。

--- a/docs/CODEBASE_MAP.md
+++ b/docs/CODEBASE_MAP.md
@@ -1,0 +1,125 @@
+# AE2 Crafting Optimizer codebase map
+
+> **Navigation only.** このMapはCodex・LLM・reviewerの探索量を減らすためのindexです。要求・完成状態の正本はREADME、現行docs、Issueです。
+
+## 使い方
+
+1. [`../AGENTS.md`](../AGENTS.md)を読む。
+2. 下のTask routeを1つ選ぶ。
+3. `Read first`と`Source scope`だけを開き、symbol検索から始める。
+4. compile/test結果が別package依存を示した場合だけscopeを広げる。
+
+初期読込の対象外:
+
+```text
+build/**
+.gradle/**
+生成JAR / run directory / logs
+CHANGELOG.md全文
+全release notes
+TEAM_DEVELOPMENT_SPEC.md全文
+全engine / 全Mixin / 全test
+```
+
+## 固定座標
+
+```text
+Minecraft        1.21.1
+NeoForge         21.1.247+
+Java             21
+AE2              19.2.17
+Advanced AE      optional 1.6.11
+Neo ECO          optional 21.1.1
+GTCEu/Mekanism   optional
+```
+
+## Task router
+
+| Route | Task | Read first | Source scope | Verification scope |
+| --- | --- | --- | --- | --- |
+| `C0` | 製品定義、ownership、文書 | `../README.md`, `FEATURE_OWNERSHIP.md`, `IMPLEMENTATION.md` | docs中心 | 文書差分、`build` |
+| `P1` | compiled Pattern graph、candidate/missing memoization、planner | `IMPLEMENTATION.md`, `EXPERIMENTAL_ENGINE.md` | `engine`と直接使用する`access`/`lifecycle`だけ | planner/engine tests |
+| `T1` | transactional batching、escrow、physical crafting tree、receipt | `BATCH_API.md`, `EXPERIMENTAL_ENGINE.md`, `RESEARCH_FINAL_ENGINE.md` | `batch`, transaction関連`engine`, `api` | batch/transaction/recovery tests |
+| `E1` | CPU execution pacing、Instant wave、per-CPU/grid budget | READMEのCPU Execution、`IMPLEMENTATION.md` | execution/lifecycle関連packageと対象Mixin | execution/budget tests、実Server計測 |
+| `B1` | BigInteger amount/capacity、host API、checked arithmetic | `BATCH_API.md`, `IMPLEMENTATION.md` | `craftingamount`, `api`, BigInteger関連engine/batch | amount/API/overflow tests |
+| `I1` | GTCEu、Mekanism、Neo ECO、Advanced AE integration | READMEのMachine Intent/Physical Tree、`FEATURE_OWNERSHIP.md` | `integration`, `gtceu`, 対象mod専用packageだけ | version contract/adapter tests |
+| `M1` | Mixin、AE2 internals、accessor、generation hook | `IMPLEMENTATION.md`, `TESTING.md` | `mixin`/`access`の対象classとtargetだけ | Mixin descriptor/contract tests |
+| `U1` | Client UI、crafting amount、command、config | `CONFIGURATION.md`, READMEの該当節 | `client`, `command`, `config`, `craftingamount` | client/config/command tests |
+| `R1` | Mod metadata、Mixin config、resources、datapack | README、対象release notes | 対象`src/main/resources`だけ | resource validation、game load |
+| `V1` | Build、CI、publishing、release evidence | `TESTING.md`, `PUBLISHING.md`, `.github/workflows/build.yml` | `build.gradle`, `gradle.properties`, `src/test`, workflow | `clean test build` |
+
+## Package map
+
+| Package/path | Responsibility |
+| --- | --- |
+| `AE2CraftingOptimizer.java` | NeoForge mod entrypointとbootstrap |
+| `engine` | compiled planning、proof、generation-aware execution internals |
+| `batch` | quantity-independent transaction、escrow/receipt/batch adapter model |
+| `api` | versioned public/host contracts |
+| `access` | AE2/optional-mod internalsへの限定access surface |
+| `craftingamount` | long/BigInteger request amount handlingとUI/network bridge |
+| `lifecycle` | generation、grid/server lifecycle、cleanup |
+| `intent` | Pattern Providerからmachineへのrecipe intent保持 |
+| `integration` | optional mod integration orchestration |
+| `gtceu` | GTCEu固有intent/adapter path |
+| `client` | client-only UI/preview/display behavior |
+| `config` | common/client configとfeature gates |
+| `command` | diagnostics/administration commands |
+| `src/main/resources` | NeoForge metadata、Mixin descriptors、lang/assets |
+| `src/test` | planner、transaction、integration、Mixin、config、API contracts |
+
+package一覧は機能追加で増えるため、route選択後に対象packageの直下だけを列挙する。repository全体の再帰treeを初手にしない。
+
+## 主要entrypointとhot areas
+
+| Purpose | Path |
+| --- | --- |
+| Mod entrypoint | `src/main/java/com/syaru/ae2craftingoptimizer/AE2CraftingOptimizer.java` |
+| Public batch contract | `src/main/java/com/syaru/ae2craftingoptimizer/api` |
+| Transaction/batching | `src/main/java/com/syaru/ae2craftingoptimizer/batch` |
+| Planner/engine | `src/main/java/com/syaru/ae2craftingoptimizer/engine` |
+| BigInteger/request amount | `src/main/java/com/syaru/ae2craftingoptimizer/craftingamount` |
+| Machine integrations | `src/main/java/com/syaru/ae2craftingoptimizer/integration`, `gtceu` |
+| Mixin/access boundary | `src/main/java/com/syaru/ae2craftingoptimizer/mixin`, `access` |
+| Config | `src/main/java/com/syaru/ae2craftingoptimizer/config` |
+| Mod metadata | `src/main/resources/META-INF/neoforge.mods.toml` |
+| Mixin descriptor | `src/main/resources`内のACO mixin JSON |
+
+大型fileは全文から読まず、transaction UUID、generation key、escrow、Pattern push、budget、target methodなど対象symbolを先に検索する。
+
+## 文書の読み分け
+
+| Need | Document |
+| --- | --- |
+| ユーザー向け機能・固定環境 | `../README.md`, `../README_ja.md` |
+| 全体実装とownership | `IMPLEMENTATION.md`, `FEATURE_OWNERSHIP.md` |
+| Transactional batch public contract | `BATCH_API.md` |
+| Experimental/deep engine | `EXPERIMENTAL_ENGINE.md` |
+| 現在の実装status | `P0_P8_IMPLEMENTATION_STATUS.md` |
+| config | `CONFIGURATION.md` |
+| test/acceptance | `TESTING.md` |
+| physical tree research conclusion | `RESEARCH_FINAL_ENGINE.md` |
+| team-wide大規模設計 | `TEAM_DEVELOPMENT_SPEC.md`（必要なheadingだけ） |
+| release history | 該当versionのrelease notesだけ |
+
+## 検証の選び方
+
+```text
+対象packageのtest
+-> ./gradlew test --no-daemon
+-> ./gradlew clean test build --no-daemon
+-> 実AE2 networkでjob/cancel/restart/overflow/integration確認
+-> 性能変更時だけ同条件Server benchmark
+```
+
+実Minecraftを起動していない結果をruntime verified、実tick計測なしをperformance verifiedと書かない。
+
+## 省トークン用prompt
+
+```text
+AGENTS.mdとdocs/CODEBASE_MAP.mdの<Route ID>だけを基準に作業する。
+Task: <作業内容>
+最初はroute記載の文書、package、直近test以外を読まない。
+別scopeへ広げる場合はcompile dependencyまたはtest failureを根拠として示す。
+AE2 authorityとconservative fallbackを弱めない。
+```


### PR DESCRIPTION
## 目的

Codex・LLM・自動レビューがACOの全engine、transaction、Mixin、optional integration、長大な設計文書を毎回読み込まず、作業対象へ直接移動できるようにします。

## 変更内容

- root `AGENTS.md`
  - AE2 authorityとconservative fallback
  - exact transaction / BigInteger / escrow / receiptの安全規則
  - 最小読込・編集・検証順
- `docs/CODEBASE_MAP.md`
  - C0/P1/T1/E1/B1/I1/M1/U1/R1/V1のTask route
  - engine、batch、api、access、integration、GTCEu、client/configのpackage map
  - 文書の用途別index
  - 大型file/TEAM_DEVELOPMENT_SPEC/CHANGELOGの不要な全文読込を抑止
  - 省トークン用prompt

## 非変更範囲

MOD source、planner、storage mutation、API、Mixin、config、runtime behaviorは変更しません。実Minecraft互換や性能改善を新たに主張しません。

## 確認

文書のみの変更です。既存CIがある場合は通常どおり実行されます。