### PR TITLE
perf: share fallback calculations and classify reasons

### DIFF
--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
@@ -12,6 +12,8 @@ import appeng.crafting.CraftingPlan;
 import com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.optimization.ProviderPatternGenerationTracker;
+import com.syaru.ae2craftingoptimizer.optimization.CraftingFallbackDiagnostics;
+import com.syaru.ae2craftingoptimizer.optimization.FallbackReasonCode;
 import java.math.BigInteger;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -46,6 +48,11 @@ public final class Ae2AuthoritativeCraftingPlanner {
                 || grid == null
                 || source == null
                 || networkSnapshot == null) {
+            CraftingFallbackDiagnostics.record(
+                    null,
+                    ProviderPatternGenerationTracker.generation(),
+                    RecipeGenerationTracker.generation(),
+                    FallbackReasonCode.DISABLED);
             return null;
         }
         return new Capture(
@@ -70,6 +77,13 @@ public final class Ae2AuthoritativeCraftingPlanner {
                 || strategy == null
                 || requestedAmount <= 0L
                 || Thread.currentThread().isInterrupted()) {
+            CraftingFallbackDiagnostics.record(
+                    output,
+                    capture == null ? ProviderPatternGenerationTracker.generation() : capture.patternGeneration(),
+                    capture == null ? RecipeGenerationTracker.generation() : capture.recipeGeneration(),
+                    Thread.currentThread().isInterrupted()
+                            ? FallbackReasonCode.CANCELLED
+                            : FallbackReasonCode.UNSUPPORTED_PATTERN);
             return null;
         }
 
@@ -80,6 +94,8 @@ public final class Ae2AuthoritativeCraftingPlanner {
             var optionalProgram = graphSnapshot.rootProgram(output);
             // 曖昧、循環、複数出力などを含むルートはコンパイルせずAE2へ戻す。
             if (optionalProgram.isEmpty()) {
+                CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
+                        FallbackReasonCode.AMBIGUOUS_PRODUCER);
                 return null;
             }
             CompiledRootProgram<AEKey> program = optionalProgram.get();
@@ -88,6 +104,11 @@ public final class Ae2AuthoritativeCraftingPlanner {
                     .orElse(null);
             // 実AE2 Pattern API上の完全一致を証明できない場合はAE2へ戻す。
             if (topology == null || !topology.acceptsInventory(capture.inventorySnapshot())) {
+                CraftingFallbackDiagnostics.record(
+                        output,
+                        capture.patternGeneration(),
+                        capture.recipeGeneration(),
+                        topology == null ? FallbackReasonCode.UNSUPPORTED_PATTERN : FallbackReasonCode.INVENTORY_CHANGED);
                 return null;
             }
             boolean wideArithmeticRequired = topology.mightRequireWideArithmetic(
@@ -106,10 +127,14 @@ public final class Ae2AuthoritativeCraftingPlanner {
                     ACOConfig.enableProofQualifiedLongPlans(),
                     wideArithmeticRequired,
                     ACOConfig.requireAqeBigPlanShadowQualification())) {
+                CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
+                        FallbackReasonCode.SHADOW_NOT_QUALIFIED);
                 return null;
             }
             // 通常注文の置換を両方の設定で無効化した場合は、wide互換経路だけを残す。
             if (!normalLongReplacementEnabled() && !wideArithmeticRequired) {
+                CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
+                        FallbackReasonCode.UNSUPPORTED_PATTERN);
                 return null;
             }
 
@@ -117,6 +142,8 @@ public final class Ae2AuthoritativeCraftingPlanner {
                     BigKeyCounterSidecars.snapshot(capture.inventorySnapshot()).orElse(null);
             // Adapter失敗を含む不完全Snapshotは、飽和値から不足数を推測せずAE2へ戻す。
             if (inventoryMetadata != null && !inventoryMetadata.complete()) {
+                CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
+                        FallbackReasonCode.INVENTORY_CHANGED);
                 return null;
             }
             CompiledRootProgram.BigInventorySnapshot<AEKey> exactPlanningInventory =
@@ -158,6 +185,8 @@ public final class Ae2AuthoritativeCraftingPlanner {
                             guard);
             // Root Program経路以外の結果はAuthoritativeとして採用しない。
             if (!promoted.provenEquivalent()) {
+                CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
+                        FallbackReasonCode.TAG_SELECTION_UNPROVEN);
                 return null;
             }
             NormalizedPlan symbolic = normalize(promoted);
