### PR TITLE
Release ACO 1.5.7 for Minecraft 1.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
-## [1.6.2] - 2026-08-08
+## [1.5.7] - 2026-08-08
+
+### Changed
+
+- Published the NeoForge 1.21.1 build with mod version `1.5.7`.
+- Kept the Minecraft version in the artifact name as `_1.21.1`; it is not
+  part of the mod version.
 
 ### Added
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ minecraft_version=1.21.1
 neo_version=21.1.247
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.6.2
+mod_version=1.5.7
 mod_group=com.syaru.ae2craftingoptimizer


### PR DESCRIPTION
## Summary\n- Set the ACO mod version to 1.5.7 for the NeoForge Minecraft 1.21.1 line.\n- Keep 1.21.1 only in the artifact name: aco1.5.7_1.21.1.jar.\n\n## Verification\n- clean build passed\n- test suite passed with 0 failures and 0 errors\n- no Minecraft startup test performed\n\nThe existing v1.5.7 tag is the Forge 1.20.1 release, so the 1.21.1 release will use the distinct tag v1.5.7-1.21.1.