### PR TITLE
[P0] Make exact storage mutation batches journaled and grid-local

### DIFF
--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExactNetworkStorageBridge.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExactNetworkStorageBridge.java
@@ -12,10 +12,13 @@ import com.syaru.ae2craftingoptimizer.access.ExtendedAePlusBigIntegerCellInvento
 import com.syaru.ae2craftingoptimizer.access.NetworkStorageMountsAccess;
 import com.syaru.ae2craftingoptimizer.api.vector.ExactStorageMutationResult;
 import com.syaru.ae2craftingoptimizer.api.vector.ExactVectorStoragePolicy;
+import com.syaru.ae2craftingoptimizer.config.ACOConfig;
+import com.syaru.ae2craftingoptimizer.lifecycle.ACORegistryAccess;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -25,6 +28,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.WeakHashMap;
 
 /**
  * AE2 NetworkStorageのmount優先順を保ったまま、監査済みBigIntegerセルだけを正確に操作する。
@@ -38,8 +42,9 @@ public final class ExactNetworkStorageBridge {
     /** 委譲循環や異常に深いアドオンwrapperでmain threadを止めない固定上限。 */
     private static final int MAXIMUM_DELEGATE_DEPTH = 16;
     private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
-    /** 複数セルへまたがる直接変更を、同一JVM内では一つずつ確定する。 */
-    private static final Object MUTATION_LOCK = new Object();
+    /** Network単位だけを排他し、別gridの正確な在庫操作は並行して進める。 */
+    private static final Map<IGrid, Object> GRID_LOCKS =
+            Collections.synchronizedMap(new WeakHashMap<>());
 
     private ExactNetworkStorageBridge() {
     }