@@ -175,6 +204,8 @@ public final class Ae2AuthoritativeCraftingPlanner {
                         promoted);
                 // 厳格な親Jobへ変換できない経路は、値を近似せずAE2本来の計算へ戻す。
                 if (result == null) {
+                    CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
+                            FallbackReasonCode.UNSUPPORTED_PATTERN);
                     return null;
                 }
             } else {
@@ -189,6 +220,8 @@ public final class Ae2AuthoritativeCraftingPlanner {
                         wideArithmeticRequired);
                 // AtomicまたはAuthoritative設定で採用できない通常計画はAE2へ戻す。
                 if (result == null) {
+                    CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
+                            FallbackReasonCode.UNSUPPORTED_PATTERN);
                     return null;
                 }
             }
@@ -209,18 +242,36 @@ public final class Ae2AuthoritativeCraftingPlanner {
                             capture.source(),
                             output);
             if (!inventoryStillMatches) {
+                CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
+                        FallbackReasonCode.INVENTORY_CHANGED);
                 return null;
             }
             // Emitterまたはファジー候補が変わった場合も、AE2と選択結果がずれるため破棄する。
             if (!topology.remainsValid(capture.grid())) {
+                CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
+                        FallbackReasonCode.GENERATION_CHANGED);
                 return null;
             }
             return result;
         } catch (PlanningCancelledException
                 | StalePlanningSnapshotException
                 | ArithmeticException ignored) {
+            CraftingFallbackDiagnostics.record(
+                    output,
+                    capture == null ? ProviderPatternGenerationTracker.generation() : capture.patternGeneration(),
+                    capture == null ? RecipeGenerationTracker.generation() : capture.recipeGeneration(),
+                    ignored instanceof PlanningCancelledException
+                            ? FallbackReasonCode.CANCELLED
+                            : ignored instanceof ArithmeticException
+                                    ? FallbackReasonCode.COUNT_OVERFLOW
+                                    : FallbackReasonCode.GENERATION_CHANGED);
             return null;
         } catch (Throwable failure) {
+            CraftingFallbackDiagnostics.record(
+                    output,
+                    capture == null ? ProviderPatternGenerationTracker.generation() : capture.patternGeneration(),
+                    capture == null ? RecipeGenerationTracker.generation() : capture.recipeGeneration(),
+                    classifyFallback(failure));
             logFallbackOnce(output, failure);
             return null;
         }
@@ -461,6 +512,17 @@ public final class Ae2AuthoritativeCraftingPlanner {
                     output.getId(),
                     failure.toString());
         }
+    }
+
+    private static FallbackReasonCode classifyFallback(Throwable failure) {
+        String name = failure.getClass().getName().toLowerCase(java.util.Locale.ROOT);
+        if (name.contains("cycle")) {
+            return FallbackReasonCode.CYCLE;
+        }
+        if (name.contains("overflow") || failure instanceof ArithmeticException) {
+            return FallbackReasonCode.COUNT_OVERFLOW;
+        }
+        return FallbackReasonCode.UNKNOWN;
     }
 
     private static KeyCounter keyCounter(Map<AEKey, Long> counts) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCalculationDiagnosticsMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCalculationDiagnosticsMixin.java
@@ -9,6 +9,7 @@ import appeng.api.stacks.GenericStack;
 import appeng.api.stacks.KeyCounter;
 import appeng.crafting.CraftingCalculation;
 import com.syaru.ae2craftingoptimizer.optimization.CraftingCalculationDiagnostics;
+import com.syaru.ae2craftingoptimizer.optimization.CraftingFallbackDiagnostics;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingShadowValidator;
 import com.syaru.ae2craftingoptimizer.engine.Ae2AuthoritativeCraftingPlanner;
 import appeng.crafting.inv.NetworkCraftingSimulationState;
