### PR TITLE
Release ACO 1.5.7 for Forge 1.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.7] - 2026-08-08
+
+### Changed
+
+- Published the synchronized Forge 1.20.1 integration artifact for the
+  revision-aware AAC release line.
+
 ## [1.5.5] - 2026-07-29
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.6
+mod_version=1.5.7
 minecraft_version=1.20.1
 mod_group=com.syaru.ae2craftingoptimizer


### PR DESCRIPTION
## Summary

- Bump the Forge 1.20.1 artifact to ACO 1.5.7.
- Record the synchronized ACO/AQE/AAC integration release.

## Verification

- ./gradlew.bat clean build --no-daemon passed.
- Tests reported no failures or errors.
- Minecraft startup was not run.