### PR TITLE
Implement #7: exact-count integration contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- Added the public exact-count integration contract for ACO, AQE, and AAC.
+- Added canonical bounded `BigInteger` payload encoding for requests, plans,
+  hosts, journals, and receipts.
+- Added capability discovery, revision wakeups, immutable snapshots, and
+  idempotent receipt reservation primitives for follow-up integrations.
+
 ## [1.6.1] - 2026-08-03
 
 ### Fixed

--- a/docs/EXACT_COUNT_API.md
+++ b/docs/EXACT_COUNT_API.md
@@ -1,0 +1,67 @@
+# Exact Count API
+
+ACO exposes the `com.syaru.ae2craftingoptimizer.api.contract` package as the only boundary that
+future AQE and AAC integrations should use for exact-count data.
+
+## One finite contract
+
+`ExactCountLimits.defaults()` is the shared boundary:
+
+| Field | Default |
+| --- | ---: |
+| maximum count bits | 1,048,576 |
+| maximum canonical count bytes | 131,072 |
+| maximum keys per payload | 65,536 |
+| maximum encoded payload bytes | 16 MiB |
+| maximum identifier length | 256 UTF-8 bytes |
+| maximum digest length | 128 bytes |
+
+The count and canonical-byte limits are deliberately matched: the largest accepted count can be
+encoded and saved without narrowing at a later stage. `longValue()` is never used as an implicit
+conversion. Callers must use `toLongExact` or `toIntExact` when a legacy narrow boundary is
+explicitly required.
+
+## Canonical persistence
+
+`CanonicalBigIntegerCodec` stores non-negative quantities as a minimal unsigned magnitude:
+
+- zero is exactly one byte, `00`;
+- positive values contain no leading zero byte;
+- negative, non-canonical, oversized, truncated, and unknown-schema values are rejected;
+- NBT schema `1` stores `<key>_schema` and `<key>_bytes`;
+- the old decimal string at `<key>` is read only as a validated migration source and is converted
+  to canonical fields on the next write.
+
+`ExactCountPayloadCodec` uses the same limits and deterministic ordering for all five owners:
+`REQUEST`, `VECTOR_PLAN`, `HOST`, `JOURNAL`, and `RECEIPT`. Payload keys are sorted lexicographically,
+duplicate keys and trailing bytes are rejected, and the payload is re-encoded after decoding to
+prove canonical equality.
+
+## Integration handshake
+
+`IntegrationCapabilitiesRegistry.initializeOnce` publishes one immutable startup snapshot. Optional
+mods read it with `snapshot()` or `peek()` and must fail closed when the required API version or
+feature is absent. ACO currently advertises no unimplemented feature as supported; later issues
+will enable bits only when their owning implementation and persistence tests are complete.
+
+The feature enum reserves contracts for atomic host snapshots, explicit host registration, receipt
+slot reservation, live transaction proof, revision wakeup, quarantined thread state, and exact
+storage journals.
+
+## Receipts, proofs, and revisions
+
+`LiveTransactionProof.UNKNOWN` is never an orphan proof. Only `ABSENT_CONFIRMED`, after the
+authoritative registries were checked at one revision, can pass `ReceiptOrphanPolicy.mayForget`.
+
+`ReceiptReservationProtocol` defines idempotent `reserve`, `commitRunning`, `markOutputReady`,
+`cancelReservation`, `acknowledge`, `forget`, and `quarantine` transitions. Reusing a transaction
+ID with a different digest is rejected.
+
+`RevisionWakeupApi` is only a wakeup optimization. Registrations return an `AutoCloseable` handle,
+listener references are weak, and durable receipts remain the completion proof. The
+`CraftingTableBatchSnapshot` output map is immutable, carries an explicit state, and is accepted
+by `SnapshotRevisionTracker` only in monotonic revision order.
+
+No ACO issue in this change alters physical crafting order, machine energy, storage ownership, or
+AE2's final crafting result. The actual AQE capacity ledger and AAC terminal ledger remain future
+issues.

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -13,6 +13,25 @@ It therefore separates:
 - physical recipe execution;
 - parent CPU completion.
 
+## Exact-count Integration Contract
+
+The shared integration contract lives under
+`com.syaru.ae2craftingoptimizer.api.contract`. It is deliberately independent
+of AE2, AQE, and AAC implementation classes so those integrations can adopt it
+without creating a compile-time cycle.
+
+- `CanonicalBigIntegerCodec` is the single bounded, unsigned-magnitude codec.
+- `ExactCountPayloadCodec` is the deterministic schema for request, plan, host,
+  journal, and receipt payloads.
+- `IntegrationCapabilitiesRegistry` exposes the immutable ACO capability
+  snapshot after common setup.
+- `ReceiptReservationProtocol` rejects stale or digest-mismatched transitions
+  instead of silently losing ownership.
+- `CraftingTableBatchSnapshot` and revision wakeups provide one consistent
+  view for later AQE/AAC host implementations.
+
+See `docs/EXACT_COUNT_API.md` for the versioned surface and adoption rules.
+
 ## Compiled Formula
 
 `CompiledRootProgram` is generation-keyed. For an eligible root it records:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -29,6 +29,10 @@ Automated tests cover:
 - nested NetworkStorage reuse while an outer capture remains active;
 - full-grid terminal reuse of AE2's cached inventory with exact sidecars;
 - preservation of add-on-specific terminal inventory paths.
+- canonical exact-count payload round trips and rejection of non-canonical
+  encodings;
+- capability snapshot initialization, receipt reservation idempotence, and
+  revisioned snapshot/wakeup behavior.
 
 ## Required Live Matrix
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/AE2CraftingOptimizer.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/AE2CraftingOptimizer.java
@@ -3,6 +3,9 @@ package com.syaru.ae2craftingoptimizer;
 import com.mojang.logging.LogUtils;
 import com.syaru.ae2craftingoptimizer.api.batch.PatternBatchApi;
 import com.syaru.ae2craftingoptimizer.api.batch.v2.PatternBatchV2Api;
+import com.syaru.ae2craftingoptimizer.api.contract.ExactCountLimits;
+import com.syaru.ae2craftingoptimizer.api.contract.IntegrationCapabilities;
+import com.syaru.ae2craftingoptimizer.api.contract.IntegrationCapabilitiesRegistry;
 import com.syaru.ae2craftingoptimizer.command.ACOIntentCommands;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.lifecycle.ACOServerLifecycle;
@@ -38,7 +41,15 @@ public final class AE2CraftingOptimizer {
     }
 
     private void commonSetup(FMLCommonSetupEvent event) {
+        IntegrationCapabilities capabilities = IntegrationCapabilities.forAco(ExactCountLimits.defaults());
+        IntegrationCapabilitiesRegistry.initializeOnce(capabilities);
         LOGGER.info("{} initialized", MOD_NAME);
+        LOGGER.info(
+                "ACO exact-count contract: {} count bits, {} canonical bytes, {} payload keys, {} encoded bytes",
+                capabilities.exactCountLimits().maximumCountBits(),
+                capabilities.exactCountLimits().maximumCanonicalBytes(),
+                capabilities.exactCountLimits().maximumKeysPerPayload(),
+                capabilities.exactCountLimits().maximumEncodedPayloadBytes());
     }
 
     private void onRegisterCommands(RegisterCommandsEvent event) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/BatchTargetRevision.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/BatchTargetRevision.java