@@ -49,7 +54,7 @@ public final class ExactNetworkStorageBridge {
             AEKey key,
             BigInteger amount,
             IActionSource source) {
-        return prepare(grid, key, amount, source, Direction.EXTRACT) != null;
+        return canMutate(grid, key, amount, source, Direction.EXTRACT);
     }
 
     public static boolean canInsert(
@@ -57,7 +62,7 @@ public final class ExactNetworkStorageBridge {
             AEKey key,
             BigInteger amount,
             IActionSource source) {
-        return prepare(grid, key, amount, source, Direction.INSERT) != null;
+        return canMutate(grid, key, amount, source, Direction.INSERT);
     }
 
     public static ExactStorageMutationResult extract(
@@ -267,30 +272,34 @@ public final class ExactNetworkStorageBridge {
                 : Optional.empty();
     }
 
+    private static boolean canMutate(
+            IGrid grid,
+            AEKey key,
+            BigInteger amount,
+            IActionSource source,
+            Direction direction) {
+        Objects.requireNonNull(grid, "grid");
+        synchronized (lockFor(grid)) {
+            return prepareBatch(
+                    grid,
+                    Map.of(
+                            Objects.requireNonNull(key, "key"),
+                            Objects.requireNonNull(amount, "amount")),
+                    source,
+                    direction)
+                    != null;
+        }
+    }
+
     private static boolean canMutateAll(
             IGrid grid,
             Map<AEKey, BigInteger> amounts,
             IActionSource source,
             Direction direction) {
-        Map<AEKey, BigInteger> checked =
-                checkedBatchAmounts(
-                        amounts);
-        synchronized (MUTATION_LOCK) {
-            // 全キーが現在のfilter・優先度・容量で処理できる場合だけtrueを返す。
-            for (Map.Entry<AEKey, BigInteger> entry :
-                    checked.entrySet()) {
-                // 一キーでも全量routeを作れない場合は、境界Batch全体を拒否する。
-                if (prepare(
-                                grid,
-                                entry.getKey(),
-                                entry.getValue(),
-                                source,
-                                direction)
-                        == null) {
-                    return false;
-                }
-            }
-            return true;
+        Map<AEKey, BigInteger> checked = checkedBatchAmounts(amounts);
+        synchronized (lockFor(grid)) {
+            // バッチ境界で一度だけrouteを準備し、同じ準備結果を確定側へ渡す。
+            return prepareBatch(grid, checked, source, direction) != null;
         }
     }
 
@@ -298,98 +307,23 @@ public final class ExactNetworkStorageBridge {
             IGrid grid,
             Map<AEKey, BigInteger> amounts,
             IActionSource source,
-            Direction direction) {
+        Direction direction) {
         Map<AEKey, BigInteger> checked =
                 checkedBatchAmounts(
                         amounts);
-        synchronized (MUTATION_LOCK) {
-            /*
-             * 一キーも変更する前に全routeを検証する。
-             * 注文数量ではなく境界AEKey数だけを一巡する。
-             */
-            for (Map.Entry<AEKey, BigInteger> entry :
-                    checked.entrySet()) {
-                // 一キーでも扱えなければ、セルを一切変更せずBatchを拒否する。
-                if (prepare(
-                                grid,
-                                entry.getKey(),
-                                entry.getValue(),
-                                source,
-                                direction)
-                        == null) {
-                    return ExactStorageMutationResult.rejected(
-                            "no exact BigInteger storage route can accept the complete key batch");
-                }
+        synchronized (lockFor(grid)) {
+            ExactStorageMutationResult recovery = recoverPending(grid);
+            if (!recovery.successful()) {
+                return recovery;
             }
-
-            List<Map.Entry<AEKey, BigInteger>> applied =
-                    new ArrayList<>();
-            // 同じ排他区間内で各キーを確定し、途中失敗時は逆順に全量を戻す。
-            for (Map.Entry<AEKey, BigInteger> entry :
-                    checked.entrySet()) {
-                ExactStorageMutationResult result =
-                        mutate(
-                                grid,
-                                entry.getKey(),
-                                entry.getValue(),
-                                source,
-                                direction);
-                // 成功したキーだけをRollback台帳へ積む。
-                if (result.successful()) {
-                    applied.add(
-                            entry);
-                    continue;
-                }
-                boolean rolledBack =
-                        rollbackBatch(
-                                grid,
-                                source,
-                                direction,
-                                applied);
-                // 元の失敗またはRollbackのどちらかが不確定なら、親Jobへ隔離を要求する。
-                if (result.stateUncertain()
-                        || !rolledBack) {
-                    return ExactStorageMutationResult.uncertain(
-                            "exact storage key batch failed and rollback could not be proven");
-                }
+            PreparedMutation prepared =
+                    prepareBatch(grid, checked, source, direction);
+            if (prepared == null) {
                 return ExactStorageMutationResult.rejected(
-                        result.detail());
+                        "no exact BigInteger storage route can accept the complete key batch");
             }
-            return ExactStorageMutationResult.success(
-                    sumAmounts(
-                            checked));
+            return executePrepared(grid, prepared, direction);
         }
-    }
-
-    private static boolean rollbackBatch(
-            IGrid grid,
-            IActionSource source,
-            Direction appliedDirection,
-            List<Map.Entry<AEKey, BigInteger>> applied) {
-        Direction rollbackDirection =
-                appliedDirection == Direction.EXTRACT
-                        ? Direction.INSERT
-                        : Direction.EXTRACT;
-        // 最後に適用したキーから逆順で、正確な同量を戻す。
-        for (int index = applied.size() - 1;
-                index >= 0;
-                index--) {
-            Map.Entry<AEKey, BigInteger> entry =
-                    applied.get(
-                            index);
-            ExactStorageMutationResult rollback =
-                    mutate(
-                            grid,
-                            entry.getKey(),
-                            entry.getValue(),
-                            source,
-                            rollbackDirection);
-            // 一件でも戻せなければ、それ以前を推測で成功扱いしない。
-            if (!rollback.successful()) {
-                return false;
-            }
-        }
-        return true;
     }
 
     private static Map<AEKey, BigInteger> checkedBatchAmounts(
@@ -446,57 +380,44 @@ public final class ExactNetworkStorageBridge {
             BigInteger amount,
             IActionSource source,
             Direction direction) {
-        synchronized (MUTATION_LOCK) {
+        synchronized (lockFor(grid)) {
+            ExactStorageMutationResult recovery = recoverPending(grid);
+            if (!recovery.successful()) {
+                return recovery;
+            }
             PreparedMutation prepared =
-                    prepare(grid, key, amount, source, direction);
+                    prepareBatch(
+                            grid,
+                            Map.of(
+                                    Objects.requireNonNull(key, "key"),
+                                    Objects.requireNonNull(amount, "amount")),
+                            source,
+                            direction);
             // simulate時点で全量を扱えない場合は、セルへ一切触れず拒否する。
             if (prepared == null) {
                 return ExactStorageMutationResult.rejected(
                         "no exact BigInteger storage route can accept the full amount");
             }
-
-            List<AppliedStep> applied = new ArrayList<>(prepared.steps().size());
-            try {
-                // 分割単位はmount数だけであり、要求数量によるloopやlong Windowを作らない。
-                for (MutationStep step : prepared.steps()) {
-                    applied.add(apply(step, direction));
-                }
-                grid.getStorageService().invalidateCache();
-                return ExactStorageMutationResult.success(amount);
-            } catch (RuntimeException | LinkageError mutationFailure) {
-                boolean rollbackComplete = rollback(applied);
-                grid.getStorageService().invalidateCache();
-                if (!rollbackComplete) {
-                    AE2CraftingOptimizer.LOGGER.error(
-                            "ACO exact storage mutation became uncertain during {}",
-                            direction,
-                            mutationFailure);
-                    return ExactStorageMutationResult.uncertain(
-                            "exact storage callback failed and rollback could not be proven");
-                }
-                AE2CraftingOptimizer.LOGGER.warn(
-                        "ACO exact storage mutation was rolled back during {}: {}",
-                        direction,
-                        mutationFailure.toString());
-                return ExactStorageMutationResult.rejected(
-                        "exact storage changed between simulation and commit");
-            }
+            return executePrepared(grid, prepared, direction);
         }
     }
 
-    private static PreparedMutation prepare(
+    /**
+     * Builds one immutable route for the complete boundary batch.
+     *
+     * <p>Mounts are resolved once and a per-cell shadow is advanced while each key is
+     * planned. This preserves exact before/after state even when multiple keys share
+     * one cell, so commit never has to prepare a route again.</p>
+     */
+    private static PreparedMutation prepareBatch(
             IGrid grid,
-            AEKey key,
-            BigInteger amount,
+            Map<AEKey, BigInteger> requested,
             IActionSource source,
             Direction direction) {
         Objects.requireNonNull(grid, "grid");
-        Objects.requireNonNull(key, "key");
+        Map<AEKey, BigInteger> checked = checkedBatchAmounts(requested);
         Objects.requireNonNull(source, "source");
         Objects.requireNonNull(direction, "direction");
-        if (Objects.requireNonNull(amount, "amount").signum() <= 0) {
-            throw new IllegalArgumentException("exact storage amount must be positive");
-        }
 
         MEStorage networkInventory = grid.getStorageService().getInventory();
         if (!(networkInventory instanceof NetworkStorage)
@@ -505,106 +426,379 @@ public final class ExactNetworkStorageBridge {
         }
         NavigableMap<Integer, List<MEStorage>> mounts =
                 accessor.aco$getPriorityInventory();
-        List<MEStorage> ordered = direction == Direction.EXTRACT
-                ? extractionOrder(mounts)
-                : insertionOrder(mounts, key, source);
+        List<ResolvedMount> resolvedMounts = resolveMounts(mounts);
+        if (resolvedMounts.isEmpty()) {
+            return null;
+        }
 
-        BigInteger remaining = amount;
-        List<MutationStep> steps = new ArrayList<>();
-        Set<ExactStorageIdentity> visitedExactCells =
-                new LinkedHashSet<>();
-        // 同じunderlying cellが複数wrapperから見えても、一度だけ在庫へ数える。
-        for (MEStorage mount : ordered) {
-            ResolvedExactStorage resolved = resolveExactStorage(mount);
-            if (resolved == null
-                    || !visitedExactCells.add(
-                            resolved.storageIdentity())) {
-                continue;
-            }
-            BigInteger available = capacity(
-                    resolved, mount, key, remaining, source, direction);
-            if (available.signum() <= 0) {
-                continue;
-            }
-            BigInteger selected = available.min(remaining);
-            Object2ObjectMap<AEKey, BigInteger> amounts =
-                    resolved.currentMap();
-            steps.add(new MutationStep(
-                    resolved.accessor(),
-                    amounts,
-                    key,
-                    amounts.getOrDefault(
-                            key,
-                            BigInteger.ZERO),
-                    authoritativeTotal(
+        Map<ExactStorageIdentity, CellShadow> shadows = new LinkedHashMap<>();
+        for (ResolvedMount resolvedMount : resolvedMounts) {
+            ResolvedExactStorage resolved = resolvedMount.resolved();
+            Object2ObjectMap<AEKey, BigInteger> amounts = resolved.currentMap();
+            shadows.putIfAbsent(
+                    resolved.storageIdentity(),
+                    new CellShadow(
                             resolved.accessor(),
-                            amounts),
-                    amounts.size(),
-                    selected));
-            remaining = remaining.subtract(selected);
-            // 全量を確保できた時点で残りmountを走査しない。
-            if (remaining.signum() == 0) {
-                return new PreparedMutation(List.copyOf(steps));
+                            amounts,
+                            new LinkedHashMap<>(amounts),
+                            authoritativeTotal(resolved.accessor(), amounts)));
+        }
+
+        List<MutationStep> steps = new ArrayList<>();
+        for (Map.Entry<AEKey, BigInteger> entry : checked.entrySet()) {
+            AEKey key = entry.getKey();
+            BigInteger remaining = entry.getValue();
+            for (ResolvedMount resolvedMount :
+                    orderedResolvedMounts(
+                            mounts,
+                            resolvedMounts,
+                            key,
+                            source,
+                            direction)) {
+                ResolvedExactStorage resolved = resolvedMount.resolved();
+                CellShadow shadow = shadows.get(resolved.storageIdentity());
+                BigInteger current = shadow.amounts().getOrDefault(key, BigInteger.ZERO);
+                BigInteger available = direction == Direction.EXTRACT
+                        ? current.min(remaining)
+                        : insertionCapacity(
+                                resolved,
+                                key,
+                                current,
+                                remaining);
+                if (available.signum() <= 0) {
+                    continue;
+                }
+                long probe = available.min(LONG_MAX).longValueExact();
+                long accepted = direction == Direction.EXTRACT
+                        ? resolvedMount.mount().extract(
+                                key,
+                                probe,
+                                Actionable.SIMULATE,
+                                source)
+                        : resolvedMount.mount().insert(
+                                key,
+                                probe,
+                                Actionable.SIMULATE,
+                                source);
+                if (accepted != probe) {
+                    continue;
+                }
+                BigInteger selected = available.min(remaining);
+                BigInteger replacement = direction == Direction.EXTRACT
+                        ? current.subtract(selected)
+                        : current.add(selected);
+                BigInteger replacementTotal = direction == Direction.EXTRACT
+                        ? shadow.total().subtract(selected)
+                        : shadow.total().add(selected);
+                int replacementTypes = replacement.signum() == 0
+                        ? shadow.amounts().size() - 1
+                        : shadow.amounts().containsKey(key)
+                                ? shadow.amounts().size()
+                                : shadow.amounts().size() + 1;
+                steps.add(new MutationStep(
+                        shadow.accessor(),
+                        shadow.actualAmounts(),
+                        key,
+                        current,
+                        shadow.total(),
+                        shadow.amounts().size(),
+                        selected,
+                        replacement,
+                        replacementTotal,
+                        replacementTypes));
+                if (replacement.signum() == 0) {
+                    shadow.amounts().remove(key);
+                } else {
+                    shadow.amounts().put(key, replacement);
+                }
+                shadow.total = replacementTotal;
+                remaining = remaining.subtract(selected);
+                if (remaining.signum() == 0) {
+                    break;
+                }
+            }
+            if (remaining.signum() != 0) {
+                return null;
             }
         }
-        return null;
+        return new PreparedMutation(
+                UUID.randomUUID(),
+                checked,
+                List.copyOf(steps));
     }
 
-    private static List<MEStorage> extractionOrder(
-            NavigableMap<Integer, List<MEStorage>> mounts) {
-        List<MEStorage> result = new ArrayList<>();
-        // AE2 NetworkStorage.extractと同じdescendingMap順をそのまま複製する。
-        for (List<MEStorage> priority : mounts.descendingMap().values()) {
-            result.addAll(priority);
+    private static ExactStorageMutationResult executePrepared(
+            IGrid grid,
+            PreparedMutation prepared,
+            Direction direction) {
+        ExactStorageMutationJournal journal =
+                ExactStorageMutationJournal.forGrid(grid);
+        if (journal == null || !journal.isHealthy()) {
+            return ExactStorageMutationResult.rejected(
+                    "exact storage journal is unavailable or malformed");
         }
-        return result;
+        try {
+            // UUIDを付けるのはjournal作成直前だけ。can*のsimulationでは保存状態を触らない。
+            for (MutationStep step : prepared.steps()) {
+                if (!step.accessor().aco$hasExactStorageUuid()) {
+                    step.accessor().aco$assignExactStorageUuid();
+                }
+            }
+            List<ExactStorageMutationJournal.Step> journalSteps = new ArrayList<>();
+            for (MutationStep step : prepared.steps()) {
+                UUID storageId = step.accessor().aco$getExactStorageUuid();
+                if (storageId == null) {
+                    throw new IllegalStateException("exact cell has no persistent storage UUID");
+                }
+                journalSteps.add(new ExactStorageMutationJournal.Step(
+                        storageId,
+                        step.key().toTagGeneric(
+                                grid.getPivot().getLevel().registryAccess()),
+                        step.beforeAmount(),
+                        step.afterAmount(),
+                        step.beforeTotal(),
+                        step.afterTotal(),
+                        step.beforeTypes(),
+                        step.afterTypes(),
+                        step.amount()));
+            }
+            if (!journal.begin(
+                    prepared.operationId(),
+                    ExactNetworkStorageSnapshotCache.currentGeneration(),
+                    direction.name(),
+                    journalSteps,
+                    ACOConfig.getBatchTransactionJournalMaximumEntries())) {
+                return ExactStorageMutationResult.rejected(
+                        "exact storage journal cannot accept the prepared operation");
+            }
+
+            List<AppliedStep> applied = new ArrayList<>(prepared.steps().size());
+            try {
+                // このリストだけがcommitのroute。再prepareやquantity windowは行わない。
+                for (int index = 0; index < prepared.steps().size(); index++) {
+                    applied.add(apply(prepared.steps().get(index), direction));
+                    if (!journal.markApplied(prepared.operationId(), index)) {
+                        throw new IllegalStateException(
+                                "exact storage journal could not acknowledge an applied step");
+                    }
+                }
+                journal.acknowledge(prepared.operationId());
+                grid.getStorageService().invalidateCache();
+                return ExactStorageMutationResult.success(
+                        sumAmounts(prepared.requested()));
+            } catch (RuntimeException | LinkageError mutationFailure) {
+                boolean rollbackComplete = rollback(applied);
+                grid.getStorageService().invalidateCache();
+                if (rollbackComplete) {
+                    journal.acknowledge(prepared.operationId());
+                    AE2CraftingOptimizer.LOGGER.warn(
+                            "ACO exact storage mutation was rolled back during {}: {}",
+                            direction,
+                            mutationFailure.toString());
+                    return ExactStorageMutationResult.rejected(
+                            "exact storage changed between simulation and commit");
+                }
+                journal.quarantine(
+                        prepared.operationId(),
+                        "callback failure or rollback mismatch: "
+                                + mutationFailure);
+                AE2CraftingOptimizer.LOGGER.error(
+                        "ACO exact storage mutation became uncertain during {}",
+                        direction,
+                        mutationFailure);
+                return ExactStorageMutationResult.uncertain(
+                        "exact storage callback failed and rollback could not be proven");
+            }
+        } catch (RuntimeException | LinkageError preparationFailure) {
+            return ExactStorageMutationResult.rejected(
+                    "exact storage journal preparation failed: "
+                            + preparationFailure.getMessage());
+        }
     }
 
-    private static List<MEStorage> insertionOrder(
-            NavigableMap<Integer, List<MEStorage>> mounts,
+    /**
+     * Replays only journal steps whose exact before-state is still present. A step
+     * matching neither before nor after is quarantined; unrelated network totals are
+     * never used as proof.
+     */
+    private static ExactStorageMutationResult recoverPending(IGrid grid) {
+        ExactStorageMutationJournal journal =
+                ExactStorageMutationJournal.forGrid(grid);
+        if (journal == null || !journal.isHealthy()) {
+            return ExactStorageMutationResult.rejected(
+                    "exact storage journal is unavailable or malformed");
+        }
+        MEStorage networkInventory = grid.getStorageService().getInventory();
+        if (!(networkInventory instanceof NetworkStorageMountsAccess mountsAccess)) {
+            return ExactStorageMutationResult.rejected(
+                    "exact storage mounts are unavailable during recovery");
+        }
+        List<ResolvedMount> mounts = resolveMounts(
+                mountsAccess.aco$getPriorityInventory());
+        Map<UUID, ExtendedAePlusBigIntegerCellInventoryAccess> cells =
+                new LinkedHashMap<>();
+        for (ResolvedMount mount : mounts) {
+            UUID storageId = mount.resolved().accessor().aco$getExactStorageUuid();
+            if (storageId != null) {
+                cells.putIfAbsent(storageId, mount.resolved().accessor());
+            }
+        }
+        for (ExactStorageMutationJournal.Entry entry : journal.pending()) {
+            boolean belongsToThisGrid = false;
+            for (ExactStorageMutationJournal.Step step : entry.steps()) {
+                if (cells.containsKey(step.storageId())) {
+                    belongsToThisGrid = true;
+                    break;
+                }
+            }
+            // Journalはworld単位なので、別gridの未完了操作を他のgridから隔離しない。
+            if (!belongsToThisGrid) {
+                continue;
+            }
+            try {
+                List<RecoveryStep> recoverySteps = new ArrayList<>();
+                for (ExactStorageMutationJournal.Step step : entry.steps()) {
+                    ExtendedAePlusBigIntegerCellInventoryAccess accessor =
+                            cells.get(step.storageId());
+                    if (accessor == null) {
+                        throw new IllegalStateException(
+                                "journal cell is no longer mounted: " + step.storageId());
+                    }
+                    AEKey key = AEKey.fromTagGeneric(
+                            grid.getPivot().getLevel().registryAccess(),
+                            step.key());
+                    if (key == null) {
+                        throw new IllegalStateException("journal key could not be decoded");
+                    }
+                    Object2ObjectMap<AEKey, BigInteger> amounts =
+                            accessor.aco$getExactStoredAmounts();
+                    BigInteger currentAmount = amounts.getOrDefault(key, BigInteger.ZERO);
+                    BigInteger currentTotal = authoritativeTotal(accessor, amounts);
+                    boolean before = currentAmount.equals(step.beforeAmount())
+                            && currentTotal.equals(step.beforeTotal())
+                            && accessor.aco$getExactStoredTypeCount() == step.beforeTypes();
+                    boolean after = currentAmount.equals(step.afterAmount())
+                            && currentTotal.equals(step.afterTotal())
+                            && accessor.aco$getExactStoredTypeCount() == step.afterTypes();
+                    if (!before && !after) {
+                        throw new IllegalStateException(
+                                "journal cell state matches neither before nor after");
+                    }
+                    recoverySteps.add(new RecoveryStep(
+                            step,
+                            accessor,
+                            amounts,
+                            key,
+                            before));
+                }
+                for (int index = 0; index < recoverySteps.size(); index++) {
+                    RecoveryStep recovery = recoverySteps.get(index);
+                    if (recovery.before()) {
+                        apply(
+                                new MutationStep(
+                                        recovery.accessor(),
+                                        recovery.amounts(),
+                                        recovery.key(),
+                                        recovery.step().beforeAmount(),
+                                        recovery.step().beforeTotal(),
+                                        recovery.step().beforeTypes(),
+                                        recovery.step().amount(),
+                                        recovery.step().afterAmount(),
+                                        recovery.step().afterTotal(),
+                                        recovery.step().afterTypes()),
+                                Direction.valueOf(entry.direction()));
+                    }
+                    journal.markApplied(entry.operationId(), index);
+                }
+                journal.acknowledge(entry.operationId());
+                grid.getStorageService().invalidateCache();
+            } catch (RuntimeException | LinkageError failure) {
+                journal.quarantine(
+                        entry.operationId(),
+                        "recovery proof failed: " + failure);
+                AE2CraftingOptimizer.LOGGER.error(
+                        "ACO quarantined exact storage operation {} during recovery",
+                        entry.operationId(),
+                        failure);
+                return ExactStorageMutationResult.uncertain(
+                        "exact storage recovery could not be proven");
+            }
+        }
+        return ExactStorageMutationResult.success(BigInteger.ZERO);
+    }
+
+    private static Object lockFor(IGrid grid) {
+        Objects.requireNonNull(grid, "grid");
+        synchronized (GRID_LOCKS) {
+            return GRID_LOCKS.computeIfAbsent(grid, ignored -> new Object());
+        }
+    }
+
+    private record RecoveryStep(
+            ExactStorageMutationJournal.Step step,
+            ExtendedAePlusBigIntegerCellInventoryAccess accessor,
+            Object2ObjectMap<AEKey, BigInteger> amounts,
             AEKey key,
-            IActionSource source) {
-        List<MEStorage> result = new ArrayList<>();
-        // 各priorityでpreferred storageを先にし、その後に同priorityの通常mountを並べる。
+            boolean before) {
+    }
+
+    private static List<ResolvedMount> resolveMounts(
+            NavigableMap<Integer, List<MEStorage>> mounts) {
+        List<ResolvedMount> result = new ArrayList<>();
         for (List<MEStorage> priority : mounts.values()) {
             for (MEStorage mount : priority) {
-                if (mount.isPreferredStorageFor(key, source)) {
-                    result.add(mount);
-                }
-            }
-            for (MEStorage mount : priority) {
-                if (!mount.isPreferredStorageFor(key, source)) {
-                    result.add(mount);
+                ResolvedExactStorage resolved = resolveExactStorage(mount);
+                if (resolved != null) {
+                    result.add(new ResolvedMount(mount, resolved));
                 }
             }
         }
         return result;
     }
 
-    private static BigInteger capacity(
-            ResolvedExactStorage resolved,
-            MEStorage mount,
+    private static List<ResolvedMount> orderedResolvedMounts(
+            NavigableMap<Integer, List<MEStorage>> mounts,
+            List<ResolvedMount> resolvedMounts,
             AEKey key,
-            BigInteger requested,
             IActionSource source,
             Direction direction) {
-        BigInteger current = resolved.currentAmount(key);
-        BigInteger candidate;
+        IdentityHashMap<MEStorage, ResolvedMount> byMount = new IdentityHashMap<>();
+        for (ResolvedMount resolvedMount : resolvedMounts) {
+            byMount.put(resolvedMount.mount(), resolvedMount);
+        }
+        List<ResolvedMount> result = new ArrayList<>();
+        Set<ExactStorageIdentity> visited = new LinkedHashSet<>();
         if (direction == Direction.EXTRACT) {
-            candidate = current.min(requested);
-        } else {
-            candidate = insertionCapacity(resolved, key, current, requested);
+            for (List<MEStorage> priority : mounts.descendingMap().values()) {
+                for (MEStorage mount : priority) {
+                    ResolvedMount resolved = byMount.get(mount);
+                    if (resolved != null
+                            && visited.add(resolved.resolved().storageIdentity())) {
+                        result.add(resolved);
+                    }
+                }
+            }
+            return result;
         }
-        if (candidate.signum() <= 0) {
-            return BigInteger.ZERO;
+        for (List<MEStorage> priority : mounts.values()) {
+            for (MEStorage mount : priority) {
+                ResolvedMount resolved = byMount.get(mount);
+                if (resolved != null
+                        && mount.isPreferredStorageFor(key, source)
+                        && visited.add(resolved.resolved().storageIdentity())) {
+                    result.add(resolved);
+                }
+            }
+            for (MEStorage mount : priority) {
+                ResolvedMount resolved = byMount.get(mount);
+                if (resolved != null
+                        && !mount.isPreferredStorageFor(key, source)
+                        && visited.add(resolved.resolved().storageIdentity())) {
+                    result.add(resolved);
+                }
+            }
         }
-
-        long probe = candidate.min(LONG_MAX).longValueExact();
-        long accepted = direction == Direction.EXTRACT
-                ? mount.extract(key, probe, Actionable.SIMULATE, source)
-                : mount.insert(key, probe, Actionable.SIMULATE, source);
-        // wrapperのfilterやextract/insert禁止を、直接Map変更より前に必ず尊重する。
-        return accepted == probe ? candidate : BigInteger.ZERO;
+        return result;
     }
 
     private static BigInteger insertionCapacity(
@@ -693,6 +887,17 @@ public final class ExactNetworkStorageBridge {
         if (replacement.signum() < 0 || replacementTotal.signum() < 0) {
             throw new IllegalStateException("exact cell amount would become negative");
         }
+        int replacementTypes = replacement.signum() == 0
+                ? amounts.size() - 1
+                : amounts.containsKey(step.key())
+                        ? amounts.size()
+                        : amounts.size() + 1;
+        if (!replacement.equals(step.afterAmount())
+                || !replacementTotal.equals(step.afterTotal())
+                || replacementTypes != step.afterTypes()) {
+            throw new IllegalStateException(
+                    "prepared exact cell transition does not match the live state");
+        }
 
         // 0量キーをMapへ残さず、ExtendedAE Plus本来の型数会計と一致させる。
         if (replacement.signum() == 0) {
@@ -700,7 +905,7 @@ public final class ExactNetworkStorageBridge {
         } else {
             amounts.put(step.key(), replacement);
         }
-        accessor.aco$setExactStoredTypeCount(amounts.size());
+        accessor.aco$setExactStoredTypeCount(replacementTypes);
         accessor.aco$setExactStoredTotal(replacementTotal);
         ExactBigIntegerCellConsistency.record(
                 amounts, replacementTotal);
@@ -731,7 +936,9 @@ public final class ExactNetworkStorageBridge {
                 if (!amounts.getOrDefault(step.key(), BigInteger.ZERO)
                                 .equals(change.afterAmount())
                         || !currentTotal.equals(
-                                change.afterTotal())) {
+                                change.afterTotal())
+                        || step.accessor().aco$getExactStoredTypeCount()
+                                != step.afterTypes()) {
                     complete = false;
                     continue;
                 }
@@ -781,8 +988,14 @@ public final class ExactNetworkStorageBridge {
         EXTRACT
     }
 
-    private record PreparedMutation(List<MutationStep> steps) {
+    private record PreparedMutation(
+            UUID operationId,
+            Map<AEKey, BigInteger> requested,
+            List<MutationStep> steps) {
         private PreparedMutation {
+            Objects.requireNonNull(operationId, "operationId");
+            requested = Collections.unmodifiableMap(
+                    new LinkedHashMap<>(requested));
             steps = List.copyOf(steps);
             if (steps.isEmpty()) {
                 throw new IllegalArgumentException(
@@ -798,7 +1011,49 @@ public final class ExactNetworkStorageBridge {
             BigInteger beforeAmount,
             BigInteger beforeTotal,
             int beforeTypes,
-            BigInteger amount) {
+            BigInteger amount,
+            BigInteger afterAmount,
+            BigInteger afterTotal,
+            int afterTypes) {
+    }
+
+    private static final class CellShadow {
+        private final ExtendedAePlusBigIntegerCellInventoryAccess accessor;
+        private final Object2ObjectMap<AEKey, BigInteger> actualAmounts;
+        private final Map<AEKey, BigInteger> amounts;
+        private BigInteger total;
+
+        private CellShadow(
+                ExtendedAePlusBigIntegerCellInventoryAccess accessor,
+                Object2ObjectMap<AEKey, BigInteger> actualAmounts,
+                Map<AEKey, BigInteger> amounts,
+                BigInteger total) {
+            this.accessor = accessor;
+            this.actualAmounts = actualAmounts;
+            this.amounts = amounts;
+            this.total = total;
+        }
+
+        private ExtendedAePlusBigIntegerCellInventoryAccess accessor() {
+            return accessor;
+        }
+
+        private Object2ObjectMap<AEKey, BigInteger> actualAmounts() {
+            return actualAmounts;
+        }
+
+        private Map<AEKey, BigInteger> amounts() {
+            return amounts;
+        }
+
+        private BigInteger total() {
+            return total;
+        }
+    }
+
+    private record ResolvedMount(
+            MEStorage mount,
+            ResolvedExactStorage resolved) {
     }
 
     private record AppliedStep(

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExactNetworkStorageSnapshotCache.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExactNetworkStorageSnapshotCache.java
@@ -72,6 +72,11 @@ public final class ExactNetworkStorageSnapshotCache {
         CAPTURES.remove();
     }
 
+    /** Generation captured in an exact mutation journal boundary. */
+    static long currentGeneration() {
+        return STORAGE_GENERATION.get();
+    }
+
     static boolean reuseOrBeginForTests(
             Object storage,
             KeyCounter target,

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExactStorageMutationJournal.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExactStorageMutationJournal.java
@@ -1,0 +1,478 @@
+package com.syaru.ae2craftingoptimizer.integration;
+
+import com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.world.level.saveddata.SavedData;
+
+/**
+ * Exact BigInteger storage mutation proof.
+ *
+ * <p>The record is written before a cell is changed. Each route step then records
+ * its applied state. Recovery can therefore distinguish an already-applied step
+ * from an untouched step without comparing an unrelated network-wide total.</p>
+ */
+public final class ExactStorageMutationJournal extends SavedData {
+    public static final String DATA_NAME = "ae2_crafting_optimizer_exact_storage_mutations";
+    private static final int SCHEMA_VERSION = 1;
+    private static final int HARD_MAXIMUM_RECORDS = 16_384;
+    private static final int HARD_MAXIMUM_STEPS = 65_536;
+
+    private final Map<UUID, Entry> entries = new LinkedHashMap<>();
+    private CompoundTag unsupportedPayload;
+
+    public static ExactStorageMutationJournal forGrid(appeng.api.networking.IGrid grid) {
+        Objects.requireNonNull(grid, "grid");
+        appeng.api.networking.IGridNode pivot = grid.getPivot();
+        if (pivot == null || pivot.getLevel() == null) {
+            return null;
+        }
+        return pivot.getLevel().getDataStorage().computeIfAbsent(
+                new SavedData.Factory<>(
+                        ExactStorageMutationJournal::new,
+                        ExactStorageMutationJournal::load),
+                DATA_NAME);
+    }
+
+    public synchronized boolean begin(
+            UUID operationId,
+            long generation,
+            String direction,
+            List<Step> steps,
+            int maximumEntries) {
+        if (!isHealthy() || entries.containsKey(operationId)) {
+            return false;
+        }
+        if (entries.size() >= Math.min(maximumEntries, HARD_MAXIMUM_RECORDS)
+                || steps.isEmpty()
+                || steps.size() > HARD_MAXIMUM_STEPS) {
+            return false;
+        }
+        entries.put(
+                operationId,
+                new Entry(
+                        operationId,
+                        generation,
+                        requireDirection(direction),
+                        steps));
+        setDirty();
+        return true;
+    }
+
+    public synchronized List<Entry> pending() {
+        List<Entry> result = new ArrayList<>();
+        for (Entry entry : entries.values()) {
+            if (!entry.quarantined()) {
+                result.add(entry.copy());
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    public synchronized boolean markApplied(UUID operationId, int stepIndex) {
+        Entry entry = requireEntry(operationId);
+        if (stepIndex < 0 || stepIndex >= entry.steps().size()) {
+            return false;
+        }
+        Step step = entry.stepAt(stepIndex);
+        if (step.applied()) {
+            return true;
+        }
+        entry.replaceStep(stepIndex, step.appliedCopy());
+        setDirty();
+        return true;
+    }
+
+    public synchronized boolean acknowledge(UUID operationId) {
+        if (entries.remove(operationId) != null) {
+            setDirty();
+            return true;
+        }
+        return false;
+    }
+
+    public synchronized boolean quarantine(UUID operationId, String reason) {
+        Entry entry = entries.get(operationId);
+        if (entry == null) {
+            return false;
+        }
+        entry.quarantined = true;
+        entry.quarantineReason = Objects.requireNonNull(reason, "reason");
+        setDirty();
+        return true;
+    }
+
+    public synchronized int size() {
+        return entries.size();
+    }
+
+    public synchronized boolean isHealthy() {
+        return unsupportedPayload == null;
+    }
+
+    @Override
+    public synchronized CompoundTag save(
+            CompoundTag tag,
+            HolderLookup.Provider registries) {
+        if (unsupportedPayload != null) {
+            return unsupportedPayload.copy();
+        }
+        tag.putInt("schema", SCHEMA_VERSION);
+        ListTag records = new ListTag();
+        for (Entry entry : entries.values()) {
+            records.add(entry.save());
+        }
+        tag.put("records", records);
+        return tag;
+    }
+
+    public static ExactStorageMutationJournal load(
+            CompoundTag tag,
+            HolderLookup.Provider registries) {
+        ExactStorageMutationJournal journal = new ExactStorageMutationJournal();
+        if (tag.getInt("schema") != SCHEMA_VERSION
+                || !tag.contains("records", Tag.TAG_LIST)) {
+            journal.unsupportedPayload = tag.copy();
+            AE2CraftingOptimizer.LOGGER.error(
+                    "ACO locked an unsupported exact storage journal schema against overwrite");
+            return journal;
+        }
+        ListTag records = tag.getList("records", Tag.TAG_COMPOUND);
+        if (records.size() > HARD_MAXIMUM_RECORDS) {
+            journal.unsupportedPayload = tag.copy();
+            AE2CraftingOptimizer.LOGGER.error(
+                    "ACO locked an oversized exact storage journal against overwrite: {} records",
+                    records.size());
+            return journal;
+        }
+        for (int index = 0; index < records.size(); index++) {
+            try {
+                Entry entry = Entry.load(records.getCompound(index));
+                if (journal.entries.putIfAbsent(entry.operationId(), entry) != null) {
+                    throw new IllegalArgumentException("duplicate exact operation id");
+                }
+            } catch (RuntimeException failure) {
+                journal.unsupportedPayload = tag.copy();
+                AE2CraftingOptimizer.LOGGER.error(
+                        "ACO locked a malformed exact storage journal against overwrite at record {}",
+                        index,
+                        failure);
+                return journal;
+            }
+        }
+        return journal;
+    }
+
+    private Entry requireEntry(UUID operationId) {
+        Entry entry = entries.get(operationId);
+        if (entry == null) {
+            throw new IllegalStateException(
+                    "unknown exact storage operation " + operationId);
+        }
+        return entry;
+    }
+
+    private static String requireDirection(String direction) {
+        if (!"INSERT".equals(direction) && !"EXTRACT".equals(direction)) {
+            throw new IllegalArgumentException("invalid exact storage direction");
+        }
+        return direction;
+    }
+
+    public static final class Entry {
+        private final UUID operationId;
+        private final long generation;
+        private final String direction;
+        private final List<Step> steps;
+        private boolean quarantined;
+        private String quarantineReason = "";
+
+        private Entry(
+                UUID operationId,
+                long generation,
+                String direction,
+                List<Step> steps) {
+            this.operationId = Objects.requireNonNull(operationId, "operationId");
+            if (generation < 0L) {
+                throw new IllegalArgumentException("generation must not be negative");
+            }
+            this.generation = generation;
+            this.direction = requireDirection(direction);
+            if (steps.isEmpty() || steps.size() > HARD_MAXIMUM_STEPS) {
+                throw new IllegalArgumentException("invalid exact journal step count");
+            }
+            this.steps = new ArrayList<>();
+            for (Step step : steps) {
+                this.steps.add(Objects.requireNonNull(step, "journal step"));
+            }
+        }
+
+        public UUID operationId() {
+            return operationId;
+        }
+
+        public long generation() {
+            return generation;
+        }
+
+        public String direction() {
+            return direction;
+        }
+
+        public List<Step> steps() {
+            return List.copyOf(steps);
+        }
+
+        private Step stepAt(int index) {
+            return steps.get(index);
+        }
+
+        private void replaceStep(int index, Step replacement) {
+            steps.set(index, replacement);
+        }
+
+        public boolean quarantined() {
+            return quarantined;
+        }
+
+        public String quarantineReason() {
+            return quarantineReason;
+        }
+
+        private Entry copy() {
+            Entry result = new Entry(operationId, generation, direction, steps);
+            result.quarantined = quarantined;
+            result.quarantineReason = quarantineReason;
+            return result;
+        }
+
+        private CompoundTag save() {
+            CompoundTag tag = new CompoundTag();
+            tag.putUUID("id", operationId);
+            tag.putLong("generation", generation);
+            tag.putString("direction", direction);
+            tag.putBoolean("quarantined", quarantined);
+            tag.putString("quarantineReason", quarantineReason);
+            ListTag savedSteps = new ListTag();
+            for (Step step : steps) {
+                savedSteps.add(step.save());
+            }
+            tag.put("steps", savedSteps);
+            return tag;
+        }
+
+        private static Entry load(CompoundTag tag) {
+            if (!tag.hasUUID("id")
+                    || !tag.contains("steps", Tag.TAG_LIST)) {
+                throw new IllegalArgumentException("malformed exact journal record");
+            }
+            ListTag steps = tag.getList("steps", Tag.TAG_COMPOUND);
+            if (steps.isEmpty() || steps.size() > HARD_MAXIMUM_STEPS) {
+                throw new IllegalArgumentException("invalid exact journal step list");
+            }
+            List<Step> loaded = new ArrayList<>(steps.size());
+            for (int index = 0; index < steps.size(); index++) {
+                loaded.add(Step.load(steps.getCompound(index)));
+            }
+            Entry entry = new Entry(
+                    tag.getUUID("id"),
+                    tag.getLong("generation"),
+                    tag.getString("direction"),
+                    loaded);
+            entry.quarantined = tag.getBoolean("quarantined");
+            entry.quarantineReason = tag.getString("quarantineReason");
+            return entry;
+        }
+    }
+
+    /** A single cell/key boundary proof; the key tag is decoded only during recovery. */
+    public static final class Step {
+        private final UUID storageId;
+        private final CompoundTag key;
+        private final BigInteger beforeAmount;
+        private final BigInteger afterAmount;
+        private final BigInteger beforeTotal;
+        private final BigInteger afterTotal;
+        private final int beforeTypes;
+        private final int afterTypes;
+        private final BigInteger amount;
+        private final boolean applied;
+
+        public Step(
+                UUID storageId,
+                CompoundTag key,
+                BigInteger beforeAmount,
+                BigInteger afterAmount,
+                BigInteger beforeTotal,
+                BigInteger afterTotal,
+                int beforeTypes,
+                int afterTypes,
+                BigInteger amount) {
+            this(
+                    storageId,
+                    key,
+                    beforeAmount,
+                    afterAmount,
+                    beforeTotal,
+                    afterTotal,
+                    beforeTypes,
+                    afterTypes,
+                    amount,
+                    false);
+        }
+
+        private Step(
+                UUID storageId,
+                CompoundTag key,
+                BigInteger beforeAmount,
+                BigInteger afterAmount,
+                BigInteger beforeTotal,
+                BigInteger afterTotal,
+                int beforeTypes,
+                int afterTypes,
+                BigInteger amount,
+                boolean applied) {
+            this.storageId = Objects.requireNonNull(storageId, "storageId");
+            this.key = Objects.requireNonNull(key, "key").copy();
+            this.beforeAmount = requireNonNegative(beforeAmount, "beforeAmount");
+            this.afterAmount = requireNonNegative(afterAmount, "afterAmount");
+            this.beforeTotal = requireNonNegative(beforeTotal, "beforeTotal");
+            this.afterTotal = requireNonNegative(afterTotal, "afterTotal");
+            if (beforeTypes < 0 || afterTypes < 0) {
+                throw new IllegalArgumentException("type counts must not be negative");
+            }
+            this.beforeTypes = beforeTypes;
+            this.afterTypes = afterTypes;
+            this.amount = requirePositive(amount, "amount");
+            this.applied = applied;
+        }
+
+        public UUID storageId() {
+            return storageId;
+        }
+
+        public CompoundTag key() {
+            return key.copy();
+        }
+
+        public BigInteger beforeAmount() {
+            return beforeAmount;
+        }
+
+        public BigInteger afterAmount() {
+            return afterAmount;
+        }
+
+        public BigInteger beforeTotal() {
+            return beforeTotal;
+        }
+
+        public BigInteger afterTotal() {
+            return afterTotal;
+        }
+
+        public int beforeTypes() {
+            return beforeTypes;
+        }
+
+        public int afterTypes() {
+            return afterTypes;
+        }
+
+        public BigInteger amount() {
+            return amount;
+        }
+
+        public boolean applied() {
+            return applied;
+        }
+
+        private Step appliedCopy() {
+            return new Step(
+                    storageId,
+                    key,
+                    beforeAmount,
+                    afterAmount,
+                    beforeTotal,
+                    afterTotal,
+                    beforeTypes,
+                    afterTypes,
+                    amount,
+                    true);
+        }
+
+        private CompoundTag save() {
+            CompoundTag tag = new CompoundTag();
+            tag.putUUID("storage", storageId);
+            tag.put("key", key.copy());
+            tag.putString("beforeAmount", beforeAmount.toString());
+            tag.putString("afterAmount", afterAmount.toString());
+            tag.putString("beforeTotal", beforeTotal.toString());
+            tag.putString("afterTotal", afterTotal.toString());
+            tag.putInt("beforeTypes", beforeTypes);
+            tag.putInt("afterTypes", afterTypes);
+            tag.putString("amount", amount.toString());
+            tag.putBoolean("applied", applied);
+            return tag;
+        }
+
+        private static Step load(CompoundTag tag) {
+            if (!tag.hasUUID("storage")
+                    || !(tag.get("key") instanceof CompoundTag key)) {
+                throw new IllegalArgumentException("malformed exact journal step");
+            }
+            return new Step(
+                    tag.getUUID("storage"),
+                    key,
+                    parseNonNegative(tag, "beforeAmount"),
+                    parseNonNegative(tag, "afterAmount"),
+                    parseNonNegative(tag, "beforeTotal"),
+                    parseNonNegative(tag, "afterTotal"),
+                    tag.getInt("beforeTypes"),
+                    tag.getInt("afterTypes"),
+                    parsePositive(tag, "amount"),
+                    tag.getBoolean("applied"));
+        }
+
+        private static BigInteger parseNonNegative(CompoundTag tag, String name) {
+            return requireNonNegative(parse(tag, name), name);
+        }
+
+        private static BigInteger parsePositive(CompoundTag tag, String name) {
+            return requirePositive(parse(tag, name), name);
+        }
+
+        private static BigInteger parse(CompoundTag tag, String name) {
+            try {
+                return new BigInteger(tag.getString(name));
+            } catch (RuntimeException failure) {
+                throw new IllegalArgumentException("invalid exact journal number " + name, failure);
+            }
+        }
+
+        private static BigInteger requireNonNegative(BigInteger value, String name) {
+            BigInteger checked = Objects.requireNonNull(value, name);
+            if (checked.signum() < 0) {
+                throw new IllegalArgumentException(name + " must not be negative");
+            }
+            return checked;
+        }
+
+        private static BigInteger requirePositive(BigInteger value, String name) {
+            BigInteger checked = Objects.requireNonNull(value, name);
+            if (checked.signum() <= 0) {
+                throw new IllegalArgumentException(name + " must be positive");
+            }
+            return checked;
+        }
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/ExactStorageMutationJournalTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/ExactStorageMutationJournalTest.java
@@ -1,0 +1,72 @@
+package com.syaru.ae2craftingoptimizer.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.UUID;
+import net.minecraft.nbt.CompoundTag;
+import org.junit.jupiter.api.Test;
+
+final class ExactStorageMutationJournalTest {
+    @Test
+    void persistsPerStepProofAndAppliedMarker() {
+        ExactStorageMutationJournal journal = new ExactStorageMutationJournal();
+        UUID operation = UUID.randomUUID();
+        UUID storage = UUID.randomUUID();
+        CompoundTag key = new CompoundTag();
+        key.putString("type", "test:key");
+        ExactStorageMutationJournal.Step step = new ExactStorageMutationJournal.Step(
+                storage,
+                key,
+                BigInteger.TEN,
+                BigInteger.valueOf(7L),
+                BigInteger.TEN,
+                BigInteger.valueOf(7L),
+                1,
+                1,
+                BigInteger.valueOf(3L));
+
+        assertTrue(journal.begin(operation, 12L, "EXTRACT", List.of(step), 16));
+        assertFalse(journal.pending().getFirst().steps().getFirst().applied());
+        assertTrue(journal.markApplied(operation, 0));
+        assertTrue(journal.pending().getFirst().steps().getFirst().applied());
+
+        CompoundTag saved = journal.save(new CompoundTag(), null);
+        ExactStorageMutationJournal loaded =
+                ExactStorageMutationJournal.load(saved, null);
+        ExactStorageMutationJournal.Entry entry = loaded.pending().getFirst();
+        assertEquals(12L, entry.generation());
+        assertEquals(operation, entry.operationId());
+        assertTrue(entry.steps().getFirst().applied());
+        assertEquals(BigInteger.valueOf(7L), entry.steps().getFirst().afterAmount());
+    }
+
+    @Test
+    void malformedJournalIsLockedAgainstOverwrite() {
+        CompoundTag malformed = new CompoundTag();
+        malformed.putInt("schema", 999);
+        malformed.put("records", new net.minecraft.nbt.ListTag());
+
+        ExactStorageMutationJournal journal =
+                ExactStorageMutationJournal.load(malformed, null);
+        assertFalse(journal.isHealthy());
+        assertFalse(journal.begin(
+                UUID.randomUUID(),
+                1L,
+                "INSERT",
+                List.of(new ExactStorageMutationJournal.Step(
+                        UUID.randomUUID(),
+                        new CompoundTag(),
+                        BigInteger.ZERO,
+                        BigInteger.ONE,
+                        BigInteger.ZERO,
+                        BigInteger.ONE,
+                        0,
+                        1,
+                        BigInteger.ONE)),
+                16));
+    }
+}


### PR DESCRIPTION
Closes #8

## Scope
- Replace the global exact-storage mutation lock with a per-grid lock.
- Build one immutable route for the complete boundary batch and commit that route without re-preparing each key.
- Keep a per-cell shadow state while preparing a multi-key batch so shared cells retain exact before/after/type-count boundaries.
- Persist an operation UUID and each cell/key transition before ownership transfer in SavedData.
- Mark each route step as applied and recover only when a cell/key state matches its recorded before or after proof.
- Quarantine malformed journals, missing cells, external same-key changes, and rollback states that cannot be proven.

## API/schema
- Added SavedData schema `ae2_crafting_optimizer_exact_storage_mutations`.
- BigInteger quantities are stored as decimal strings.
- Each journal step stores storage UUID, serialized AE key, before/after amount, before/after total, before/after type count, amount, and applied marker.
- Snapshot generation is recorded at the operation boundary.

## Safety
- Unsupported network mounts are rejected before mutation.
- Commit never falls back to the long API.
- Rollback is reverse-order and requires exact after-state/type-count proof.
- A state matching neither before nor after is quarantined rather than guessed.
- Separate grids no longer block one another on a static JVM-wide lock.

## Verification
- `./gradlew.bat test --no-daemon -PacoLocalModsDir=C:/Users/newadmin/Desktop/ae2-crafting-optimizer-src/.ci-mods`
- 311 tests passed.
- `git diff --check` passed.
- Minecraft/server runtime was intentionally not started.
