### PR TITLE
Implement #10: explicit Big Crafting Host lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced the Big Crafting Host owner `WeakHashMap` with an explicit,
+  generation-bound registration lifecycle. Closing a registration releases the
+  host runtime and cannot affect a newer replacement for the same owner.
+- Added atomic immutable Big Crafting Host snapshots for capacity, reservations,
+  availability, overcommit state, and standard/BigInteger job counts.
+- Made AQE controller tracking explicit rather than dependent on weak-key GC;
+  stale cluster controllers are closed during reform and server shutdown.
+
 ### Added
 
 - Added the public exact-count integration contract for ACO, AQE, and AAC.

--- a/docs/EXACT_COUNT_API.md
+++ b/docs/EXACT_COUNT_API.md
@@ -41,12 +41,31 @@ prove canonical equality.
 
 `IntegrationCapabilitiesRegistry.initializeOnce` publishes one immutable startup snapshot. Optional
 mods read it with `snapshot()` or `peek()` and must fail closed when the required API version or
-feature is absent. ACO currently advertises no unimplemented feature as supported; later issues
-will enable bits only when their owning implementation and persistence tests are complete.
+feature is absent. ACO advertises `HOST_ATOMIC_SNAPSHOT` and
+`EXPLICIT_HOST_REGISTRATION` only after their owning implementation and lifecycle tests are
+complete. Receipt journaling, live transaction proof, and other reserved features remain disabled
+until their owning implementations are merged.
 
 The feature enum reserves contracts for atomic host snapshots, explicit host registration, receipt
 slot reservation, live transaction proof, revision wakeup, quarantined thread state, and exact
 storage journals.
+
+## Big Crafting Host lifecycle
+
+`BigCraftingHostRegistry.register(owner, runtime)` returns a
+`BigCraftingHostRegistration`. The handle carries the owner identity, runtime UUID, and
+monotonically increasing generation. `close()` is idempotent; an old handle cannot remove a newer
+registration for the same owner. `unregister`, server stop, and registry clear close the runtime
+and release the strong owner reference.
+
+The existing AQE bridge must call `unregister` on cluster destroy, break, reform, or unload. A
+controller must cancel pending futures, return only work that has not been physically accepted, and
+quarantine uncertain ownership before it is released. `BigCraftingHostRuntime.close()` therefore
+stops new admission but does not delete durable jobs or physical ownership.
+
+`BigCraftingHostRegistration.snapshot(revision, backendState)` obtains one monitor-consistent
+`BigCraftingHostSnapshot`. Its `available` field is derived from `physicalCapacity - reserved` and
+is clamped to zero when `overcommitted` is true.
 
 ## Receipts, proofs, and revisions
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -32,6 +32,18 @@ without creating a compile-time cycle.
 
 See `docs/EXACT_COUNT_API.md` for the versioned surface and adoption rules.
 
+## Big Crafting Host lifecycle
+
+`BigCraftingHostRegistry` retains owners only between explicit registration and
+close. The AQE controller map uses identity keys and is closed on stale cluster
+reform and server stop. A host close is admission-only: durable BigInteger jobs
+remain available for recovery, while the controller owns cancellation, rollback,
+and quarantine of pending physical work.
+
+`BigCraftingHostRuntime.snapshot(...)` reads capacity, reservations, and all job
+counts under one monitor and returns an immutable `BigCraftingHostSnapshot`. No
+consumer should compose an accounting decision from separate getters.
+
 ## Compiled Formula
 
 `CompiledRootProgram` is generation-keyed. For an eligible root it records:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -29,6 +29,11 @@ Automated tests cover:
 - nested NetworkStorage reuse while an outer capture remains active;
 - full-grid terminal reuse of AE2's cached inventory with exact sidecars;
 - preservation of add-on-specific terminal inventory paths.