@@ -79,6 +80,7 @@ public abstract class CraftingCalculationDiagnosticsMixin {
     @Inject(method = "run", at = @At("HEAD"))
     private void aco$startCalculationTimer(CallbackInfoReturnable<ICraftingPlan> cir) {
         aco$calculationStartedAt = System.nanoTime();
+        CraftingFallbackDiagnostics.reset();
     }
 
     /**
@@ -99,6 +101,7 @@ public abstract class CraftingCalculationDiagnosticsMixin {
 
     @Inject(method = "run", at = @At("RETURN"))
     private void aco$logSlowCalculation(CallbackInfoReturnable<ICraftingPlan> cir) {
+        CraftingFallbackDiagnostics.Observation fallback = CraftingFallbackDiagnostics.take();
         CraftingCalculationDiagnostics.logIfSlow(
                 output,
                 requestedAmount,
@@ -106,7 +109,8 @@ public abstract class CraftingCalculationDiagnosticsMixin {
                 System.nanoTime() - aco$calculationStartedAt,
                 aco$usedAuthoritativePlan
                         ? "compiled-strict"
-                        : "ae2-fallback");
+                        : "ae2-fallback",
+                fallback);
         // Authoritative結果を自分自身と比較して一致回数を水増しせず、AE2標準結果だけを教材にする。
         if (!aco$usedAuthoritativePlan) {
             Ae2CraftingShadowValidator.validate(

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingServiceCalculationDeduplicationMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingServiceCalculationDeduplicationMixin.java
@@ -64,7 +64,7 @@ public abstract class CraftingServiceCalculationDeduplicationMixin {
             long amount,
             CalculationStrategy strategy,
             CallbackInfoReturnable<Future<ICraftingPlan>> cir) {
-        CraftingCalculationDeduplicator.remember(
+        Future<ICraftingPlan> returned = CraftingCalculationDeduplicator.remember(
                 (CraftingService) (Object) this,
                 level,
                 requester,
@@ -72,5 +72,8 @@ public abstract class CraftingServiceCalculationDeduplicationMixin {
                 amount,
                 strategy,
                 cir.getReturnValue());
+        if (returned != cir.getReturnValue()) {
+            cir.setReturnValue(returned);
+        }
     }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/CraftingCalculationDeduplicator.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/CraftingCalculationDeduplicator.java
@@ -8,6 +8,8 @@ import appeng.me.service.CraftingService;
 import com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.integration.AppliedECompatibility;
+import com.syaru.ae2craftingoptimizer.engine.RecipeGenerationTracker;
+import com.syaru.ae2craftingoptimizer.optimization.ProviderPatternGenerationTracker;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -57,11 +59,12 @@ public final class CraftingCalculationDeduplicator {
                         amount,
                         strategy);
             }
-            return entry.future;
+            OptimizationMetrics.recordCraftingCalculationDeduplication(true);
+            return entry.future.acquire();
         }
     }
 
-    public static void remember(
+    public static Future<ICraftingPlan> remember(
             CraftingService craftingService,
             Level level,
             ICraftingSimulationRequester requester,
@@ -70,7 +73,7 @@ public final class CraftingCalculationDeduplicator {
             CalculationStrategy strategy,
             Future<ICraftingPlan> future) {
         if (!ACOConfig.deduplicateActiveCraftingCalculations() || future == null || future.isDone() || future.isCancelled()) {
-            return;
+            return future;
         }
 
         RequestKey requestKey = RequestKey.of(level, requester, output, amount, strategy);
@@ -79,7 +82,14 @@ public final class CraftingCalculationDeduplicator {
         synchronized (ACTIVE_CALCULATIONS) {
             Map<RequestKey, Entry> serviceEntries = ACTIVE_CALCULATIONS.computeIfAbsent(craftingService, ignored -> new HashMap<>());
             cleanupActive(craftingService, serviceEntries, now);
-            serviceEntries.put(requestKey, new Entry(future, now));
+            Entry existing = serviceEntries.get(requestKey);
+            if (existing != null && existing.isReusable(now)) {
+                OptimizationMetrics.recordCraftingCalculationDeduplication(true);
+                return existing.future.acquire();
+            }
+            SharedCalculationFuture<ICraftingPlan> shared = new SharedCalculationFuture<>(future);
+            serviceEntries.put(requestKey, new Entry(shared, now));
+            return shared.acquire();
         }
     }
 
@@ -90,6 +100,16 @@ public final class CraftingCalculationDeduplicator {
         }
         if (ACOConfig.logCraftingCalculationDeduplication()) {
             AE2CraftingOptimizer.LOGGER.debug("Cleared active AE2 crafting calculation table: {}", reason);
+        }
+    }
+
+    /** Invalidate only in-flight work when storage content changes. */
+    public static void clearActive(String reason) {
+        synchronized (ACTIVE_CALCULATIONS) {
+            ACTIVE_CALCULATIONS.clear();
+        }
+        if (ACOConfig.logCraftingCalculationDeduplication()) {
+            AE2CraftingOptimizer.LOGGER.debug("Cleared active AE2 crafting calculations: {}", reason);
         }
     }
 
@@ -125,6 +145,7 @@ public final class CraftingCalculationDeduplicator {
                     requestKey.amount,
                     requestKey.strategy);
         }