@@ -1,0 +1,67 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import java.util.Objects;
+
+/** Immutable revision hint used only to wake a waiting integration. */
+public final class BatchTargetRevision {
+    private final String targetIdentity;
+    private final String runtimeIdentity;
+    private final String transactionId;
+    private final long ownershipRevision;
+    private final long progressRevision;
+    private final long receiptRevision;
+    private final String stateHint;
+
+    public BatchTargetRevision(
+            String targetIdentity,
+            String runtimeIdentity,
+            String transactionId,
+            long ownershipRevision,
+            long progressRevision,
+            long receiptRevision,
+            String stateHint,
+            ExactCountLimits limits) {
+        if (ownershipRevision < 0L || progressRevision < 0L || receiptRevision < 0L) {
+            throw new IllegalArgumentException("revisions must not be negative");
+        }
+        Objects.requireNonNull(limits, "limits").validateRequiredIdentifier(targetIdentity);
+        limits.validateRequiredIdentifier(runtimeIdentity);
+        limits.validateRequiredIdentifier(transactionId);
+        limits.validateIdentifier(stateHint);
+        this.targetIdentity = targetIdentity;
+        this.runtimeIdentity = runtimeIdentity;
+        this.transactionId = transactionId;
+        this.ownershipRevision = ownershipRevision;
+        this.progressRevision = progressRevision;
+        this.receiptRevision = receiptRevision;
+        this.stateHint = stateHint;
+    }
+
+    public String targetIdentity() {
+        return targetIdentity;
+    }
+
+    public String runtimeIdentity() {
+        return runtimeIdentity;
+    }
+
+    public String transactionId() {
+        return transactionId;
+    }
+
+    public long ownershipRevision() {
+        return ownershipRevision;
+    }
+
+    public long progressRevision() {
+        return progressRevision;
+    }
+
+    public long receiptRevision() {
+        return receiptRevision;
+    }
+
+    public String stateHint() {
+        return stateHint;
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/CanonicalBigIntegerCodec.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/CanonicalBigIntegerCodec.java
@@ -1,0 +1,108 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Objects;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
+
+/** Canonical unsigned-magnitude codec for non-negative exact quantities. */
+public final class CanonicalBigIntegerCodec {
+    public static final int NBT_SCHEMA_VERSION = 1;
+
+    private CanonicalBigIntegerCodec() {
+    }
+
+    public static byte[] encodeNonNegative(BigInteger value, ExactCountLimits limits) {
+        Objects.requireNonNull(limits, "limits").validateNonNegative(value);
+        byte[] encoded = value.toByteArray();
+        if (encoded.length > 1 && encoded[0] == 0) {
+            encoded = Arrays.copyOfRange(encoded, 1, encoded.length);
+        }
+        limits.validateCanonicalBytes(encoded);
+        return encoded;
+    }
+
+    public static byte[] encodePositive(BigInteger value, ExactCountLimits limits) {
+        Objects.requireNonNull(limits, "limits").validatePositive(value);
+        return encodeNonNegative(value, limits);
+    }
+
+    public static BigInteger decodeNonNegative(byte[] encoded, ExactCountLimits limits) {
+        Objects.requireNonNull(limits, "limits").validateCanonicalBytes(encoded);
+        return new BigInteger(1, encoded);
+    }
+
+    public static long toLongExact(BigInteger value, ExactCountLimits limits) {
+        return Objects.requireNonNull(limits, "limits").toLongExact(value);
+    }
+
+    public static int toIntExact(BigInteger value, ExactCountLimits limits) {
+        return Objects.requireNonNull(limits, "limits").toIntExact(value);
+    }
+
+    /**
+     * Writes the schema and bytes beside the supplied key. A legacy string at the key itself is
+     * removed so a subsequent save completes the migration to the canonical representation.
+     */
+    public static void writeNonNegative(
+            CompoundTag tag,
+            String key,
+            BigInteger value,
+            ExactCountLimits limits) {
+        Objects.requireNonNull(tag, "tag");
+        Objects.requireNonNull(key, "key");
+        byte[] encoded = encodeNonNegative(value, limits);
+        tag.putInt(schemaKey(key), NBT_SCHEMA_VERSION);
+        tag.putByteArray(bytesKey(key), encoded);
+        tag.remove(key);
+    }
+
+    /**
+     * Reads the canonical form or the legacy decimal string form. Unknown schemas and mixed
+     * canonical/legacy fields are rejected instead of being silently reset.
+     */
+    public static BigInteger readNonNegative(
+            CompoundTag tag,
+            String key,
+            ExactCountLimits limits) {
+        Objects.requireNonNull(tag, "tag");
+        Objects.requireNonNull(key, "key");
+        String schemaKey = schemaKey(key);
+        String bytesKey = bytesKey(key);
+        boolean hasSchema = tag.contains(schemaKey, Tag.TAG_INT);
+        boolean hasBytes = tag.contains(bytesKey, Tag.TAG_BYTE_ARRAY);
+        boolean hasLegacy = tag.contains(key, Tag.TAG_STRING);
+        if (hasLegacy && (hasSchema || hasBytes)) {
+            throw new IllegalArgumentException("mixed canonical and legacy count fields");
+        }
+        if (hasLegacy) {
+            String legacy = tag.getString(key);
+            if (legacy.isEmpty()) {
+                throw new IllegalArgumentException("legacy count is empty");
+            }
+            try {
+                BigInteger value = new BigInteger(legacy);
+                limits.validateNonNegative(value);
+                return value;
+            } catch (NumberFormatException exception) {
+                throw new IllegalArgumentException("invalid legacy count", exception);
+            }
+        }
+        if (!hasSchema || !hasBytes) {
+            throw new IllegalArgumentException("missing canonical count fields");
+        }
+        if (tag.getInt(schemaKey) != NBT_SCHEMA_VERSION) {
+            throw new IllegalArgumentException("unknown exact count NBT schema");
+        }
+        return decodeNonNegative(tag.getByteArray(bytesKey), limits);
+    }
+
+    private static String schemaKey(String key) {
+        return key + "_schema";
+    }
+
+    private static String bytesKey(String key) {
+        return key + "_bytes";
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/CraftingTableBatchSnapshot.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/CraftingTableBatchSnapshot.java
@@ -1,0 +1,57 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.TreeMap;
+
+/** Immutable, revisioned output snapshot for external consumers. */
+public final class CraftingTableBatchSnapshot {
+    private final long revision;
+    private final SnapshotState state;
+    private final NavigableMap<String, BigInteger> outputCounts;
+
+    private CraftingTableBatchSnapshot(
+            long revision,
+            SnapshotState state,
+            NavigableMap<String, BigInteger> outputCounts) {
+        this.revision = revision;
+        this.state = state;
+        this.outputCounts = Collections.unmodifiableNavigableMap(outputCounts);
+    }
+
+    public static CraftingTableBatchSnapshot of(
+            long revision,
+            SnapshotState state,
+            Map<String, BigInteger> outputCounts,
+            ExactCountLimits limits) {
+        if (revision < 0L) {
+            throw new IllegalArgumentException("revision must not be negative");
+        }
+        Objects.requireNonNull(state, "state");
+        Objects.requireNonNull(outputCounts, "outputCounts");
+        Objects.requireNonNull(limits, "limits").validateKeyCount(outputCounts.size());
+        NavigableMap<String, BigInteger> ordered = new TreeMap<>();
+        for (Map.Entry<String, BigInteger> entry : outputCounts.entrySet()) {
+            limits.validateRequiredIdentifier(entry.getKey());
+            limits.validateNonNegative(entry.getValue());
+            ordered.put(entry.getKey(), entry.getValue());
+        }
+        return new CraftingTableBatchSnapshot(revision, state, ordered);
+    }
+
+    public long revision() {
+        return revision;
+    }
+
+    public SnapshotState state() {
+        return state;
+    }
+
+    /** Returns an immutable, lexicographically ordered view. */
+    public Map<String, BigInteger> outputCounts() {
+        return outputCounts;
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/ExactCountLimits.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/ExactCountLimits.java
@@ -1,0 +1,182 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+/**
+ * The single finite boundary shared by exact-count requests and persistence payloads.
+ *
+ * <p>The default count limit is intentionally the existing request boundary of 1,048,576
+ * bits. Its canonical magnitude is 131,072 bytes, so it is persisted without a narrower
+ * codec-specific truncation boundary.</p>
+ */
+public final class ExactCountLimits {
+    public static final int DEFAULT_MAXIMUM_COUNT_BITS = 1_048_576;
+    public static final int DEFAULT_MAXIMUM_CANONICAL_BYTES = 131_072;
+    public static final int DEFAULT_MAXIMUM_KEYS_PER_PAYLOAD = 65_536;
+    public static final int DEFAULT_MAXIMUM_ENCODED_PAYLOAD_BYTES = 16 * 1024 * 1024;
+    public static final int DEFAULT_MAXIMUM_IDENTIFIER_LENGTH = 256;
+    public static final int DEFAULT_MAXIMUM_DIGEST_LENGTH = 128;
+
+    private final int maximumCountBits;
+    private final int maximumCanonicalBytes;
+    private final int maximumKeysPerPayload;
+    private final int maximumEncodedPayloadBytes;
+    private final int maximumIdentifierLength;
+    private final int maximumDigestLength;
+
+    public ExactCountLimits(
+            int maximumCountBits,
+            int maximumCanonicalBytes,
+            int maximumKeysPerPayload,
+            int maximumEncodedPayloadBytes,
+            int maximumIdentifierLength,
+            int maximumDigestLength) {
+        if (maximumCountBits < 1) {
+            throw new IllegalArgumentException("maximumCountBits must be positive");
+        }
+        if (maximumCanonicalBytes < 1) {
+            throw new IllegalArgumentException("maximumCanonicalBytes must be positive");
+        }
+        if ((long) maximumCanonicalBytes * 8L < maximumCountBits) {
+            throw new IllegalArgumentException(
+                    "maximumCanonicalBytes cannot store maximumCountBits");
+        }
+        if (maximumKeysPerPayload < 0) {
+            throw new IllegalArgumentException("maximumKeysPerPayload must not be negative");
+        }
+        if (maximumEncodedPayloadBytes < maximumCanonicalBytes) {
+            throw new IllegalArgumentException(
+                    "maximumEncodedPayloadBytes must include one maximum count");
+        }
+        if (maximumIdentifierLength < 1) {
+            throw new IllegalArgumentException("maximumIdentifierLength must be positive");
+        }
+        if (maximumDigestLength < 0) {
+            throw new IllegalArgumentException("maximumDigestLength must not be negative");
+        }
+        this.maximumCountBits = maximumCountBits;
+        this.maximumCanonicalBytes = maximumCanonicalBytes;
+        this.maximumKeysPerPayload = maximumKeysPerPayload;
+        this.maximumEncodedPayloadBytes = maximumEncodedPayloadBytes;
+        this.maximumIdentifierLength = maximumIdentifierLength;
+        this.maximumDigestLength = maximumDigestLength;
+    }
+
+    public static ExactCountLimits defaults() {
+        return new ExactCountLimits(
+                DEFAULT_MAXIMUM_COUNT_BITS,
+                DEFAULT_MAXIMUM_CANONICAL_BYTES,
+                DEFAULT_MAXIMUM_KEYS_PER_PAYLOAD,
+                DEFAULT_MAXIMUM_ENCODED_PAYLOAD_BYTES,
+                DEFAULT_MAXIMUM_IDENTIFIER_LENGTH,
+                DEFAULT_MAXIMUM_DIGEST_LENGTH);
+    }
+
+    public int maximumCountBits() {
+        return maximumCountBits;
+    }
+
+    public int maximumCanonicalBytes() {
+        return maximumCanonicalBytes;
+    }
+
+    public int maximumKeysPerPayload() {
+        return maximumKeysPerPayload;
+    }
+
+    public int maximumEncodedPayloadBytes() {
+        return maximumEncodedPayloadBytes;
+    }
+
+    public int maximumIdentifierLength() {
+        return maximumIdentifierLength;
+    }
+
+    public int maximumDigestLength() {
+        return maximumDigestLength;
+    }
+
+    public void validateNonNegative(BigInteger value) {
+        Objects.requireNonNull(value, "value");
+        if (value.signum() < 0) {
+            throw new IllegalArgumentException("exact counts must not be negative");
+        }
+        if (value.signum() != 0 && value.bitLength() > maximumCountBits) {
+            throw new IllegalArgumentException(
+                    "exact count exceeds maximum bit length " + maximumCountBits);
+        }
+    }
+
+    public void validatePositive(BigInteger value) {
+        validateNonNegative(value);
+        if (value.signum() == 0) {
+            throw new IllegalArgumentException("exact count must be positive");
+        }
+    }
+
+    public void validateCanonicalBytes(byte[] bytes) {
+        Objects.requireNonNull(bytes, "bytes");
+        if (bytes.length == 0 || bytes.length > maximumCanonicalBytes) {
+            throw new IllegalArgumentException("invalid canonical count byte length");
+        }
+        if (bytes.length > 1 && bytes[0] == 0) {
+            throw new IllegalArgumentException("non-canonical count has a leading zero");
+        }
+        int bitLength = bytes.length == 1 && bytes[0] == 0
+                ? 0
+                : (bytes.length - 1) * 8 + (Integer.SIZE - Integer.numberOfLeadingZeros(bytes[0] & 0xff));
+        if (bitLength > maximumCountBits) {
+            throw new IllegalArgumentException(
+                    "canonical count exceeds maximum bit length " + maximumCountBits);
+        }
+    }
+
+    public void validateIdentifier(String identifier) {
+        Objects.requireNonNull(identifier, "identifier");
+        if (utf8Length(identifier) > maximumIdentifierLength) {
+            throw new IllegalArgumentException("identifier exceeds maximum length");
+        }
+    }
+
+    public void validateRequiredIdentifier(String identifier) {
+        validateIdentifier(identifier);
+        if (identifier.isEmpty()) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+    }
+
+    public void validateDigest(byte[] digest) {
+        Objects.requireNonNull(digest, "digest");
+        if (digest.length > maximumDigestLength) {
+            throw new IllegalArgumentException("digest exceeds maximum length");
+        }
+    }
+
+    public void validateKeyCount(int keyCount) {
+        if (keyCount < 0 || keyCount > maximumKeysPerPayload) {
+            throw new IllegalArgumentException("payload contains too many keys");
+        }
+    }
+
+    public void validateEncodedPayloadLength(int length) {
+        if (length < 0 || length > maximumEncodedPayloadBytes) {
+            throw new IllegalArgumentException("encoded payload exceeds maximum length");
+        }
+    }
+
+    public long toLongExact(BigInteger value) {
+        validateNonNegative(value);
+        return value.longValueExact();
+    }
+
+    public int toIntExact(BigInteger value) {
+        validateNonNegative(value);
+        return value.intValueExact();
+    }
+
+    private static int utf8Length(String value) {
+        return value.getBytes(StandardCharsets.UTF_8).length;
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/ExactCountPayload.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/ExactCountPayload.java
@@ -1,0 +1,88 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.TreeMap;
+
+/** Immutable common payload used by requests, plans, hosts, journals, and receipts. */
+public final class ExactCountPayload {
+    private final PayloadKind kind;
+    private final String identifier;
+    private final NavigableMap<String, BigInteger> counts;
+    private final byte[] digest;
+
+    private ExactCountPayload(
+            PayloadKind kind,
+            String identifier,
+            NavigableMap<String, BigInteger> counts,
+            byte[] digest) {
+        this.kind = kind;
+        this.identifier = identifier;
+        this.counts = Collections.unmodifiableNavigableMap(counts);
+        this.digest = digest.clone();
+    }
+
+    public static ExactCountPayload of(
+            PayloadKind kind,
+            String identifier,
+            Map<String, BigInteger> counts,
+            byte[] digest,
+            ExactCountLimits limits) {
+        Objects.requireNonNull(kind, "kind");
+        Objects.requireNonNull(counts, "counts");
+        Objects.requireNonNull(limits, "limits");
+        limits.validateIdentifier(identifier);
+        limits.validateDigest(digest);
+        limits.validateKeyCount(counts.size());
+        NavigableMap<String, BigInteger> ordered = new TreeMap<>();
+        for (Map.Entry<String, BigInteger> entry : counts.entrySet()) {
+            limits.validateRequiredIdentifier(entry.getKey());
+            limits.validateNonNegative(entry.getValue());
+            if (ordered.put(entry.getKey(), entry.getValue()) != null) {
+                throw new IllegalArgumentException("duplicate exact-count payload key");
+            }
+        }
+        return new ExactCountPayload(kind, identifier, ordered, digest);
+    }
+
+    public PayloadKind kind() {
+        return kind;
+    }
+
+    public String identifier() {
+        return identifier;
+    }
+
+    /** Returns an immutable, lexicographically ordered view. */
+    public Map<String, BigInteger> counts() {
+        return counts;
+    }
+
+    public byte[] digest() {
+        return digest.clone();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof ExactCountPayload payload)) {
+            return false;
+        }
+        return kind == payload.kind
+                && identifier.equals(payload.identifier)
+                && counts.equals(payload.counts)
+                && Arrays.equals(digest, payload.digest);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(kind, identifier, counts);
+        return 31 * result + Arrays.hashCode(digest);
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/ExactCountPayloadCodec.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/ExactCountPayloadCodec.java
@@ -1,0 +1,203 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
+
+/** Deterministic binary/NBT codec shared by every exact-count payload owner. */
+public final class ExactCountPayloadCodec {
+    public static final int NBT_SCHEMA_VERSION = 1;
+    private static final int MAGIC = 0x41434f31;
+
+    private ExactCountPayloadCodec() {
+    }
+
+    public static byte[] encode(ExactCountPayload payload, ExactCountLimits limits) {
+        Objects.requireNonNull(payload, "payload");
+        Objects.requireNonNull(limits, "limits");
+        // Revalidate at the codec boundary so callers cannot pair a payload with a narrower store.
+        ExactCountPayload validated = ExactCountPayload.of(
+                payload.kind(), payload.identifier(), payload.counts(), payload.digest(), limits);
+        try {
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            DataOutputStream output = new DataOutputStream(bytes);
+            output.writeInt(MAGIC);
+            output.writeByte(NBT_SCHEMA_VERSION);
+            output.writeByte(validated.kind().wireId());
+            writeString(output, validated.identifier(), limits, false);
+            byte[] digest = validated.digest();
+            limits.validateDigest(digest);
+            output.writeInt(digest.length);
+            output.write(digest);
+            limits.validateKeyCount(validated.counts().size());
+            output.writeInt(validated.counts().size());
+            for (Map.Entry<String, BigInteger> entry : validated.counts().entrySet()) {
+                writeString(output, entry.getKey(), limits, true);
+                byte[] count = CanonicalBigIntegerCodec.encodeNonNegative(entry.getValue(), limits);
+                output.writeInt(count.length);
+                output.write(count);
+            }
+            output.flush();
+            byte[] encoded = bytes.toByteArray();
+            limits.validateEncodedPayloadLength(encoded.length);
+            return encoded;
+        } catch (IOException exception) {
+            throw new IllegalStateException("in-memory exact-count encoding failed", exception);
+        }
+    }
+
+    public static ExactCountPayload decode(byte[] encoded, ExactCountLimits limits) {
+        Objects.requireNonNull(encoded, "encoded");
+        Objects.requireNonNull(limits, "limits");
+        limits.validateEncodedPayloadLength(encoded.length);
+        try {
+            DataInputStream input = new DataInputStream(new ByteArrayInputStream(encoded));
+            if (input.readInt() != MAGIC) {
+                throw new IllegalArgumentException("invalid exact-count payload magic");
+            }
+            if (input.readUnsignedByte() != NBT_SCHEMA_VERSION) {
+                throw new IllegalArgumentException("unknown exact-count payload schema");
+            }
+            PayloadKind kind = PayloadKind.fromWireId(input.readUnsignedByte());
+            String identifier = readString(input, limits, false);
+            int digestLength = readLength(input, limits.maximumDigestLength(), "digest");
+            byte[] digest = input.readNBytes(digestLength);
+            if (digest.length != digestLength) {
+                throw new EOFException("truncated exact-count digest");
+            }
+            int keyCount = readLength(input, limits.maximumKeysPerPayload(), "key");
+            java.util.Map<String, BigInteger> counts = new java.util.TreeMap<>();
+            String previousKey = null;
+            for (int index = 0; index < keyCount; index++) {
+                String key = readString(input, limits, true);
+                if (previousKey != null && previousKey.compareTo(key) >= 0) {
+                    throw new IllegalArgumentException("exact-count keys are not canonical");
+                }
+                previousKey = key;
+                int countLength = readLength(input, limits.maximumCanonicalBytes(), "count");
+                byte[] countBytes = input.readNBytes(countLength);
+                if (countBytes.length != countLength) {
+                    throw new EOFException("truncated exact-count value");
+                }
+                BigInteger count = CanonicalBigIntegerCodec.decodeNonNegative(countBytes, limits);
+                if (counts.put(key, count) != null) {
+                    throw new IllegalArgumentException("duplicate exact-count key");
+                }
+            }
+            if (input.available() != 0) {
+                throw new IllegalArgumentException("trailing bytes in exact-count payload");
+            }
+            ExactCountPayload payload = ExactCountPayload.of(kind, identifier, counts, digest, limits);
+            if (!Arrays.equals(encoded, encode(payload, limits))) {
+                throw new IllegalArgumentException("non-canonical exact-count payload");
+            }
+            return payload;
+        } catch (EOFException exception) {
+            throw new IllegalArgumentException("truncated exact-count payload", exception);
+        } catch (IOException exception) {
+            throw new IllegalArgumentException("invalid exact-count payload", exception);
+        }
+    }
+
+    public static void writeToNbt(
+            CompoundTag tag,
+            String key,
+            ExactCountPayload payload,
+            ExactCountLimits limits) {
+        Objects.requireNonNull(tag, "tag");
+        Objects.requireNonNull(key, "key");
+        tag.putInt(schemaKey(key), NBT_SCHEMA_VERSION);
+        tag.putByteArray(bytesKey(key), encode(payload, limits));
+        tag.remove(key);
+    }
+
+    public static ExactCountPayload readFromNbt(
+            CompoundTag tag,
+            String key,
+            ExactCountLimits limits) {
+        Objects.requireNonNull(tag, "tag");
+        Objects.requireNonNull(key, "key");
+        String schemaKey = schemaKey(key);
+        String bytesKey = bytesKey(key);
+        if (tag.contains(key, Tag.TAG_STRING)) {
+            throw new IllegalArgumentException("legacy payload has no safe migration");
+        }
+        if (!tag.contains(schemaKey, Tag.TAG_INT) || !tag.contains(bytesKey, Tag.TAG_BYTE_ARRAY)) {
+            throw new IllegalArgumentException("missing exact-count payload fields");
+        }
+        if (tag.getInt(schemaKey) != NBT_SCHEMA_VERSION) {
+            throw new IllegalArgumentException("unknown exact-count payload NBT schema");
+        }
+        return decode(tag.getByteArray(bytesKey), limits);
+    }
+
+    private static int readLength(DataInputStream input, int maximum, String label) throws IOException {
+        int length = input.readInt();
+        if (length < 0 || length > maximum) {
+            throw new IllegalArgumentException(label + " length exceeds the exact-count limit");
+        }
+        return length;
+    }
+
+    private static void writeString(
+            DataOutputStream output,
+            String value,
+            ExactCountLimits limits,
+            boolean required) throws IOException {
+        if (required) {
+            limits.validateRequiredIdentifier(value);
+        } else {
+            limits.validateIdentifier(value);
+        }
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        output.writeInt(bytes.length);
+        output.write(bytes);
+    }
+
+    private static String readString(
+            DataInputStream input,
+            ExactCountLimits limits,
+            boolean required) throws IOException {
+        int length = readLength(input, limits.maximumIdentifierLength(), "identifier");
+        byte[] bytes = input.readNBytes(length);
+        if (bytes.length != length) {
+            throw new EOFException("truncated identifier");
+        }
+        try {
+            String value = StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(bytes))
+                    .toString();
+            if (required) {
+                limits.validateRequiredIdentifier(value);
+            } else {
+                limits.validateIdentifier(value);
+            }
+            return value;
+        } catch (CharacterCodingException exception) {
+            throw new IllegalArgumentException("identifier is not valid UTF-8", exception);
+        }
+    }
+
+    private static String schemaKey(String key) {
+        return key + "_schema";
+    }
+
+    private static String bytesKey(String key) {
+        return key + "_bytes";
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/IntegrationCapabilities.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/IntegrationCapabilities.java
@@ -1,0 +1,94 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+
+/** Immutable startup handshake snapshot exposed to optional integration mods. */
+public final class IntegrationCapabilities {
+    public static final int API_VERSION = 1;
+
+    private final int bigCraftingApiVersion;
+    private final int patternBatchApiVersion;
+    private final int craftingTableBatchApiVersion;
+    private final int receiptProtocolVersion;
+    private final int persistenceSchemaVersion;
+    private final ExactCountLimits exactCountLimits;
+    private final Set<SupportedFeature> supportedFeatures;
+
+    public IntegrationCapabilities(
+            int bigCraftingApiVersion,
+            int patternBatchApiVersion,
+            int craftingTableBatchApiVersion,
+            int receiptProtocolVersion,
+            int persistenceSchemaVersion,
+            ExactCountLimits exactCountLimits,
+            Set<SupportedFeature> supportedFeatures) {
+        this.bigCraftingApiVersion = positiveVersion(bigCraftingApiVersion, "bigCraftingApiVersion");
+        this.patternBatchApiVersion = positiveVersion(patternBatchApiVersion, "patternBatchApiVersion");
+        this.craftingTableBatchApiVersion = positiveVersion(
+                craftingTableBatchApiVersion, "craftingTableBatchApiVersion");
+        this.receiptProtocolVersion = positiveVersion(receiptProtocolVersion, "receiptProtocolVersion");
+        this.persistenceSchemaVersion = positiveVersion(persistenceSchemaVersion, "persistenceSchemaVersion");
+        this.exactCountLimits = Objects.requireNonNull(exactCountLimits, "exactCountLimits");
+        Objects.requireNonNull(supportedFeatures, "supportedFeatures");
+        EnumSet<SupportedFeature> copy = EnumSet.noneOf(SupportedFeature.class);
+        for (SupportedFeature feature : supportedFeatures) {
+            copy.add(Objects.requireNonNull(feature, "supportedFeatures contains null"));
+        }
+        this.supportedFeatures = Set.copyOf(copy);
+    }
+
+    public static IntegrationCapabilities forAco(ExactCountLimits limits) {
+        // Features are advertised only after their owning implementation is complete.
+        return new IntegrationCapabilities(1, 1, 1, 1, 1, limits, Set.of());
+    }
+
+    public int bigCraftingApiVersion() {
+        return bigCraftingApiVersion;
+    }
+
+    public int patternBatchApiVersion() {
+        return patternBatchApiVersion;
+    }
+
+    public int craftingTableBatchApiVersion() {
+        return craftingTableBatchApiVersion;
+    }
+
+    public int receiptProtocolVersion() {
+        return receiptProtocolVersion;
+    }
+
+    public int persistenceSchemaVersion() {
+        return persistenceSchemaVersion;
+    }
+
+    public ExactCountLimits exactCountLimits() {
+        return exactCountLimits;
+    }
+
+    public Set<SupportedFeature> supportedFeatures() {
+        return supportedFeatures;
+    }
+
+    public boolean supports(SupportedFeature feature) {
+        return supportedFeatures.contains(Objects.requireNonNull(feature, "feature"));
+    }
+
+    public void requireFeatures(Set<SupportedFeature> required) {
+        Objects.requireNonNull(required, "required");
+        for (SupportedFeature feature : required) {
+            if (!supports(feature)) {
+                throw new IllegalStateException("required integration feature is unavailable: " + feature);
+            }
+        }
+    }
+
+    private static int positiveVersion(int value, String name) {
+        if (value < 1) {
+            throw new IllegalArgumentException(name + " must be positive");
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/IntegrationCapabilitiesRegistry.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/IntegrationCapabilitiesRegistry.java
@@ -1,0 +1,32 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** One-shot owner of the immutable integration handshake snapshot. */
+public final class IntegrationCapabilitiesRegistry {
+    private static final AtomicReference<IntegrationCapabilities> SNAPSHOT = new AtomicReference<>();
+
+    private IntegrationCapabilitiesRegistry() {
+    }
+
+    public static void initializeOnce(IntegrationCapabilities capabilities) {
+        Objects.requireNonNull(capabilities, "capabilities");
+        if (!SNAPSHOT.compareAndSet(null, capabilities)) {
+            throw new IllegalStateException("integration capabilities were already initialized");
+        }
+    }
+
+    public static Optional<IntegrationCapabilities> peek() {
+        return Optional.ofNullable(SNAPSHOT.get());
+    }
+
+    public static IntegrationCapabilities snapshot() {
+        IntegrationCapabilities capabilities = SNAPSHOT.get();
+        if (capabilities == null) {
+            throw new IllegalStateException("integration capabilities are not initialized");
+        }
+        return capabilities;
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/LiveTransactionProof.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/LiveTransactionProof.java
@@ -1,0 +1,101 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/** Immutable proof returned by a live transaction authority. */
+public final class LiveTransactionProof {
+    private final String ownerRuntimeId;
+    private final long ownerGeneration;
+    private final String transactionId;
+    private final byte[] payloadDigest;
+    private final LiveTransactionState result;
+    private final String accountingStateHint;
+
+    public LiveTransactionProof(
+            String ownerRuntimeId,
+            long ownerGeneration,
+            String transactionId,
+            byte[] payloadDigest,
+            LiveTransactionState result,
+            String accountingStateHint,
+            ExactCountLimits limits) {
+        if (ownerGeneration < 0L) {
+            throw new IllegalArgumentException("ownerGeneration must not be negative");
+        }
+        Objects.requireNonNull(limits, "limits").validateRequiredIdentifier(ownerRuntimeId);
+        limits.validateRequiredIdentifier(transactionId);
+        limits.validateDigest(payloadDigest);
+        limits.validateIdentifier(accountingStateHint);
+        this.ownerRuntimeId = ownerRuntimeId;
+        this.ownerGeneration = ownerGeneration;
+        this.transactionId = transactionId;
+        this.payloadDigest = payloadDigest.clone();
+        this.result = Objects.requireNonNull(result, "result");
+        this.accountingStateHint = accountingStateHint;
+    }
+
+    public static LiveTransactionProof unknown(
+            String ownerRuntimeId,
+            long ownerGeneration,
+            String transactionId,
+            byte[] payloadDigest,
+            ExactCountLimits limits) {
+        return new LiveTransactionProof(
+                ownerRuntimeId,
+                ownerGeneration,
+                transactionId,
+                payloadDigest,
+                LiveTransactionState.UNKNOWN,
+                "unknown",
+                limits);
+    }
+
+    public static LiveTransactionProof absentConfirmed(
+            String ownerRuntimeId,
+            long ownerGeneration,
+            String transactionId,
+            byte[] payloadDigest,
+            ExactCountLimits limits) {
+        return new LiveTransactionProof(
+                ownerRuntimeId,
+                ownerGeneration,
+                transactionId,
+                payloadDigest,
+                LiveTransactionState.ABSENT_CONFIRMED,
+                "absent_confirmed",
+                limits);
+    }
+
+    public String ownerRuntimeId() {
+        return ownerRuntimeId;
+    }
+
+    public long ownerGeneration() {
+        return ownerGeneration;
+    }
+
+    public String transactionId() {
+        return transactionId;
+    }
+
+    public byte[] payloadDigest() {
+        return payloadDigest.clone();
+    }
+
+    public LiveTransactionState result() {
+        return result;
+    }
+
+    public String accountingStateHint() {
+        return accountingStateHint;
+    }
+
+    public boolean isAuthoritativelyAbsent() {
+        return result == LiveTransactionState.ABSENT_CONFIRMED;
+    }
+
+    public boolean sameTransaction(String transactionId, byte[] digest) {
+        return this.transactionId.equals(transactionId) && Arrays.equals(payloadDigest, digest);
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/LiveTransactionState.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/LiveTransactionState.java
@@ -1,0 +1,9 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+/** Proof result used when deciding whether a receipt may be treated as orphaned. */
+public enum LiveTransactionState {
+    ACTIVE,
+    RECOVERABLE,
+    ABSENT_CONFIRMED,
+    UNKNOWN
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/PayloadKind.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/PayloadKind.java
@@ -1,0 +1,29 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+/** Payload owners that must share the exact-count validator and codec. */
+public enum PayloadKind {
+    REQUEST(1),
+    VECTOR_PLAN(2),
+    HOST(3),
+    JOURNAL(4),
+    RECEIPT(5);
+
+    private final int wireId;
+
+    PayloadKind(int wireId) {
+        this.wireId = wireId;
+    }
+
+    int wireId() {
+        return wireId;
+    }
+
+    static PayloadKind fromWireId(int wireId) {
+        for (PayloadKind kind : values()) {
+            if (kind.wireId == wireId) {
+                return kind;
+            }
+        }
+        throw new IllegalArgumentException("unknown exact-count payload kind " + wireId);
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/ReceiptOrphanPolicy.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/ReceiptOrphanPolicy.java
@@ -1,0 +1,11 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+/** Fail-closed orphan policy. Unknown or incomplete proof never authorizes deletion. */
+public final class ReceiptOrphanPolicy {
+    private ReceiptOrphanPolicy() {
+    }
+
+    public static boolean mayForget(LiveTransactionProof proof) {
+        return proof != null && proof.result() == LiveTransactionState.ABSENT_CONFIRMED;
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/ReceiptReservation.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/ReceiptReservation.java
@@ -1,0 +1,38 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/** Immutable reservation state. It never owns an item, fluid, or machine object. */
+public final class ReceiptReservation {
+    private final String transactionId;
+    private final byte[] payloadDigest;
+    private final ReceiptReservationState state;
+
+    ReceiptReservation(String transactionId, byte[] payloadDigest, ReceiptReservationState state) {
+        this.transactionId = transactionId;
+        this.payloadDigest = payloadDigest.clone();
+        this.state = Objects.requireNonNull(state, "state");
+    }
+
+    public String transactionId() {
+        return transactionId;
+    }
+
+    public byte[] payloadDigest() {
+        return payloadDigest.clone();
+    }
+
+    public ReceiptReservationState state() {
+        return state;
+    }
+
+    boolean matches(String transactionId, byte[] payloadDigest) {
+        return this.transactionId.equals(transactionId)
+                && Arrays.equals(this.payloadDigest, payloadDigest);
+    }
+
+    ReceiptReservation withState(ReceiptReservationState nextState) {
+        return new ReceiptReservation(transactionId, payloadDigest, nextState);
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/ReceiptReservationProtocol.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/ReceiptReservationProtocol.java
@@ -1,0 +1,140 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import java.util.Objects;
+
+/**
+ * Pure, idempotent reservation transition contract. AAC may implement durable storage around
+ * these transitions without exposing its internal ledger to ACO.
+ */
+public final class ReceiptReservationProtocol {
+    private ReceiptReservationProtocol() {
+    }
+
+    public static ReceiptReservation reserve(
+            String transactionId,
+            byte[] payloadDigest,
+            ExactCountLimits limits) {
+        validateIdentity(transactionId, payloadDigest, limits);
+        return new ReceiptReservation(transactionId, payloadDigest, ReceiptReservationState.RESERVED);
+    }
+
+    public static ReceiptReservation reserve(
+            ReceiptReservation current,
+            String transactionId,
+            byte[] payloadDigest,
+            ExactCountLimits limits) {
+        if (current == null) {
+            return reserve(transactionId, payloadDigest, limits);
+        }
+        requireMatch(current, transactionId, payloadDigest, limits);
+        if (current.state() == ReceiptReservationState.FORGOTTEN
+                || current.state() == ReceiptReservationState.QUARANTINED) {
+            throw new IllegalStateException("cannot reserve a terminal or quarantined receipt");
+        }
+        return current;
+    }
+
+    public static ReceiptReservation commitRunning(
+            ReceiptReservation current,
+            String transactionId,
+            byte[] payloadDigest,
+            ExactCountLimits limits) {
+        requireMatch(current, transactionId, payloadDigest, limits);
+        return switch (current.state()) {
+            case RESERVED -> current.withState(ReceiptReservationState.RUNNING);
+            case RUNNING -> current;
+            default -> throw invalidTransition(current, ReceiptReservationState.RUNNING);
+        };
+    }
+
+    public static ReceiptReservation markOutputReady(
+            ReceiptReservation current,
+            String transactionId,
+            byte[] payloadDigest,
+            ExactCountLimits limits) {
+        requireMatch(current, transactionId, payloadDigest, limits);
+        return switch (current.state()) {
+            case RUNNING -> current.withState(ReceiptReservationState.OUTPUT_READY);
+            case OUTPUT_READY -> current;
+            default -> throw invalidTransition(current, ReceiptReservationState.OUTPUT_READY);
+        };
+    }
+
+    public static ReceiptReservation cancelReservation(
+            ReceiptReservation current,
+            String transactionId,
+            byte[] payloadDigest,
+            ExactCountLimits limits) {
+        requireMatch(current, transactionId, payloadDigest, limits);
+        return switch (current.state()) {
+            case RESERVED, RUNNING -> current.withState(ReceiptReservationState.CANCELLED);
+            case CANCELLED -> current;
+            default -> throw invalidTransition(current, ReceiptReservationState.CANCELLED);
+        };
+    }
+
+    public static ReceiptReservation acknowledge(
+            ReceiptReservation current,
+            String transactionId,
+            byte[] payloadDigest,
+            ExactCountLimits limits) {
+        requireMatch(current, transactionId, payloadDigest, limits);
+        return switch (current.state()) {
+            case OUTPUT_READY -> current.withState(ReceiptReservationState.ACKNOWLEDGED);
+            case ACKNOWLEDGED -> current;
+            default -> throw invalidTransition(current, ReceiptReservationState.ACKNOWLEDGED);
+        };
+    }
+
+    public static ReceiptReservation forget(
+            ReceiptReservation current,
+            String transactionId,
+            byte[] payloadDigest,
+            ExactCountLimits limits) {
+        requireMatch(current, transactionId, payloadDigest, limits);
+        return switch (current.state()) {
+            case ACKNOWLEDGED, CANCELLED -> current.withState(ReceiptReservationState.FORGOTTEN);
+            case FORGOTTEN -> current;
+            default -> throw invalidTransition(current, ReceiptReservationState.FORGOTTEN);
+        };
+    }
+
+    public static ReceiptReservation quarantine(
+            ReceiptReservation current,
+            String transactionId,
+            byte[] payloadDigest,
+            ExactCountLimits limits) {
+        requireMatch(current, transactionId, payloadDigest, limits);
+        if (current.state() == ReceiptReservationState.FORGOTTEN) {
+            throw invalidTransition(current, ReceiptReservationState.QUARANTINED);
+        }
+        if (current.state() == ReceiptReservationState.QUARANTINED) {
+            return current;
+        }
+        return current.withState(ReceiptReservationState.QUARANTINED);
+    }
+
+    private static void validateIdentity(String transactionId, byte[] payloadDigest, ExactCountLimits limits) {
+        Objects.requireNonNull(limits, "limits").validateRequiredIdentifier(transactionId);
+        limits.validateDigest(payloadDigest);
+    }
+
+    private static void requireMatch(
+            ReceiptReservation current,
+            String transactionId,
+            byte[] payloadDigest,
+            ExactCountLimits limits) {
+        Objects.requireNonNull(current, "current");
+        validateIdentity(transactionId, payloadDigest, limits);
+        if (!current.matches(transactionId, payloadDigest)) {
+            throw new IllegalArgumentException("receipt transaction or payload digest mismatch");
+        }
+    }
+
+    private static IllegalStateException invalidTransition(
+            ReceiptReservation current,
+            ReceiptReservationState target) {
+        return new IllegalStateException(
+                "invalid receipt transition from " + current.state() + " to " + target);
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/ReceiptReservationState.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/ReceiptReservationState.java
@@ -1,0 +1,12 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+/** Durable receipt reservation states shared by ACO and future AAC adapters. */
+public enum ReceiptReservationState {
+    RESERVED,
+    RUNNING,
+    OUTPUT_READY,
+    ACKNOWLEDGED,
+    CANCELLED,
+    FORGOTTEN,
+    QUARANTINED
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/RevisionWakeupApi.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/RevisionWakeupApi.java
@@ -1,0 +1,42 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import java.lang.ref.WeakReference;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Event-only revision notification. Listener references are weak and registrations have an
+ * explicit close lifecycle; notifications never replace a durable receipt.
+ */
+public final class RevisionWakeupApi {
+    private static final CopyOnWriteArrayList<ListenerReference> LISTENERS = new CopyOnWriteArrayList<>();
+
+    private RevisionWakeupApi() {
+    }
+
+    public static RevisionWakeupRegistration register(RevisionWakeupListener listener) {
+        ListenerReference reference = new ListenerReference(listener);
+        LISTENERS.add(reference);
+        return new RevisionWakeupRegistration(() -> LISTENERS.remove(reference));
+    }
+
+    public static void publish(BatchTargetRevision revision) {
+        Objects.requireNonNull(revision, "revision");
+        for (ListenerReference reference : LISTENERS) {
+            RevisionWakeupListener listener = reference.listener.get();
+            if (listener == null) {
+                LISTENERS.remove(reference);
+                continue;
+            }
+            listener.onRevision(revision);
+        }
+    }
+
+    private static final class ListenerReference {
+        private final WeakReference<RevisionWakeupListener> listener;
+
+        private ListenerReference(RevisionWakeupListener listener) {
+            this.listener = new WeakReference<>(Objects.requireNonNull(listener, "listener"));
+        }
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/RevisionWakeupListener.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/RevisionWakeupListener.java
@@ -1,0 +1,6 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+@FunctionalInterface
+public interface RevisionWakeupListener {
+    void onRevision(BatchTargetRevision revision);
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/RevisionWakeupRegistration.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/RevisionWakeupRegistration.java
@@ -1,0 +1,21 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/** Explicitly closable registration handle. Closing more than once is safe. */
+public final class RevisionWakeupRegistration implements AutoCloseable {
+    private final AtomicBoolean closed = new AtomicBoolean();
+    private final Runnable closeAction;
+
+    RevisionWakeupRegistration(Runnable closeAction) {
+        this.closeAction = Objects.requireNonNull(closeAction, "closeAction");
+    }
+
+    @Override
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            closeAction.run();
+        }
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/SnapshotRevisionTracker.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/SnapshotRevisionTracker.java
@@ -1,0 +1,21 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import java.util.Objects;
+
+/** Rejects stale snapshots so consumers cannot confuse an older generation with a new one. */
+public final class SnapshotRevisionTracker {
+    private long latestRevision = -1L;
+
+    public synchronized CraftingTableBatchSnapshot accept(CraftingTableBatchSnapshot snapshot) {
+        Objects.requireNonNull(snapshot, "snapshot");
+        if (snapshot.revision() < latestRevision) {
+            throw new IllegalArgumentException("snapshot revision moved backwards");
+        }
+        latestRevision = snapshot.revision();
+        return snapshot;
+    }
+
+    public synchronized long latestRevision() {
+        return latestRevision;
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/SnapshotState.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/SnapshotState.java
@@ -1,0 +1,10 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+/** Explicit state values for external snapshots; empty output is never used as a status flag. */
+public enum SnapshotState {
+    ACTIVE,
+    PAUSED,
+    QUARANTINED,
+    CANCELLED,
+    ACKNOWLEDGED
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/SupportedFeature.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/SupportedFeature.java
@@ -1,0 +1,12 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+/** Capability bits negotiated by ACO, AQE, and AAC at startup. */
+public enum SupportedFeature {
+    HOST_ATOMIC_SNAPSHOT,
+    EXPLICIT_HOST_REGISTRATION,
+    RECEIPT_SLOT_RESERVATION,
+    LIVE_TRANSACTION_PROOF,
+    TARGET_REVISION_WAKEUP,
+    QUARANTINED_THREAD_STATE,
+    EXACT_STORAGE_OPERATION_JOURNAL
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/contract/CanonicalBigIntegerCodecTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/contract/CanonicalBigIntegerCodecTest.java
@@ -1,0 +1,79 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigInteger;
+import net.minecraft.nbt.CompoundTag;
+import org.junit.jupiter.api.Test;
+
+class CanonicalBigIntegerCodecTest {
+    private static final ExactCountLimits LIMITS = new ExactCountLimits(16, 2, 8, 4096, 32, 8);
+
+    @Test
+    void encodesZeroAndPositiveValuesWithoutSignPadding() {
+        assertArrayEquals(new byte[] {0}, CanonicalBigIntegerCodec.encodeNonNegative(BigInteger.ZERO, LIMITS));
+        assertArrayEquals(new byte[] {(byte) 0xff},
+                CanonicalBigIntegerCodec.encodeNonNegative(BigInteger.valueOf(255), LIMITS));
+        assertEquals(BigInteger.valueOf(255),
+                CanonicalBigIntegerCodec.decodeNonNegative(new byte[] {(byte) 0xff}, LIMITS));
+    }
+
+    @Test
+    void rejectsNegativeNonCanonicalAndOutOfRangeValues() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CanonicalBigIntegerCodec.encodeNonNegative(BigInteger.valueOf(-1), LIMITS));
+        assertThrows(IllegalArgumentException.class,
+                () -> CanonicalBigIntegerCodec.decodeNonNegative(new byte[] {0, 1}, LIMITS));
+        assertThrows(IllegalArgumentException.class,
+                () -> CanonicalBigIntegerCodec.encodeNonNegative(BigInteger.ONE.shiftLeft(16), LIMITS));
+        assertThrows(IllegalArgumentException.class,
+                () -> CanonicalBigIntegerCodec.encodePositive(BigInteger.ZERO, LIMITS));
+    }
+
+    @Test
+    void exactConversionAndBitBoundariesAreChecked() {
+        BigInteger maximum = BigInteger.ONE.shiftLeft(LIMITS.maximumCountBits()).subtract(BigInteger.ONE);
+        assertEquals(maximum,
+                CanonicalBigIntegerCodec.decodeNonNegative(
+                        CanonicalBigIntegerCodec.encodeNonNegative(maximum, LIMITS), LIMITS));
+        assertThrows(IllegalArgumentException.class,
+                () -> CanonicalBigIntegerCodec.encodeNonNegative(
+                        BigInteger.ONE.shiftLeft(LIMITS.maximumCountBits()), LIMITS));
+        assertEquals(255L, CanonicalBigIntegerCodec.toLongExact(BigInteger.valueOf(255), LIMITS));
+        assertThrows(ArithmeticException.class,
+                () -> CanonicalBigIntegerCodec.toLongExact(
+                        BigInteger.ONE.shiftLeft(63), ExactCountLimits.defaults()));
+    }
+
+    @Test
+    void nbtRoundTripAndLegacyMigrationAreExact() {
+        CompoundTag tag = new CompoundTag();
+        BigInteger value = BigInteger.ONE.shiftLeft(15).add(BigInteger.valueOf(7));
+        CanonicalBigIntegerCodec.writeNonNegative(tag, "count", value, LIMITS);
+        assertEquals(value, CanonicalBigIntegerCodec.readNonNegative(tag, "count", LIMITS));
+
+        CompoundTag legacy = new CompoundTag();
+        legacy.putString("count", value.toString());
+        assertEquals(value, CanonicalBigIntegerCodec.readNonNegative(legacy, "count", LIMITS));
+        CanonicalBigIntegerCodec.writeNonNegative(legacy, "count", value, LIMITS);
+        assertEquals(value, CanonicalBigIntegerCodec.readNonNegative(legacy, "count", LIMITS));
+    }
+
+    @Test
+    void unknownAndMixedNbtSchemasFailClosed() {
+        CompoundTag unknown = new CompoundTag();
+        unknown.putInt("count_schema", 99);
+        unknown.putByteArray("count_bytes", new byte[] {1});
+        assertThrows(IllegalArgumentException.class,
+                () -> CanonicalBigIntegerCodec.readNonNegative(unknown, "count", LIMITS));
+
+        CompoundTag mixed = new CompoundTag();
+        mixed.putString("count", "1");
+        mixed.putInt("count_schema", 1);
+        mixed.putByteArray("count_bytes", new byte[] {1});
+        assertThrows(IllegalArgumentException.class,
+                () -> CanonicalBigIntegerCodec.readNonNegative(mixed, "count", LIMITS));
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/contract/ExactCountPayloadCodecTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/contract/ExactCountPayloadCodecTest.java
@@ -1,0 +1,74 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigInteger;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import net.minecraft.nbt.CompoundTag;
+import org.junit.jupiter.api.Test;
+
+class ExactCountPayloadCodecTest {
+    private static final ExactCountLimits LIMITS = new ExactCountLimits(32, 4, 4, 4096, 32, 8);
+
+    @Test
+    void allPayloadKindsUseOneCanonicalDeterministicCodec() {
+        Map<String, BigInteger> reverseOrder = new LinkedHashMap<>();
+        reverseOrder.put("minecraft:zinc", BigInteger.valueOf(9));
+        reverseOrder.put("minecraft:iron", BigInteger.ONE);
+        ExactCountPayload first = ExactCountPayload.of(
+                PayloadKind.REQUEST, "tx-1", reverseOrder, new byte[] {1, 2}, LIMITS);
+        Map<String, BigInteger> sortedOrder = new LinkedHashMap<>();
+        sortedOrder.put("minecraft:iron", BigInteger.ONE);
+        sortedOrder.put("minecraft:zinc", BigInteger.valueOf(9));
+        ExactCountPayload second = ExactCountPayload.of(
+                PayloadKind.REQUEST, "tx-1", sortedOrder, new byte[] {1, 2}, LIMITS);
+
+        byte[] encoded = ExactCountPayloadCodec.encode(first, LIMITS);
+        assertArrayEquals(encoded, ExactCountPayloadCodec.encode(second, LIMITS));
+        ExactCountPayload decoded = ExactCountPayloadCodec.decode(encoded, LIMITS);
+        assertEquals(first, decoded);
+        assertEquals(PayloadKind.REQUEST, decoded.kind());
+        assertEquals(sortedOrder, decoded.counts());
+        assertArrayEquals(new byte[] {1, 2}, decoded.digest());
+    }
+
+    @Test
+    void payloadNbtRoundTripUsesTheSameCodec() {
+        ExactCountPayload payload = ExactCountPayload.of(
+                PayloadKind.RECEIPT,
+                "receipt-1",
+                Map.of("minecraft:iron", BigInteger.ONE.shiftLeft(31)),
+                new byte[] {7},
+                LIMITS);
+        CompoundTag tag = new CompoundTag();
+        ExactCountPayloadCodec.writeToNbt(tag, "payload", payload, LIMITS);
+        ExactCountPayload restored = ExactCountPayloadCodec.readFromNbt(tag, "payload", LIMITS);
+        assertEquals(payload.kind(), restored.kind());
+        assertEquals(payload.identifier(), restored.identifier());
+        assertEquals(payload.counts(), restored.counts());
+        assertArrayEquals(payload.digest(), restored.digest());
+    }
+
+    @Test
+    void rejectsNonCanonicalOrderTrailingDataAndLimits() {
+        ExactCountPayload payload = ExactCountPayload.of(
+                PayloadKind.HOST, "host-1", Map.of("minecraft:iron", BigInteger.ONE), new byte[0], LIMITS);
+        byte[] encoded = ExactCountPayloadCodec.encode(payload, LIMITS);
+        byte[] trailing = java.util.Arrays.copyOf(encoded, encoded.length + 1);
+        trailing[trailing.length - 1] = 1;
+        assertThrows(IllegalArgumentException.class,
+                () -> ExactCountPayloadCodec.decode(trailing, LIMITS));
+
+        ExactCountLimits oneKey = new ExactCountLimits(32, 4, 1, 4096, 32, 8);
+        assertThrows(IllegalArgumentException.class,
+                () -> ExactCountPayload.of(
+                        PayloadKind.JOURNAL,
+                        "journal-1",
+                        Map.of("a", BigInteger.ONE, "b", BigInteger.TWO),
+                        new byte[0],
+                        oneKey));
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/contract/IntegrationContractTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/contract/IntegrationContractTest.java
@@ -1,0 +1,29 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class IntegrationContractTest {
+    @Test
+    void capabilitiesAreImmutableAndDoNotAdvertiseUnimplementedFeatures() {
+        ExactCountLimits limits = ExactCountLimits.defaults();
+        IntegrationCapabilities capabilities = IntegrationCapabilities.forAco(limits);
+        assertSame(limits, capabilities.exactCountLimits());
+        assertFalse(capabilities.supports(SupportedFeature.EXACT_STORAGE_OPERATION_JOURNAL));
+        assertThrows(IllegalStateException.class,
+                () -> capabilities.requireFeatures(Set.of(SupportedFeature.LIVE_TRANSACTION_PROOF)));
+    }
+
+    @Test
+    void registryInitializesOnce() {
+        IntegrationCapabilitiesRegistry.initializeOnce(IntegrationCapabilities.forAco(ExactCountLimits.defaults()));
+        assertSame(IntegrationCapabilitiesRegistry.peek().orElseThrow(), IntegrationCapabilitiesRegistry.snapshot());
+        assertThrows(IllegalStateException.class,
+                () -> IntegrationCapabilitiesRegistry.initializeOnce(
+                        IntegrationCapabilities.forAco(ExactCountLimits.defaults())));
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/contract/ReceiptReservationProtocolTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/contract/ReceiptReservationProtocolTest.java
@@ -1,0 +1,42 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class ReceiptReservationProtocolTest {
+    private static final ExactCountLimits LIMITS = ExactCountLimits.defaults();
+
+    @Test
+    void transitionsAreIdempotentAndDigestBound() {
+        byte[] digest = {1, 2, 3};
+        ReceiptReservation reservation = ReceiptReservationProtocol.reserve("tx-1", digest, LIMITS);
+        reservation = ReceiptReservationProtocol.reserve(reservation, "tx-1", digest, LIMITS);
+        reservation = ReceiptReservationProtocol.commitRunning(reservation, "tx-1", digest, LIMITS);
+        reservation = ReceiptReservationProtocol.commitRunning(reservation, "tx-1", digest, LIMITS);
+        reservation = ReceiptReservationProtocol.markOutputReady(reservation, "tx-1", digest, LIMITS);
+        reservation = ReceiptReservationProtocol.acknowledge(reservation, "tx-1", digest, LIMITS);
+        reservation = ReceiptReservationProtocol.acknowledge(reservation, "tx-1", digest, LIMITS);
+        assertEquals(ReceiptReservationState.ACKNOWLEDGED, reservation.state());
+        ReceiptReservation acknowledged = reservation;
+        reservation = ReceiptReservationProtocol.forget(acknowledged, "tx-1", digest, LIMITS);
+        assertEquals(ReceiptReservationState.FORGOTTEN, reservation.state());
+        ReceiptReservation forgotten = reservation;
+        assertThrows(IllegalStateException.class,
+                () -> ReceiptReservationProtocol.reserve(forgotten, "tx-1", digest, LIMITS));
+        assertThrows(IllegalArgumentException.class,
+                () -> ReceiptReservationProtocol.acknowledge(
+                        acknowledged, "tx-1", new byte[] {9}, LIMITS));
+    }
+
+    @Test
+    void unknownOrActiveReceiptsCannotBeForgotten() {
+        ReceiptReservation reservation = ReceiptReservationProtocol.reserve("tx-2", new byte[0], LIMITS);
+        ReceiptReservation active = reservation;
+        assertThrows(IllegalStateException.class,
+                () -> ReceiptReservationProtocol.forget(active, "tx-2", new byte[0], LIMITS));
+        reservation = ReceiptReservationProtocol.quarantine(reservation, "tx-2", new byte[0], LIMITS);
+        assertEquals(ReceiptReservationState.QUARANTINED, reservation.state());
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/contract/RevisionAndSnapshotTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/contract/RevisionAndSnapshotTest.java
@@ -1,0 +1,61 @@
+package com.syaru.ae2craftingoptimizer.api.contract;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigInteger;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class RevisionAndSnapshotTest {
+    private static final ExactCountLimits LIMITS = ExactCountLimits.defaults();
+
+    @Test
+    void wakeupRegistrationIsExplicitlyClosable() {
+        AtomicInteger calls = new AtomicInteger();
+        RevisionWakeupListener listener = revision -> calls.incrementAndGet();
+        try (RevisionWakeupRegistration ignored = RevisionWakeupApi.register(listener)) {
+            RevisionWakeupApi.publish(revision(1));
+            assertEquals(1, calls.get());
+        }
+        RevisionWakeupApi.publish(revision(2));
+        assertEquals(1, calls.get());
+    }
+
+    @Test
+    void snapshotStateAndRevisionAreExplicitAndImmutable() {
+        CraftingTableBatchSnapshot snapshot = CraftingTableBatchSnapshot.of(
+                3,
+                SnapshotState.PAUSED,
+                Map.of("minecraft:iron", BigInteger.ONE),
+                LIMITS);
+        assertEquals(SnapshotState.PAUSED, snapshot.state());
+        assertEquals(BigInteger.ONE, snapshot.outputCounts().get("minecraft:iron"));
+        assertThrows(UnsupportedOperationException.class,
+                () -> snapshot.outputCounts().put("minecraft:zinc", BigInteger.ONE));
+
+        SnapshotRevisionTracker tracker = new SnapshotRevisionTracker();
+        tracker.accept(snapshot);
+        assertThrows(IllegalArgumentException.class,
+                () -> tracker.accept(CraftingTableBatchSnapshot.of(
+                        2, SnapshotState.ACTIVE, Map.of(), LIMITS)));
+    }
+
+    @Test
+    void unknownProofIsNeverAnOrphanProof() {
+        LiveTransactionProof unknown = LiveTransactionProof.unknown(
+                "aco-runtime", 1, "tx-1", new byte[] {1}, LIMITS);
+        LiveTransactionProof absent = LiveTransactionProof.absentConfirmed(
+                "aco-runtime", 1, "tx-1", new byte[] {1}, LIMITS);
+        assertEquals(LiveTransactionState.UNKNOWN, unknown.result());
+        assertEquals(LiveTransactionState.ABSENT_CONFIRMED, absent.result());
+        assertEquals(false, ReceiptOrphanPolicy.mayForget(unknown));
+        assertEquals(true, ReceiptOrphanPolicy.mayForget(absent));
+    }
+
+    private static BatchTargetRevision revision(long value) {
+        return new BatchTargetRevision(
+                "target-1", "runtime-1", "tx-1", value, value, value, "active", LIMITS);
+    }
+}


### PR DESCRIPTION
Closes #7

## Summary
Adds the ACO-side public exact-count contract required by the cross-mod roadmap. This PR is limited to ACO; AQE and AAC implementations remain in their dependency-ordered follow-up issues.

## Changes
- Adds one immutable ExactCountLimits boundary for count bits, canonical bytes, payload keys, encoded payload bytes, identifier length, and digest length.
- Adds canonical non-negative BigInteger binary and NBT persistence with exact conversions and strict rejection of negative, non-canonical, oversized, unknown-schema, mixed, truncated, and trailing data.
- Uses one deterministic ExactCountPayloadCodec for REQUEST, VECTOR_PLAN, HOST, JOURNAL, and RECEIPT.
- Adds immutable startup IntegrationCapabilities and a one-shot registry; unimplemented features are not advertised.
- Adds fail-closed LiveTransactionProof, idempotent receipt reservation transitions, weak closable revision wakeups, and immutable revisioned snapshots.

## Persistence and safety
- Canonical NBT schema version is 1. Legacy decimal strings are read only as validated migration input and are written canonically.
- Unknown or unsafe state is rejected or quarantined; corrupt data is never silently deleted or reset.
- No AE2 recipe, physical craft order, storage mutation, energy accounting, or UI behavior changes.
- Same transaction ID plus digest is idempotent; digest mismatch is rejected; UNKNOWN never authorizes orphan deletion.

## Validation
- gradlew.bat clean build --stacktrace: successful.
- 15 exact-count contract tests: successful.
- git diff --check: successful.

## Follow-up work
AQE #4, #5, #7 and AAC #4, #5, #6, #8 consume this API later. ACO #10, #11, #8 and later correctness/performance issues are intentionally out of scope. The AQE capacity ledger, AAC physical assemble ledger, and exact storage journal are not implemented here.