+- 1,000 explicit Big Crafting Host register/close cycles returning the registry
+  to zero without relying on GC;
+- replacement-generation safety where an old handle cannot close a newer host;
+- atomic host snapshots, clamped overcommit availability, and close-time
+  admission rejection.
 - canonical exact-count payload round trips and rejection of non-canonical
   encodings;
 - capability snapshot initialization, receipt reservation idempotence, and

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostBackendState.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostBackendState.java
@@ -1,0 +1,11 @@
+package com.syaru.ae2craftingoptimizer.api.big;
+
+/** Stable state labels used by an atomic Big Crafting Host snapshot. */
+public enum BigCraftingHostBackendState {
+    ACTIVE,
+    PAUSED,
+    DEGRADED,
+    CLOSING,
+    CLOSED,
+    UNAVAILABLE
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRegistration.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRegistration.java
@@ -1,0 +1,19 @@
+package com.syaru.ae2craftingoptimizer.api.big;
+
+import java.util.UUID;
+
+/** Explicit lifecycle handle for one owner/runtime registration. */
+public interface BigCraftingHostRegistration extends AutoCloseable {
+    Object ownerIdentity();
+    UUID runtimeIdentity();
+    long generation();
+    boolean isClosed();
+    BigCraftingHostSnapshot snapshot(long revision, BigCraftingHostBackendState backendState);
+
+    /** Registers controller cleanup that runs exactly once when this generation closes. */
+    void onClose(Runnable cleanup);
+
+    /** Idempotent; an old generation cannot close a newer registration. */
+    @Override
+    void close();
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRegistry.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRegistry.java
@@ -1,42 +1,229 @@
 package com.syaru.ae2craftingoptimizer.api.big;
 
 import appeng.api.stacks.AEKey;
+import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.LinkedHashMap;
-import java.util.WeakHashMap;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.CopyOnWriteArrayList;
 
-/** Weak owner-to-runtime registry for optional CPU add-ons. */
+/**
+ * Explicit owner-to-runtime registry for optional CPU add-ons.
+ *
+ * <p>Owners are retained until their registration is closed. Lifecycle events, not GC, are the
+ * authority for releasing a host. The immutable identity map returned by {@link #snapshot()} is
+ * safe to iterate while a cluster is being reformed.</p>
+ */
 public final class BigCraftingHostRegistry {
-    private static final Map<Object, BigCraftingHostRuntime<AEKey>> HOSTS = new WeakHashMap<>();
+    private static final Map<Object, Registration> HOSTS = new IdentityHashMap<>();
+    private static long nextGeneration;
 
     private BigCraftingHostRegistry() {
     }
 
-    public static synchronized void register(Object owner, BigCraftingHostRuntime<AEKey> runtime) {
+    /** Registers a host, replacing and closing a previous generation for the same owner. */
+    public static BigCraftingHostRegistration register(
+            Object owner,
+            BigCraftingHostRuntime<AEKey> runtime) {
         Objects.requireNonNull(owner, "owner");
         Objects.requireNonNull(runtime, "runtime");
-        BigCraftingHostRuntime<AEKey> existing = HOSTS.putIfAbsent(owner, runtime);
-        if (existing != null && existing != runtime) {
-            throw new IllegalStateException("crafting host owner is already registered");
+        Registration previous;
+        Registration replacement;
+        synchronized (HOSTS) {
+            previous = HOSTS.remove(owner);
+            if (previous != null) {
+                previous.markClosed();
+            }
+            replacement = new Registration(owner, runtime, ++nextGeneration);
+            HOSTS.put(owner, replacement);
+        }
+        if (previous != null) {
+            previous.closeRuntime();
+        }
+        return replacement;
+    }
+
+    public static Optional<BigCraftingHostRuntime<AEKey>> find(Object owner) {
+        Objects.requireNonNull(owner, "owner");
+        synchronized (HOSTS) {
+            Registration registration = HOSTS.get(owner);
+            return registration == null || registration.isClosed()
+                    ? Optional.empty()
+                    : Optional.of(registration.runtime());
         }
     }
 
-    public static synchronized Optional<BigCraftingHostRuntime<AEKey>> find(Object owner) {
-        return Optional.ofNullable(HOSTS.get(Objects.requireNonNull(owner, "owner")));
+    public static Optional<BigCraftingHostRegistration> findRegistration(Object owner) {
+        Objects.requireNonNull(owner, "owner");
+        synchronized (HOSTS) {
+            Registration registration = HOSTS.get(owner);
+            return registration == null || registration.isClosed()
+                    ? Optional.empty()
+                    : Optional.of(registration);
+        }
     }
 
-    /** Server-tick integrations iterate an immutable snapshot so weak-map cleanup cannot race the loop. */
-    public static synchronized Map<Object, BigCraftingHostRuntime<AEKey>> snapshot() {
-        return Map.copyOf(new LinkedHashMap<>(HOSTS));
+    /** Server-tick integrations iterate an immutable identity snapshot. */
+    public static Map<Object, BigCraftingHostRuntime<AEKey>> snapshot() {
+        synchronized (HOSTS) {
+            Map<Object, BigCraftingHostRuntime<AEKey>> copy = new IdentityHashMap<>();
+            HOSTS.forEach((owner, registration) -> {
+                if (!registration.isClosed()) {
+                    copy.put(owner, registration.runtime());
+                }
+            });
+            return Map.copyOf(copy);
+        }
     }
 
-    public static synchronized void unregister(Object owner) {
-        HOSTS.remove(Objects.requireNonNull(owner, "owner"));
+    public static void unregister(Object owner) {
+        Registration removed;
+        synchronized (HOSTS) {
+            removed = HOSTS.remove(Objects.requireNonNull(owner, "owner"));
+            if (removed != null) {
+                removed.markClosed();
+            }
+        }
+        if (removed != null) {
+            removed.closeRuntime();
+        }
     }
 
-    public static synchronized void clear() {
-        HOSTS.clear();
+    /** Closes every registration and releases all strong owner references. */
+    public static void clear() {
+        List<Registration> removed;
+        synchronized (HOSTS) {
+            removed = List.copyOf(HOSTS.values());
+            HOSTS.clear();
+            removed.forEach(Registration::markClosed);
+        }
+        RuntimeException firstFailure = null;
+        for (Registration registration : removed) {
+            try {
+                registration.closeRuntime();
+            } catch (RuntimeException failure) {
+                if (firstFailure == null) {
+                    firstFailure = failure;
+                }
+            }
+        }
+        if (firstFailure != null) {
+            throw firstFailure;
+        }
+    }
+
+    public static int registrationCount() {
+        synchronized (HOSTS) {
+            return HOSTS.size();
+        }
+    }
+
+    private static final class Registration implements BigCraftingHostRegistration {
+        private final Object owner;
+        private final BigCraftingHostRuntime<AEKey> runtime;
+        private final long generation;
+        private final AtomicBoolean closed = new AtomicBoolean();
+        private final CopyOnWriteArrayList<Runnable> closeActions = new CopyOnWriteArrayList<>();
+
+        private Registration(Object owner, BigCraftingHostRuntime<AEKey> runtime, long generation) {
+            this.owner = owner;
+            this.runtime = runtime;
+            this.generation = generation;
+        }
+
+        @Override
+        public Object ownerIdentity() {
+            return owner;
+        }
+
+        @Override
+        public UUID runtimeIdentity() {
+            return runtime.runtimeId();
+        }
+
+        @Override
+        public long generation() {
+            return generation;
+        }
+
+        @Override
+        public boolean isClosed() {
+            return closed.get();
+        }
+
+        @Override
+        public BigCraftingHostSnapshot snapshot(
+                long revision,
+                BigCraftingHostBackendState backendState) {
+            synchronized (HOSTS) {
+                if (HOSTS.get(owner) != this || isClosed()) {
+                    throw new IllegalStateException("crafting host registration is stale");
+                }
+                return runtime.snapshot(revision, backendState);
+            }
+        }
+
+        @Override
+        public void onClose(Runnable cleanup) {
+            Objects.requireNonNull(cleanup, "cleanup");
+            if (isClosed()) {
+                cleanup.run();
+                return;
+            }
+            closeActions.add(cleanup);
+            if (isClosed() && closeActions.remove(cleanup)) {
+                cleanup.run();
+            }
+        }
+
+        @Override
+        public void close() {
+            boolean removed = false;
+            synchronized (HOSTS) {
+                if (!closed.get() && HOSTS.get(owner) == this) {
+                    HOSTS.remove(owner);
+                    removed = true;
+                }
+                closed.set(true);
+            }
+            if (removed) {
+                closeRuntime();
+            }
+        }
+
+        private void markClosed() {
+            closed.set(true);
+        }
+
+        private void closeRuntime() {
+            RuntimeException firstFailure = null;
+            for (Runnable action : closeActions) {
+                try {
+                    action.run();
+                } catch (RuntimeException failure) {
+                    if (firstFailure == null) {
+                        firstFailure = failure;
+                    }
+                }
+            }
+            closeActions.clear();
+            try {
+                runtime.close();
+            } catch (RuntimeException failure) {
+                if (firstFailure == null) {
+                    firstFailure = failure;
+                }
+            }
+            if (firstFailure != null) {
+                throw firstFailure;
+            }
+        }
+
+        private BigCraftingHostRuntime<AEKey> runtime() {
+            return runtime;
+        }
     }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRuntime.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRuntime.java
@@ -22,7 +22,7 @@ import net.minecraft.nbt.Tag;
  * {@link #reserveExternal}系で容量を予約する。ACOコマンド由来の独立親Jobだけが内部の
  * {@link BigCraftingRuntime}を使用する。双方を同じ容量から差し引き、二重予約を防ぐ。</p>
  */
-public final class BigCraftingHostRuntime<K> {
+public final class BigCraftingHostRuntime<K> implements AutoCloseable {
     public static final int SCHEMA_VERSION = 2;
     public static final int MAX_EXTERNAL_RESERVATIONS = 65_536;
     public static final int MAX_EXTERNAL_EXECUTIONS = 16_384;
@@ -41,6 +41,7 @@ public final class BigCraftingHostRuntime<K> {
     private BigInteger externalReserved = BigInteger.ZERO;
     private long externalCountBytes;
     private final BigCraftingRuntime<K> bigRuntime;
+    private boolean closed;
 
     BigCraftingHostRuntime(
             BigInteger physicalCapacity,
@@ -93,6 +94,7 @@ public final class BigCraftingHostRuntime<K> {
 
     /** 通常AE2・Advanced AE Job用の容量を原子的に予約する。 */
     public synchronized boolean reserveExternal(UUID jobId, BigInteger amount) {
+        ensureOpen();
         Objects.requireNonNull(jobId, "jobId");
         BigInteger checked = checkedPositive(amount, "external reservation", maximumBits);
         if (externalReservations.containsKey(jobId)) {
@@ -132,6 +134,7 @@ public final class BigCraftingHostRuntime<K> {
     public synchronized boolean promoteExternalReservation(
             UUID jobId,
             BigInteger exactAmount) {
+        ensureOpen();
         Objects.requireNonNull(jobId, "jobId");
         BigInteger checked = checkedPositive(exactAmount, "promoted external reservation", maximumBits);
         BigInteger previous = externalReservations.get(jobId);
@@ -174,6 +177,7 @@ public final class BigCraftingHostRuntime<K> {
      * 構造の容量が戻るかJobが完了するまで新規Jobを受理しない。</p>
      */
     public synchronized void replaceExternalReservations(Map<UUID, BigInteger> replacement) {
+        ensureOpen();
         Objects.requireNonNull(replacement, "external reservations");
         Map<UUID, BigInteger> unmanaged = new LinkedHashMap<>();
         replacement.forEach((jobId, amount) -> {
@@ -202,11 +206,13 @@ public final class BigCraftingHostRuntime<K> {
     }
 
     public synchronized void resizePhysicalCapacity(BigInteger replacement) {
+        ensureOpen();
         physicalCapacity = checkedCapacity(replacement, maximumBits);
         rebalanceBigRuntimeCapacity();
     }
 
     public synchronized boolean submit(BigCraftingJob<K> job) {
+        ensureOpen();
         Objects.requireNonNull(job, "job");
         if (available().compareTo(job.reservedCapacity()) < 0) {
             return false;
@@ -216,18 +222,21 @@ public final class BigCraftingHostRuntime<K> {
     }
 
     public synchronized List<BigCraftingRuntime.ExecutionLease<K>> schedule(long operationBudget) {
+        ensureOpen();
         return bigRuntime.schedule(operationBudget);
     }
 
     public synchronized List<BigCraftingRuntime.ExecutionLease<K>> schedule(
             long operationBudget,
             int maximumWindows) {
+        ensureOpen();
         return bigRuntime.schedule(operationBudget, maximumWindows);
     }
 
     /** Exact Vector対応設備へ渡せる、まだ子Windowを持たない親Job一覧。 */
     public synchronized List<BigCraftingRuntime.VectorCandidate<K>>
             vectorCandidates() {
+        ensureOpen();
         return bigRuntime.vectorCandidates();
     }
 
@@ -238,6 +247,7 @@ public final class BigCraftingHostRuntime<K> {
                     UUID transactionId,
                     String executorId,
                     String planFingerprint) {
+        ensureOpen();
         return bigRuntime.prepareVector(
                 jobId, transactionId, executorId, planFingerprint);
     }
@@ -252,6 +262,7 @@ public final class BigCraftingHostRuntime<K> {
                     CompoundTag executionState,
                     int progressNumerator,
                     int progressDenominator) {
+        ensureOpen();
         return bigRuntime.prepareVector(
                 jobId,
                 transactionId,
@@ -314,6 +325,7 @@ public final class BigCraftingHostRuntime<K> {
             BigCraftingRuntime.ExecutionLease<K> lease,
             UUID childCpuId,
             BigInteger childReservedCapacity) {
+        ensureOpen();
         Objects.requireNonNull(lease, "lease");
         Objects.requireNonNull(childCpuId, "childCpuId");
         BigInteger checkedCapacity = checkedPositive(
@@ -445,6 +457,41 @@ public final class BigCraftingHostRuntime<K> {
     /** 状態画面へ一つのBigInteger Jobだけを同期する。 */
     public synchronized BigCraftingStatusPage<K> statusPage(UUID jobId) {
         return bigRuntime.statusPage(jobId);
+    }
+
+    /**
+     * Captures capacity, reservations, and job counts under this host's one monitor. The
+     * registration generation supplies the caller-owned revision; ACO never samples the fields
+     * through separate calls for a single UI or accounting decision.
+     */
+    public synchronized BigCraftingHostSnapshot snapshot(
+            long revision,
+            BigCraftingHostBackendState backendState) {
+        return BigCraftingHostSnapshot.of(
+                runtimeId(),
+                revision,
+                physicalCapacity,
+                reserved(),
+                externalReserved,
+                bigRuntime.reserved(),
+                externalReservations.size(),
+                bigRuntime.jobIds().size(),
+                externalExecutions.size(),
+                backendState);
+    }
+
+    /**
+     * Ends admission for this runtime without deleting durable jobs or ownership. The controller
+     * lifecycle is responsible for cancelling pending futures and quarantining uncertain work
+     * before the persisted host is discarded or replaced.
+     */
+    @Override
+    public synchronized void close() {
+        closed = true;
+    }
+
+    public synchronized boolean isClosed() {
+        return closed;
     }
 
     public synchronized CompoundTag save() {
@@ -779,6 +826,12 @@ public final class BigCraftingHostRuntime<K> {
 
     private static long saturatedLong(BigInteger value) {
         return value.compareTo(LONG_MAX) >= 0 ? Long.MAX_VALUE : value.longValueExact();
+    }
+
+    private void ensureOpen() {
+        if (closed) {
+            throw new IllegalStateException("Big Crafting Host runtime is closed");
+        }
     }
 
     private boolean exceedsExternalCountBudget(long additionalBytes) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostSnapshot.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostSnapshot.java
@@ -1,0 +1,122 @@
+package com.syaru.ae2craftingoptimizer.api.big;
+
+import java.math.BigInteger;
+import java.util.Objects;
+import java.util.UUID;
+
+/** Immutable, atomic accounting view of one Big Crafting Host. */
+public final class BigCraftingHostSnapshot {
+    private final UUID runtimeId;
+    private final long revision;
+    private final BigInteger physicalCapacity;
+    private final BigInteger reserved;
+    private final BigInteger available;
+    private final BigInteger externalReserved;
+    private final BigInteger bigReserved;
+    private final long standardJobCount;
+    private final long bigJobCount;
+    private final long managedChildJobCount;
+    private final boolean overcommitted;
+    private final BigCraftingHostBackendState backendState;
+
+    private BigCraftingHostSnapshot(
+            UUID runtimeId,
+            long revision,
+            BigInteger physicalCapacity,
+            BigInteger reserved,
+            BigInteger available,
+            BigInteger externalReserved,
+            BigInteger bigReserved,
+            long standardJobCount,
+            long bigJobCount,
+            long managedChildJobCount,
+            boolean overcommitted,
+            BigCraftingHostBackendState backendState) {
+        this.runtimeId = runtimeId;
+        this.revision = revision;
+        this.physicalCapacity = physicalCapacity;
+        this.reserved = reserved;
+        this.available = available;
+        this.externalReserved = externalReserved;
+        this.bigReserved = bigReserved;
+        this.standardJobCount = standardJobCount;
+        this.bigJobCount = bigJobCount;
+        this.managedChildJobCount = managedChildJobCount;
+        this.overcommitted = overcommitted;
+        this.backendState = backendState;
+    }
+
+    /** Derives available from one accounting revision and clamps it on overcommit. */
+    public static BigCraftingHostSnapshot of(
+            UUID runtimeId,
+            long revision,
+            BigInteger physicalCapacity,
+            BigInteger reserved,
+            BigInteger externalReserved,
+            BigInteger bigReserved,
+            long standardJobCount,
+            long bigJobCount,
+            long managedChildJobCount,
+            BigCraftingHostBackendState backendState) {
+        Objects.requireNonNull(runtimeId, "runtimeId");
+        if (revision < 0L) {
+            throw new IllegalArgumentException("revision must not be negative");
+        }
+        requireNonNegative(physicalCapacity, "physicalCapacity");
+        requireNonNegative(reserved, "reserved");
+        requireNonNegative(externalReserved, "externalReserved");
+        requireNonNegative(bigReserved, "bigReserved");
+        if (externalReserved.add(bigReserved).compareTo(reserved) > 0) {
+            throw new IllegalArgumentException(
+                    "external and BigInteger reservations exceed total reservation");
+        }
+        requireNonNegative(standardJobCount, "standardJobCount");
+        requireNonNegative(bigJobCount, "bigJobCount");
+        requireNonNegative(managedChildJobCount, "managedChildJobCount");
+        Objects.requireNonNull(backendState, "backendState");
+
+        boolean overcommitted = reserved.compareTo(physicalCapacity) > 0;
+        BigInteger available = overcommitted
+                ? BigInteger.ZERO
+                : physicalCapacity.subtract(reserved);
+        return new BigCraftingHostSnapshot(
+                runtimeId,
+                revision,
+                physicalCapacity,
+                reserved,
+                available,
+                externalReserved,
+                bigReserved,
+                standardJobCount,
+                bigJobCount,
+                managedChildJobCount,
+                overcommitted,
+                backendState);
+    }
+
+    public UUID runtimeId() { return runtimeId; }
+    public long revision() { return revision; }
+    public BigInteger physicalCapacity() { return physicalCapacity; }
+    public BigInteger reserved() { return reserved; }
+    public BigInteger available() { return available; }
+    public BigInteger externalReserved() { return externalReserved; }
+    public BigInteger bigReserved() { return bigReserved; }
+    public long standardJobCount() { return standardJobCount; }
+    public long bigJobCount() { return bigJobCount; }
+    public long managedChildJobCount() { return managedChildJobCount; }
+    public boolean overcommitted() { return overcommitted; }
+    public BigCraftingHostBackendState backendState() { return backendState; }
+
+    private static void requireNonNegative(BigInteger value, String name) {
+        Objects.requireNonNull(value, name);
+        if (value.signum() < 0) {
+            throw new IllegalArgumentException(name + " must not be negative");
+        }
+    }
+
+    private static void requireNonNegative(long value, String name) {
+        if (value < 0L) {
+            throw new IllegalArgumentException(name + " must not be negative");
+        }
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/IntegrationCapabilities.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/contract/IntegrationCapabilities.java
@@ -40,8 +40,17 @@ public final class IntegrationCapabilities {
     }
 
     public static IntegrationCapabilities forAco(ExactCountLimits limits) {
-        // Features are advertised only after their owning implementation is complete.
-        return new IntegrationCapabilities(1, 1, 1, 1, 1, limits, Set.of());
+        // These two bits are backed by the explicit ACO host registry and immutable snapshot API.
+        return new IntegrationCapabilities(
+                1,
+                1,
+                1,
+                1,
+                1,
+                limits,
+                Set.of(
+                        SupportedFeature.HOST_ATOMIC_SNAPSHOT,
+                        SupportedFeature.EXPLICIT_HOST_REGISTRATION));
     }
 
     public int bigCraftingApiVersion() {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/AqeBigCraftingExecutionManager.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/AqeBigCraftingExecutionManager.java
@@ -53,7 +53,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.WeakHashMap;
+import java.util.IdentityHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import net.minecraft.commands.CommandSourceStack;
@@ -72,7 +72,8 @@ import net.minecraft.world.level.block.entity.BlockEntity;
  * 対象外だけをchecked-longのAdvanced AE子Jobへ委譲する。</p>
  */
 public final class AqeBigCraftingExecutionManager {
-    private static final Map<AdvCraftingCPUCluster, Controller> CONTROLLERS = new WeakHashMap<>();
+    /** Controllers are released by cluster reform/unload/server-stop paths, never by GC timing. */
+    private static final Map<AdvCraftingCPUCluster, Controller> CONTROLLERS = new IdentityHashMap<>();
 
     private AqeBigCraftingExecutionManager() {
     }
@@ -85,6 +86,10 @@ public final class AqeBigCraftingExecutionManager {
             if (!(entry.getKey() instanceof AdvCraftingCPUCluster cluster)) {
                 continue;
             }
+            var registration = BigCraftingHostRegistry.findRegistration(cluster).orElse(null);
+            if (registration == null) {
+                continue;
+            }
             liveClusters.add(cluster);
             Controller current = CONTROLLERS.get(cluster);
             if (current == null || current.host != entry.getValue()) {
@@ -93,6 +98,8 @@ public final class AqeBigCraftingExecutionManager {
                 }
                 current = new Controller(cluster, entry.getValue());
                 CONTROLLERS.put(cluster, current);
+                Controller registeredController = current;
+                registration.onClose(() -> closeController(cluster, registeredController));
             }
             current.tick();
         }
@@ -290,6 +297,15 @@ public final class AqeBigCraftingExecutionManager {
         ExactVectorGridTickBudget.clearAll();
     }
 
+    private static synchronized void closeController(
+            AdvCraftingCPUCluster cluster,
+            Controller controller) {
+        if (CONTROLLERS.get(cluster) == controller) {
+            CONTROLLERS.remove(cluster);
+        }
+        controller.close(true);
+    }
+
     private static AdvCraftingCPUCluster clusterAt(CommandSourceStack source, BlockPos position) {
         var blockEntity = source.getLevel().getBlockEntity(position);
         if (!(blockEntity instanceof AdvCraftingBlockEntity craftingBlock)
@@ -322,6 +338,7 @@ public final class AqeBigCraftingExecutionManager {
                 revalidatedPrograms =
                         new ProgramFingerprintRevalidationCache();
         private boolean recovered;
+        private boolean closed;
 
         private Controller(
                 AdvCraftingCPUCluster cluster,
@@ -331,6 +348,9 @@ public final class AqeBigCraftingExecutionManager {
         }
 
         private void tick() {
+            if (closed) {
+                return;
+            }
             recoverOnce();
             pollCalculations();
             if (!cluster.isActive()
@@ -1600,6 +1620,10 @@ public final class AqeBigCraftingExecutionManager {
         }
 
         private void close(boolean rollbackPending) {
+            if (closed) {
+                return;
+            }
+            closed = true;
             for (PendingCalculation calculation : List.copyOf(pending.values())) {
                 calculation.future().cancel(true);
                 if (rollbackPending) {

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRegistryLifecycleTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRegistryLifecycleTest.java
@@ -1,0 +1,114 @@
+package com.syaru.ae2craftingoptimizer.api.big;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import appeng.api.stacks.AEKey;
+import com.syaru.ae2craftingoptimizer.engine.BigCraftingKeyCodec;
+import java.math.BigInteger;
+import java.util.UUID;
+import net.minecraft.nbt.CompoundTag;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class BigCraftingHostRegistryLifecycleTest {
+    private static final BigCraftingKeyCodec<AEKey> UNUSED_CODEC = new BigCraftingKeyCodec<>() {
+        @Override
+        public CompoundTag encode(AEKey key) {
+            throw new UnsupportedOperationException("not used by registry lifecycle tests");
+        }
+
+        @Override
+        public AEKey decode(CompoundTag tag) {
+            throw new UnsupportedOperationException("not used by registry lifecycle tests");
+        }
+    };
+
+    @AfterEach
+    void clearRegistry() {
+        BigCraftingHostRegistry.clear();
+    }
+
+    @Test
+    void closeIsIdempotentAndReleasesTheOwner() {
+        Object owner = new Object();
+        BigCraftingHostRuntime<AEKey> host = host();
+        BigCraftingHostRegistration registration = BigCraftingHostRegistry.register(owner, host);
+
+        assertEquals(1, BigCraftingHostRegistry.registrationCount());
+        assertEquals(1000, registration.snapshot(1, BigCraftingHostBackendState.ACTIVE)
+                .available().intValue());
+        registration.close();
+        registration.close();
+
+        assertTrue(registration.isClosed());
+        assertTrue(host.isClosed());
+        assertEquals(0, BigCraftingHostRegistry.registrationCount());
+        assertTrue(BigCraftingHostRegistry.find(owner).isEmpty());
+        assertThrows(IllegalStateException.class,
+                () -> host.reserveExternal(UUID.randomUUID(), BigInteger.ONE));
+    }
+
+    @Test
+    void anOldHandleCannotCloseAReplacementGeneration() {
+        Object owner = new Object();
+        BigCraftingHostRuntime<AEKey> oldHost = host();
+        BigCraftingHostRuntime<AEKey> newHost = host();
+
+        BigCraftingHostRegistration old = BigCraftingHostRegistry.register(owner, oldHost);
+        BigCraftingHostRegistration current = BigCraftingHostRegistry.register(owner, newHost);
+
+        assertTrue(old.isClosed());
+        assertNotEquals(old.generation(), current.generation());
+        old.close();
+        assertSame(newHost, BigCraftingHostRegistry.find(owner).orElseThrow());
+        assertFalse(newHost.isClosed());
+
+        current.close();
+        assertTrue(newHost.isClosed());
+    }
+
+    @Test
+    void repeatedFormAndDestroyReturnsTheRegistryToZero() {
+        Object owner = new Object();
+        for (int i = 0; i < 1000; i++) {
+            BigCraftingHostRegistration registration = BigCraftingHostRegistry.register(owner, host());
+            registration.close();
+        }
+        assertEquals(0, BigCraftingHostRegistry.registrationCount());
+    }
+
+    @Test
+    void snapshotDerivesAvailableAndMarksOvercommitAtomically() {
+        BigCraftingHostSnapshot snapshot = BigCraftingHostSnapshot.of(
+                UUID.randomUUID(),
+                9,
+                BigInteger.valueOf(100),
+                BigInteger.valueOf(120),
+                BigInteger.valueOf(60),
+                BigInteger.valueOf(60),
+                2,
+                3,
+                1,
+                BigCraftingHostBackendState.DEGRADED);
+
+        assertEquals(BigInteger.ZERO, snapshot.available());
+        assertTrue(snapshot.overcommitted());
+        assertEquals(9, snapshot.revision());
+        assertEquals(2, snapshot.standardJobCount());
+        assertEquals(BigCraftingHostBackendState.DEGRADED, snapshot.backendState());
+        assertThrows(IllegalArgumentException.class, () -> BigCraftingHostSnapshot.of(
+                UUID.randomUUID(), 1, BigInteger.TEN, BigInteger.ONE,
+                BigInteger.TEN, BigInteger.ONE, 0, 0, 0,
+                BigCraftingHostBackendState.ACTIVE));
+    }
+
+    private static BigCraftingHostRuntime<AEKey> host() {
+        return new BigCraftingHostRuntime<>(
+                BigInteger.valueOf(1000), UNUSED_CODEC, 256, 64, 64, 4L * 1024L * 1024L);
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/contract/IntegrationContractTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/contract/IntegrationContractTest.java
@@ -3,6 +3,7 @@ package com.syaru.ae2craftingoptimizer.api.contract;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,8 @@ class IntegrationContractTest {
         ExactCountLimits limits = ExactCountLimits.defaults();
         IntegrationCapabilities capabilities = IntegrationCapabilities.forAco(limits);
         assertSame(limits, capabilities.exactCountLimits());
+        assertTrue(capabilities.supports(SupportedFeature.HOST_ATOMIC_SNAPSHOT));
+        assertTrue(capabilities.supports(SupportedFeature.EXPLICIT_HOST_REGISTRATION));
         assertFalse(capabilities.supports(SupportedFeature.EXACT_STORAGE_OPERATION_JOURNAL));
         assertThrows(IllegalStateException.class,
                 () -> capabilities.requireFeatures(Set.of(SupportedFeature.LIVE_TRANSACTION_PROOF)));


### PR DESCRIPTION
Closes #10

## Scope
- Replace WeakHashMap host authority with explicit lifecycle registrations.
- Add idempotent owner/runtime/generation handles and close callbacks.
- Close ACO controllers, cancel pending futures, roll back recoverable work, and keep uncertain ownership visible for quarantine.
- Add one immutable host snapshot covering capacity, reservations, job counts, overcommit, and backend state.
- Advertise the host registration and atomic snapshot capabilities through the #7 integration contract.

## Compatibility and data
- Existing BigCraftingHostRegistry.register(owner, runtime) call sites remain source-compatible; the returned handle may be ignored.
- Existing host NBT schema and runtime persistence are unchanged.
- No live Minecraft/server launch was performed; verification is Gradle-only.

## Safety and performance
- Closed registrations reject new admission while allowing unwind/recovery paths.
- Old generations cannot close replacements.
- Registry snapshots are identity-stable and immutable for the caller.
- Close operations are idempotent and bounded by registered controllers/futures.

## Verification
- gradlew clean test --rerun-tasks --no-daemon -PacoLocalModsDir=.ci-mods
- gradlew clean build --no-daemon -PacoLocalModsDir=.ci-mods
- git diff --check
- Lifecycle tests cover 1000 register/close cycles, generation replacement, close idempotence, admission rejection, and overcommit snapshots.

## Follow-ups
- Wire external AQE host owners to close their registration on every host unload/reform path.