+        OptimizationMetrics.recordCraftingCalculationCacheHit();
         return java.util.concurrent.CompletableFuture.completedFuture(entry.plan);
     }
 
@@ -149,7 +170,7 @@ public final class CraftingCalculationDeduplicator {
 
         ICraftingPlan plan;
         try {
-            plan = entry.future.get();
+            plan = entry.future.delegate().get();
         } catch (Exception ignored) {
             return;
         }
@@ -208,11 +229,11 @@ public final class CraftingCalculationDeduplicator {
 
     private record RequestKey(
             ResourceLocation dimension,
-            String requesterClass,
-            int requesterIdentity,
             AEKey output,
             long amount,
-            CalculationStrategy strategy) {
+            CalculationStrategy strategy,
+            long patternGeneration,
+            long recipeGeneration) {
         private static RequestKey of(
                 Level level,
                 ICraftingSimulationRequester requester,
@@ -222,15 +243,15 @@ public final class CraftingCalculationDeduplicator {
             ResourceLocation dimension = level.dimension().location();
             return new RequestKey(
                     dimension,
-                    requester.getClass().getName(),
-                    System.identityHashCode(requester),
                     output,
                     amount,
-                    strategy);
+                    strategy,
+                    ProviderPatternGenerationTracker.generation(),
+                    RecipeGenerationTracker.generation());
         }
     }
 
-    private record Entry(Future<ICraftingPlan> future, long createdAtNanos) {
+    private record Entry(SharedCalculationFuture<ICraftingPlan> future, long createdAtNanos) {
         private boolean isReusable(long now) {
             return !future.isDone()
                     && !future.isCancelled()

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/CraftingCalculationDiagnostics.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/CraftingCalculationDiagnostics.java
@@ -16,7 +16,8 @@ public final class CraftingCalculationDiagnostics {
             long requestedAmount,
             ICraftingPlan plan,
             long elapsedNanos,
-            String plannerRoute) {
+            String plannerRoute,
+            CraftingFallbackDiagnostics.Observation fallback) {
         if (!ACOConfig.logSlowCraftCalculations()) {
             return;
         }
@@ -30,13 +31,17 @@ public final class CraftingCalculationDiagnostics {
         int missingCount = plan != null ? plan.missingItems().size() : -1;
         long bytes = plan != null ? plan.bytes() : -1L;
         AE2CraftingOptimizer.LOGGER.info(
-                "Slow AE2 crafting calculation: requested {} x{}, final {}, missing entries {}, bytes {}, elapsed {} ms, planner route {}",
+                "Slow AE2 crafting calculation: requested {} x{}, final {}, missing entries {}, bytes {}, elapsed {} ms, planner route {}, fallback reason {}, generations {}/{}, aggregate {}",
                 output.getId(),
                 requestedAmount,
                 finalOutput,
                 missingCount,
                 bytes,
                 elapsedMillis,
-                plannerRoute);
+                plannerRoute,
+                fallback.code(),
+                fallback.patternGeneration(),
+                fallback.recipeGeneration(),
+                fallback.aggregateCount());
     }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/CraftingFallbackDiagnostics.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/CraftingFallbackDiagnostics.java
@@ -1,0 +1,66 @@
+package com.syaru.ae2craftingoptimizer.optimization;
+
+import appeng.api.stacks.AEKey;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Per-calculation fallback state plus compact aggregation for slow-calculation
+ * diagnostics. No AE2 objects are retained by the thread-local state.
+ */
+public final class CraftingFallbackDiagnostics {
+    private static final int MAX_AGGREGATES = 4096;
+    private static final ThreadLocal<Observation> CURRENT = new ThreadLocal<>();
+    private static final Map<AggregateKey, LongAdder> AGGREGATES = new ConcurrentHashMap<>();
+
+    private CraftingFallbackDiagnostics() {
+    }
+
+    public static void reset() {
+        CURRENT.remove();
+    }
+
+    public static void record(
+            AEKey output,
+            long patternGeneration,
+            long recipeGeneration,
+            FallbackReasonCode code) {
+        if (CURRENT.get() != null) {
+            return;
+        }
+        String outputId = output == null ? "<unknown>" : output.getId().toString();
+        AggregateKey key = new AggregateKey(outputId, patternGeneration, recipeGeneration, code);
+        if (AGGREGATES.size() >= MAX_AGGREGATES) {
+            AGGREGATES.clear();
+        }
+        LongAdder aggregate = AGGREGATES.computeIfAbsent(key, ignored -> new LongAdder());
+        aggregate.increment();
+        long aggregateCount = aggregate.sum();
+        CURRENT.set(new Observation(code, patternGeneration, recipeGeneration, aggregateCount));
+        OptimizationMetrics.recordCraftingFallback(code);
+    }
+
+    public static Observation take() {
+        Observation observation = CURRENT.get();
+        CURRENT.remove();
+        return observation == null ? Observation.none() : observation;
+    }
+
+    public record Observation(
+            FallbackReasonCode code,
+            long patternGeneration,
+            long recipeGeneration,
+            long aggregateCount) {
+        private static Observation none() {
+            return new Observation(FallbackReasonCode.UNKNOWN, -1L, -1L, 0L);
+        }
+    }
+
+    private record AggregateKey(
+            String outputId,
+            long patternGeneration,
+            long recipeGeneration,
+            FallbackReasonCode code) {
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/FallbackReasonCode.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/FallbackReasonCode.java
@@ -1,0 +1,19 @@
+package com.syaru.ae2craftingoptimizer.optimization;
+
+/** Stable, bounded reason codes for returning a calculation to AE2. */
+public enum FallbackReasonCode {
+    AMBIGUOUS_PRODUCER,
+    MULTIPLE_PATHS,
+    DYNAMIC_PATTERN,
+    PROCESSING_BOUNDARY,
+    TAG_SELECTION_UNPROVEN,
+    CYCLE,
+    GENERATION_CHANGED,
+    INVENTORY_CHANGED,
+    UNSUPPORTED_PATTERN,
+    SHADOW_NOT_QUALIFIED,
+    COUNT_OVERFLOW,
+    CANCELLED,
+    DISABLED,
+    UNKNOWN
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationMetrics.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationMetrics.java
@@ -32,6 +32,9 @@ public final class OptimizationMetrics {
     private static final LongAdder APPLIED_E_PATTERN_FALLBACKS = new LongAdder();
     private static final LongAdder APPLIED_E_DYNAMIC_PROVIDER_REFRESHES = new LongAdder();
     private static final LongAdder APPLIED_E_COMPLETED_PLAN_CACHE_BYPASSES = new LongAdder();
+    private static final LongAdder CRAFTING_CALCULATION_DEDUP_HITS = new LongAdder();
+    private static final LongAdder CRAFTING_CALCULATION_CACHE_HITS = new LongAdder();
+    private static final Map<FallbackReasonCode, LongAdder> CRAFTING_FALLBACK_REASONS = new ConcurrentHashMap<>();
     private static final LongAdder NATIVE_BATCH_TRANSACTIONS = new LongAdder();
     private static final Map<String, LongAdder> NATIVE_BATCH_EXECUTIONS = new ConcurrentHashMap<>();
     private static final LongAdder INSTANT_DISPATCH_CALLS = new LongAdder();
@@ -158,6 +161,20 @@ public final class OptimizationMetrics {
 
     public static void recordAppliedECompletedPlanCacheBypass() {
         APPLIED_E_COMPLETED_PLAN_CACHE_BYPASSES.increment();
+    }
+
+    public static void recordCraftingCalculationDeduplication(boolean hit) {
+        if (hit) {
+            CRAFTING_CALCULATION_DEDUP_HITS.increment();
+        }
+    }
+
+    public static void recordCraftingCalculationCacheHit() {
+        CRAFTING_CALCULATION_CACHE_HITS.increment();
+    }
+
+    public static void recordCraftingFallback(FallbackReasonCode code) {
+        CRAFTING_FALLBACK_REASONS.computeIfAbsent(code, ignored -> new LongAdder()).increment();
     }
 
     public static void recordNativePatternBatch(String adapterId, long executions) {
@@ -313,6 +330,10 @@ public final class OptimizationMetrics {
                         + " dynamic pattern fallback(s), " + APPLIED_E_DYNAMIC_PROVIDER_REFRESHES.sum()
                         + " provider refresh(es) preserved, " + APPLIED_E_COMPLETED_PLAN_CACHE_BYPASSES.sum()
                         + " completed plan cache bypass(es)",
+                "AE2 calculation reuse: " + CRAFTING_CALCULATION_DEDUP_HITS.sum()
+                        + " active hit(s), " + CRAFTING_CALCULATION_CACHE_HITS.sum()
+                        + " completed-plan hit(s)",
+                "AE2 fallback reasons: " + CRAFTING_FALLBACK_REASONS,
                 "Experimental native batch: " + NATIVE_BATCH_TRANSACTIONS.sum()
                         + " transaction(s), executions by adapter " + NATIVE_BATCH_EXECUTIONS,
                 "Sequential Instant: " + SEQUENTIAL_INSTANT_WAVES.sum()
@@ -391,6 +412,9 @@ public final class OptimizationMetrics {
         APPLIED_E_PATTERN_FALLBACKS.reset();
         APPLIED_E_DYNAMIC_PROVIDER_REFRESHES.reset();
         APPLIED_E_COMPLETED_PLAN_CACHE_BYPASSES.reset();
+        CRAFTING_CALCULATION_DEDUP_HITS.reset();
+        CRAFTING_CALCULATION_CACHE_HITS.reset();
+        CRAFTING_FALLBACK_REASONS.clear();
         NATIVE_BATCH_TRANSACTIONS.reset();
         NATIVE_BATCH_EXECUTIONS.clear();
         INSTANT_DISPATCH_CALLS.reset();

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/SharedCalculationFuture.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/SharedCalculationFuture.java
@@ -1,0 +1,91 @@
+package com.syaru.ae2craftingoptimizer.optimization;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Shares one AE2 calculation without allowing one requester's cancellation to
+ * cancel the calculation still used by other requesters.
+ */
+final class SharedCalculationFuture<T> {
+    private final Future<T> delegate;
+    private final AtomicInteger subscribers = new AtomicInteger();
+
+    SharedCalculationFuture(Future<T> delegate) {
+        this.delegate = delegate;
+    }
+
+    Future<T> acquire() {
+        subscribers.incrementAndGet();
+        return new Subscriber();
+    }
+
+    Future<T> delegate() {
+        return delegate;
+    }
+
+    boolean isDone() {
+        return delegate.isDone();
+    }
+
+    boolean isCancelled() {
+        return delegate.isCancelled();
+    }
+
+    private void release(boolean mayInterruptIfRunning) {
+        int remaining = subscribers.decrementAndGet();
+        if (remaining == 0 && !delegate.isDone()) {
+            delegate.cancel(mayInterruptIfRunning);
+        }
+    }
+
+    private final class Subscriber implements Future<T> {
+        private volatile boolean cancelled;
+        private boolean released;
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            synchronized (this) {
+                if (cancelled || released || isDone()) {
+                    return false;
+                }
+                cancelled = true;
+                released = true;
+            }
+            release(mayInterruptIfRunning);
+            return true;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled || delegate.isCancelled();
+        }
+
+        @Override
+        public boolean isDone() {
+            return cancelled || delegate.isDone();
+        }
+
+        @Override
+        public T get() throws InterruptedException, java.util.concurrent.ExecutionException {
+            ensureNotCancelled();
+            return delegate.get();
+        }
+
+        @Override
+        public T get(long timeout, TimeUnit unit)
+                throws InterruptedException, java.util.concurrent.ExecutionException,
+                java.util.concurrent.TimeoutException {
+            ensureNotCancelled();
+            return delegate.get(timeout, unit);
+        }
+
+        private void ensureNotCancelled() {
+            if (cancelled) {
+                throw new CancellationException();
+            }
+        }
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/StorageWatcherUpdateBuffer.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/StorageWatcherUpdateBuffer.java
@@ -16,6 +16,9 @@ public final class StorageWatcherUpdateBuffer {
     }
 
     public static void onStackChange(IStorageWatcherNode watcher, AEKey key, long amount) {
+        // Any in-flight plan may have used the previous amount. Do not reuse it
+        // across an inventory generation boundary.
+        CraftingCalculationDeduplicator.clearActive("storage watcher update");
         if (!ACOConfig.throttleStorageWatcherUpdates()) {
             watcher.onStackChange(key, amount);
             return;

--- a/src/test/java/com/syaru/ae2craftingoptimizer/optimization/CraftingFallbackDiagnosticsTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/optimization/CraftingFallbackDiagnosticsTest.java
@@ -1,0 +1,25 @@
+package com.syaru.ae2craftingoptimizer.optimization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class CraftingFallbackDiagnosticsTest {
+    @AfterEach
+    void clearThreadState() {
+        CraftingFallbackDiagnostics.reset();
+    }
+
+    @Test
+    void keepsTheFirstReasonAndGenerationForOneCalculation() {
+        CraftingFallbackDiagnostics.record(null, 7L, 11L, FallbackReasonCode.INVENTORY_CHANGED);
+        CraftingFallbackDiagnostics.record(null, 8L, 12L, FallbackReasonCode.UNKNOWN);
+
+        CraftingFallbackDiagnostics.Observation observation = CraftingFallbackDiagnostics.take();
+        assertEquals(FallbackReasonCode.INVENTORY_CHANGED, observation.code());
+        assertEquals(7L, observation.patternGeneration());
+        assertEquals(11L, observation.recipeGeneration());
+        assertEquals(1L, observation.aggregateCount());
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/optimization/SharedCalculationFutureTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/optimization/SharedCalculationFutureTest.java
@@ -1,0 +1,39 @@
+package com.syaru.ae2craftingoptimizer.optimization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.Test;
+
+class SharedCalculationFutureTest {
+    @Test
+    void oneRequesterCancellationDoesNotCancelOtherSubscribers() throws Exception {
+        CompletableFuture<String> delegate = new CompletableFuture<>();
+        SharedCalculationFuture<String> shared = new SharedCalculationFuture<>(delegate);
+        Future<String> first = shared.acquire();
+        Future<String> second = shared.acquire();
+
+        assertTrue(first.cancel(true));
+        assertTrue(first.isCancelled());
+        assertFalse(delegate.isCancelled());
+
+        delegate.complete("plan");
+        assertEquals("plan", second.get());
+        assertFalse(second.isCancelled());
+    }
+
+    @Test
+    void lastRequesterCancellationCancelsUnderlyingCalculation() {
+        CompletableFuture<String> delegate = new CompletableFuture<>();
+        SharedCalculationFuture<String> shared = new SharedCalculationFuture<>(delegate);
+        Future<String> first = shared.acquire();
+        Future<String> second = shared.acquire();
+
+        assertTrue(first.cancel(true));
+        assertTrue(second.cancel(true));
+        assertTrue(delegate.isCancelled());
+    }
+}


### PR DESCRIPTION
## Summary
Closes #5.

- Share active AE2 crafting calculations across requesters using grid/output/amount/strategy/pattern-generation/recipe-generation identity.
- Isolate requester cancellation with reference-counted subscriber futures.
- Invalidate in-flight reuse when storage watcher content changes.
- Add bounded fallback reason codes and compact output/generation/reason aggregation to slow-calculation diagnostics.
- Keep AE2 as the authoritative fallback and do not change plan contents.

## Contract
- Fallback results, missing entries, and AE2 provider selection remain unchanged.
- Generation and storage invalidation prevent stale active or completed reuse.
- A cancelled subscriber cannot cancel a calculation still used by another subscriber; the underlying future is cancelled only after the last subscriber leaves.
- Diagnostics keep fixed reason codes and bounded aggregate state; no stack traces or AE2 objects are retained in the hot-path key.

## Verification
- `./gradlew.bat test --no-daemon -PacoLocalModsDir=C:/Users/newadmin/Desktop/ae2-crafting-optimizer-src/.ci-mods`
- `git diff --check`
- Minecraft/server startup was not run.