### PR TITLE
Support AE2-UELM 15.5.0-uelm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ae2Variant: [upstream, uelm]
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -27,7 +31,7 @@ jobs:
       - name: Build
         run: |
           chmod +x gradlew
-          ./gradlew clean build --stacktrace
+          ./gradlew clean build --stacktrace -Pae2Variant=${{ matrix.ae2Variant }}
 
       - name: Verify 1.20.1 artifact boundary
         shell: bash
@@ -43,6 +47,6 @@ jobs:
       - name: Upload jar
         uses: actions/upload-artifact@v6
         with:
-          name: aco-1.20.1-${{ github.sha }}
+          name: aco-1.20.1-${{ matrix.ae2Variant }}-${{ github.sha }}
           path: build/libs/aco*_1.20.1.jar
           if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.8] - Unreleased
+
+### Added
+
+- Added a Gradle `ae2Variant=upstream|uelm` build profile. The UELM profile
+  resolves `appeng:appliedenergistics2-forge:15.5.0-uelm` from the Expandium
+  releases repository.
+- Added evidence-based AE2-UELM detection for the shared `ae2` mod id.
+
+### Fixed
+
+- Delegated only the verified long craft amount menu/screen surface to UELM.
+- Kept ACO's BigInteger NetworkStorage, KeyCounter, and ExtendedAE cell paths
+  enabled because the compared UELM sources do not replace those surfaces.
+- Allowed the experimental compatibility audit to accept upstream AE2 15.4.10
+  and UELM 15.5.0-uelm without changing the upstream profile.
+
 ## [1.5.7] - 2026-08-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ uses `aco<version>_1.20.1.jar`; the NeoForge line is maintained separately on
 - Forge `47.4.18+`
 - Java `17`
 - Applied Energistics 2 `15.4.10`
+- AE2 Unofficial Extended Life Modern `15.5.0-uelm` (optional replacement
+  profile; keeps the `ae2` mod id)
 - Optional Advanced AE `1.3.5-1.20.1`
 - Optional Neo ECO AE Extension `20.3.x`
 - Optional GTCEu Modern `7.5.3`
@@ -40,6 +42,22 @@ Install the same ACO JAR on the server and every client. The common config is:
 ```text
 config/ae2_crafting_optimizer-common.toml
 ```
+
+### AE2-UELM build profile
+
+The UELM build is selected explicitly; it is not detected by a second mod id.
+UELM is the Forge 1.20.1 replacement distribution with artifact
+`appeng:appliedenergistics2-forge:15.5.0-uelm` and shared mod id `ae2`.
+
+```text
+gradlew.bat check --no-daemon -Pae2Variant=upstream
+gradlew.bat check --no-daemon -Pae2Variant=uelm
+```
+
+For an offline checked-out pack, place the matching JAR in the configured
+`acoLocalModsDir` using the artifact filename. ACO delegates UELM's native
+long craft amount menu/screen and retains its own exact BigInteger storage
+paths because UELM does not replace those storage classes.
 
 ## Core Optimizations
 

--- a/build.gradle
+++ b/build.gradle
@@ -164,8 +164,15 @@ tasks.register('normalizeReobfJarName') {
         }.files
         def source = sources.find { it.name != expected.name }
         if (source != null && source.exists()) {
-            if (!source.renameTo(expected)) {
-                throw new GradleException("Could not normalize ${source.name} to ${expected.name}")
+            try {
+                java.nio.file.Files.move(
+                        source.toPath(),
+                        expected.toPath(),
+                        java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+            } catch (java.io.IOException exception) {
+                throw new GradleException(
+                        "Could not normalize ${source.name} to ${expected.name}",
+                        exception)
             }
         }
         if (!expected.isFile()) {

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,13 @@ repositories {
         }
     }
     maven {
+        name = 'ExpandiumReleases'
+        url = 'https://repo.expandium.net/releases'
+        content {
+            includeGroup 'appeng'
+        }
+    }
+    maven {
         name = 'GTCEu'
         url = 'https://maven.gtceu.com/'
         content {
@@ -77,8 +84,13 @@ repositories {
 dependencies {
     minecraft 'net.minecraftforge:forge:1.20.1-47.4.18'
 
+    def ae2Variant = (findProperty('ae2Variant') ?: 'upstream').toString().toLowerCase()
+    if (!(ae2Variant in ['upstream', 'uelm'])) {
+        throw new GradleException("ae2Variant must be 'upstream' or 'uelm', got ${ae2Variant}")
+    }
+    def ae2Version = ae2Variant == 'uelm' ? '15.5.0-uelm' : '15.4.10'
     def localModsDir = file(findProperty('acoLocalModsDir') ?: '../../mods')
-    def localAe2 = new File(localModsDir, 'appliedenergistics2-forge-15.4.10.jar')
+    def localAe2 = new File(localModsDir, "appliedenergistics2-forge-${ae2Version}.jar")
     def localGtceu = new File(localModsDir, 'gtceu-1.20.1-7.5.3.jar')
     def localLdlib = new File(localModsDir, 'ldlib-forge-1.20.1-1.0.50.jar')
     def localMekanism = new File(localModsDir, 'Mekanism-1.20.1-10.4.16.80.jar')
@@ -95,7 +107,7 @@ dependencies {
         compileOnly files(localAppliedMekanistics)
         compileOnly files(localAdvancedAe)
     } else {
-        implementation fg.deobf('appeng:appliedenergistics2-forge:15.4.10')
+        implementation fg.deobf("appeng:appliedenergistics2-forge:${ae2Version}")
         def gtceuDependency = project.dependencies.create('com.gregtechceu.gtceu:gtceu-1.20.1:7.5.3') {
             transitive = false
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.7
+mod_version=1.5.8
 minecraft_version=1.20.1
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/BatchPayloadFingerprint.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/BatchPayloadFingerprint.java
@@ -2,7 +2,6 @@ package com.syaru.ae2craftingoptimizer.api.batch.v2;
 
 import appeng.api.stacks.GenericStack;
 import com.syaru.ae2craftingoptimizer.util.StableFingerprint;
-import com.syaru.ae2craftingoptimizer.transaction.BatchTransactionRecord;
 
 /** 取引IDとは独立した、入力・期待出力・実行数の決定的Fingerprint。 */
 public final class BatchPayloadFingerprint {
@@ -14,7 +13,23 @@ public final class BatchPayloadFingerprint {
     }
 
     public static String of(BatchTransactionRecord record) {
+        if (record == null) {
+            throw new NullPointerException("record");
+        }
         return of(record.offeredExecutions(), record.extractedInputs(), record.expectedOutputs());
+    }
+
+    /**
+     * Binary-compatibility bridge for adapters compiled against ACO 1.5.7.
+     * New source must use the public recovery record overload above.
+     */
+    @Deprecated(forRemoval = false)
+    public static String of(
+            com.syaru.ae2craftingoptimizer.transaction.BatchTransactionRecord record) {
+        if (record == null) {
+            throw new NullPointerException("record");
+        }
+        return record.toPublicView().payloadDigest();
     }
 
     private static String of(

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/BatchSourceReconciler.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/BatchSourceReconciler.java
@@ -1,15 +1,20 @@
 package com.syaru.ae2craftingoptimizer.api.batch.v2;
 
-import com.syaru.ae2craftingoptimizer.transaction.BatchTransactionRecord;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 
 public interface BatchSourceReconciler {
     ResourceLocation id();
 
-    SourceRecoveryResult rollbackPrepared(ServerLevel level, BatchTransactionRecord record);
+    default SourceRecoveryResult rollbackPrepared(ServerLevel level, BatchTransactionRecord record) {
+        throw new UnsupportedOperationException(
+                "source reconciler does not implement public transaction recovery");
+    }
 
-    SourceRecoveryResult accountAccepted(ServerLevel level, BatchTransactionRecord record);
+    default SourceRecoveryResult accountAccepted(ServerLevel level, BatchTransactionRecord record) {
+        throw new UnsupportedOperationException(
+                "source reconciler does not implement public transaction recovery");
+    }
 
     /** Called after the matching durable journal record reached a terminal phase. */
     default void forgetResolvedSource(ServerLevel level, BatchTransactionRecord record) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/BatchTransactionRecord.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/BatchTransactionRecord.java
@@ -67,27 +67,6 @@ public final class BatchTransactionRecord {
         this.updatedTick = updatedTick;
     }
 
-    static BatchTransactionRecord fromInternal(
-            com.syaru.ae2craftingoptimizer.transaction.BatchTransactionRecord record) {
-        return new BatchTransactionRecord(
-                record.id(),
-                record.adapterId(),
-                record.sourceId(),
-                record.dimensionId(),
-                record.targetPos(),
-                record.patternFingerprint(),
-                record.offeredExecutions(),
-                record.acceptedExecutions(),
-                record.createdTick(),
-                record.updatedTick(),
-                record.phase().name(),
-                record.extractedInputs(),
-                record.expectedOutputs(),
-                record.sourceData(),
-                record.adapterData(),
-                record.receipt());
-    }
-
     public UUID id() { return id; }
     public ResourceLocation adapterId() { return adapterId; }
     public ResourceLocation sourceId() { return sourceId; }
@@ -104,4 +83,49 @@ public final class BatchTransactionRecord {
     public CompoundTag sourceData() { return sourceData.copy(); }
     public CompoundTag adapterData() { return adapterData.copy(); }
     public String receipt() { return receipt; }
+
+    /**
+     * The canonical ownership payload digest used by ACO recovery.
+     * Integrations must use this value instead of reproducing ACO's encoding.
+     */
+    public String payloadDigest() {
+        return BatchPayloadFingerprint.of(this);
+    }
+
+    /** Creates an immutable public recovery view from the internal journal bridge. */
+    public static BatchTransactionRecord snapshot(
+            UUID id,
+            ResourceLocation adapterId,
+            ResourceLocation sourceId,
+            ResourceLocation dimensionId,
+            BlockPos targetPos,
+            String patternFingerprint,
+            long offeredExecutions,
+            long acceptedExecutions,
+            long createdTick,
+            long updatedTick,
+            String phase,
+            List<GenericStack> extractedInputs,
+            List<GenericStack> expectedOutputs,
+            CompoundTag sourceData,
+            CompoundTag adapterData,
+            String receipt) {
+        return new BatchTransactionRecord(
+                id,
+                adapterId,
+                sourceId,
+                dimensionId,
+                targetPos,
+                patternFingerprint,
+                offeredExecutions,
+                acceptedExecutions,
+                createdTick,
+                updatedTick,
+                phase,
+                extractedInputs,
+                expectedOutputs,
+                sourceData,
+                adapterData,
+                receipt);
+    }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/TransactionalPatternBatchAdapter.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/TransactionalPatternBatchAdapter.java
@@ -50,17 +50,6 @@ public interface TransactionalPatternBatchAdapter {
     /** Called only before durable target acceptance. */
     void rollback(PatternBatchContext context, PreparedPatternBatch prepared);
 
-    /**
-     * Legacy recovery entry point retained for binary compatibility with the
-     * 1.5.x built-in adapters. New integrations should implement the public
-     * read-only record overload below.
-     */
-    default BatchRecoveryResult reconcileTarget(
-            ServerLevel level,
-            com.syaru.ae2craftingoptimizer.transaction.BatchTransactionRecord record) {
-        return reconcileTarget(level, BatchTransactionRecord.fromInternal(record));
-    }
-
     /** Recovery entry point for integrations that use only the public API. */
     default BatchRecoveryResult reconcileTarget(
             ServerLevel level,
@@ -71,13 +60,6 @@ public interface TransactionalPatternBatchAdapter {
 
     /** Called after the matching durable journal record reached a terminal phase. */
     default void forgetResolvedTarget(PatternBatchContext context, UUID transactionId) {
-    }
-
-    /** Recovery-side counterpart for legacy built-in adapters. */
-    default void forgetResolvedTarget(
-            ServerLevel level,
-            com.syaru.ae2craftingoptimizer.transaction.BatchTransactionRecord record) {
-        forgetResolvedTarget(level, BatchTransactionRecord.fromInternal(record));
     }
 
     /** Recovery-side counterpart for public-API integrations. */

--- a/src/main/java/com/syaru/ae2craftingoptimizer/batch/Ae2BatchSourceReconciler.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/batch/Ae2BatchSourceReconciler.java
@@ -17,7 +17,7 @@ import com.syaru.ae2craftingoptimizer.access.CraftingJobTransactionAccess;
 import com.syaru.ae2craftingoptimizer.access.CraftingLogicTransactionAccess;
 import com.syaru.ae2craftingoptimizer.access.CraftingOwnerTransactionAccess;
 import com.syaru.ae2craftingoptimizer.access.CraftingTaskProgressAccess;
-import com.syaru.ae2craftingoptimizer.transaction.BatchTransactionRecord;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord;
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Locale;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.fml.ModList;
+import com.syaru.ae2craftingoptimizer.integration.Ae2UelmCompatibility;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.config.ModConfig;
 
@@ -1587,7 +1588,9 @@ public final class ACOConfig {
     }
 
     public static boolean enableLongRootCraftAmounts() {
-        return enableOptimizer() && ENABLE_LONG_ROOT_CRAFT_AMOUNTS.get();
+        return enableOptimizer()
+                && !Ae2UelmCompatibility.ownsAe2ExtendedAmountSurface()
+                && ENABLE_LONG_ROOT_CRAFT_AMOUNTS.get();
     }
 
     public static boolean enableCraftingEngineShadowMode() {
@@ -1682,6 +1685,7 @@ public final class ACOConfig {
 
     public static boolean enableExactBigIntegerInventorySnapshots() {
         return enableBigIntegerCraftingBackend()
+                && !Ae2UelmCompatibility.ownsAe2StorageSurface()
                 && ENABLE_EXACT_BIG_INTEGER_INVENTORY_SNAPSHOTS.get();
     }
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
@@ -1685,7 +1685,6 @@ public final class ACOConfig {
 
     public static boolean enableExactBigIntegerInventorySnapshots() {
         return enableBigIntegerCraftingBackend()
-                && !Ae2UelmCompatibility.ownsAe2StorageSurface()
                 && ENABLE_EXACT_BIG_INTEGER_INVENTORY_SNAPSHOTS.get();
     }
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/PhysicalCraftingTreeTransaction.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/PhysicalCraftingTreeTransaction.java
@@ -4,6 +4,7 @@ import appeng.api.crafting.IPatternDetails;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.crafting.ICraftingProvider;
 import appeng.api.networking.security.IActionSource;
+import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
 import appeng.me.service.CraftingService;
 import com.syaru.ae2craftingoptimizer.api.batch.ExactPatternFormula;
@@ -50,7 +51,8 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 public final class PhysicalCraftingTreeTransaction {
     public static final String ENGINE_ID =
             "aco:physical-crafting-table-tree-v4";
-    private static final int SCHEMA_VERSION = 2;
+    private static final int SCHEMA_VERSION = 3;
+    private static final int LEGACY_SCHEMA_VERSION = 2;
     /** 一つの物理レシピ段をGUI進捗へ換算する固定単位。 */
     private static final int PROGRESS_UNITS_PER_STEP = 100;
     /** 破損NBTによる巨大なキー配列確保を防ぐ固定上限。 */
@@ -59,6 +61,8 @@ public final class PhysicalCraftingTreeTransaction {
     private static final int MAXIMUM_DETAIL_LENGTH = 2_048;
 
     private final PreparedVectorBatch plan;
+    /** Immutable accounting identity captured before physical ownership begins. */
+    private final Map<String, PatternAccountingIdentity> patternIdentities;
     private final ExactCraftingEscrow<AEKey> escrow;
     private final List<StepReceipt> steps;
     private State state;
@@ -81,6 +85,7 @@ public final class PhysicalCraftingTreeTransaction {
 
     private PhysicalCraftingTreeTransaction(
             PreparedVectorBatch plan,
+            Map<String, PatternAccountingIdentity> patternIdentities,
             Map<AEKey, BigInteger> escrow,
             List<StepReceipt> steps,
             State state,
@@ -96,6 +101,10 @@ public final class PhysicalCraftingTreeTransaction {
                 Objects.requireNonNull(
                         plan,
                         "plan");
+        this.patternIdentities =
+                checkedPatternIdentities(
+                        plan,
+                        patternIdentities);
         this.escrow =
                 new ExactCraftingEscrow<>(
                         checkedCounts(
@@ -137,6 +146,12 @@ public final class PhysicalCraftingTreeTransaction {
 
     public static PhysicalCraftingTreeTransaction create(
             PreparedVectorBatch plan) {
+        return create(plan, Map.of());
+    }
+
+    public static PhysicalCraftingTreeTransaction create(
+            PreparedVectorBatch plan,
+            Map<String, PatternAccountingIdentity> patternIdentities) {
         Objects.requireNonNull(
                 plan,
                 "plan");
@@ -173,6 +188,7 @@ public final class PhysicalCraftingTreeTransaction {
         }
         return new PhysicalCraftingTreeTransaction(
                 plan,
+                patternIdentities,
                 Map.of(),
                 receipts,
                 State.VALIDATING,
@@ -195,9 +211,8 @@ public final class PhysicalCraftingTreeTransaction {
          * 旧「全Patternを証明して最終出力を直接生成」方式は意味が異なる。
          * schema移行で出力を推測すると複製し得るため、v4だけを復元する。
          */
-        if (owner.getInt(
-                            "schema")
-                        != SCHEMA_VERSION
+        int schema = owner.getInt("schema");
+        if ((schema != SCHEMA_VERSION && schema != LEGACY_SCHEMA_VERSION)
                 || !owner.contains(
                         "plan",
                         Tag.TAG_COMPOUND)) {
@@ -236,6 +251,9 @@ public final class PhysicalCraftingTreeTransaction {
                         : null;
         return new PhysicalCraftingTreeTransaction(
                 plan,
+                schema == SCHEMA_VERSION
+                        ? decodePatternIdentities(owner, plan)
+                        : Map.of(),
                 decodeCounts(
                         owner,
                         "escrow"),
@@ -265,7 +283,14 @@ public final class PhysicalCraftingTreeTransaction {
                 new CompoundTag();
         owner.putInt(
                 "schema",
-                SCHEMA_VERSION);
+                hasCompletePatternIdentities()
+                        ? SCHEMA_VERSION
+                        : LEGACY_SCHEMA_VERSION);
+        if (hasCompletePatternIdentities()) {
+            owner.put(
+                    "patternIdentities",
+                    encodePatternIdentities(patternIdentities));
+        }
         owner.put(
                 "plan",
                 PreparedVectorBatchCodec.encode(
@@ -319,6 +344,18 @@ public final class PhysicalCraftingTreeTransaction {
                 "steps",
                 encodedSteps);
         return owner;
+    }
+
+    private boolean hasCompletePatternIdentities() {
+        if (patternIdentities.size() != plan.craftingSteps().size()) {
+            return false;
+        }
+        for (ExactCraftingStep step : plan.craftingSteps()) {
+            if (!patternIdentities.containsKey(step.patternId())) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -499,33 +536,36 @@ public final class PhysicalCraftingTreeTransaction {
         Map<AEKey, BigInteger> expectedOutputs = new LinkedHashMap<>();
         Map<AEKey, BigInteger> introducedOutputs = new LinkedHashMap<>();
         Map<AEKey, BigInteger> creditedOutputs = new LinkedHashMap<>();
+        // v2 transactions are lazily migrated when the live graph is available.
+        ensurePatternIdentities(snapshot, level);
         // 固有Pattern数だけを一巡し、注文数量ぶんの会計要素は作らない。
         for (StepReceipt receipt : steps) {
-            ResolvedStep resolved = resolveStep(
-                    snapshot,
-                    level,
-                    receipt.index());
-            String patternId = resolved.step().patternId();
-            BigInteger executions = resolved.step().executions();
+            ExactCraftingStep step = plan.craftingSteps().get(receipt.index());
+            PatternAccountingIdentity identity = patternIdentities.get(step.patternId());
+            if (identity == null) {
+                throw new PatternUnavailableException(
+                        "saved accounting identity is not available for pattern " + step.patternId());
+            }
+            BigInteger executions = step.executions();
             mergePositive(
                     plannedTasks,
-                    patternId,
+                    identity.patternId(),
                     executions);
-            resolved.expectedOutputs().forEach((key, amount) ->
+            identity.expectedOutputs().forEach((key, amount) ->
                     mergePositive(expectedOutputs, key, amount));
             // Pattern Busが一度でも仕事を所有した段だけ、通常AE2のtask減算へ反映する。
             if (receipt.dispatched()) {
                 mergePositive(
                         dispatchedTasks,
-                        patternId,
+                        identity.patternId(),
                         executions);
                 // 通常AE2と同じく、Pattern投入時点でだけそのPatternの全出力をwaitingForへ加える。
-                resolved.expectedOutputs().forEach((key, amount) ->
+                identity.expectedOutputs().forEach((key, amount) ->
                         mergePositive(introducedOutputs, key, amount));
             }
             // 実出力をEscrowへ一度会計した段だけ、通常AE2のwaitingForから差し引く。
             if (receipt.outputCredited()) {
-                resolved.expectedOutputs().forEach((key, amount) ->
+                identity.expectedOutputs().forEach((key, amount) ->
                         mergePositive(creditedOutputs, key, amount));
             }
         }
@@ -534,8 +574,8 @@ public final class PhysicalCraftingTreeTransaction {
                         && (state == State.RETURNING_RESULTS
                                 || state == State.COMPLETE);
         return new AccountingSnapshot(
-                plannedTasks,
-                dispatchedTasks,
+                patternDefinitions(plannedTasks),
+                patternDefinitions(dispatchedTasks),
                 expectedOutputs,
                 introducedOutputs,
                 creditedOutputs,
@@ -581,13 +621,18 @@ public final class PhysicalCraftingTreeTransaction {
          * 境界素材へ触る前に、材料側から完成品側までの全式と依存順を
          * 仮想Escrowで一度だけ証明する。実行時は同じ式を再探索しない。
          */
-        if (!validateCompiledTree(
-                snapshot,
-                level)) {
-            quarantine(
-                    "compiled crafting-table tree does not conserve its exact inputs and outputs");
-            return TickOutcome.quarantined(
-                    detail);
+        try {
+            if (!validateCompiledTree(
+                    snapshot,
+                    level)) {
+                quarantine(
+                        "compiled crafting-table tree conflicts with its saved pattern identity");
+                return TickOutcome.quarantined(
+                        detail);
+            }
+        } catch (PatternUnavailableException unavailable) {
+            detail = unavailable.getMessage();
+            return TickOutcome.waiting(detail);
         }
         validatedPatternGeneration =
                 snapshot.graph()
@@ -632,16 +677,17 @@ public final class PhysicalCraftingTreeTransaction {
          * Providerまたはレシピ世代が変わった場合だけ、保存式を全体再検証する。
          * 不一致なら新しい式へ勝手に差し替えず、取消経路へ移る。
          */
-        if (!isValidatedFor(
-                        snapshot)
-                && !validateCompiledTree(
-                        snapshot,
-                        level)) {
-            state =
-                    State.CANCELLING_THREADS;
-            detail =
-                    "crafting-table recipe generation changed during execution";
-            return TickOutcome.changed();
+        if (!isValidatedFor(snapshot)) {
+            try {
+                if (!validateCompiledTree(snapshot, level)) {
+                    quarantine(
+                            "live crafting-table pattern conflicts with its saved physical identity");
+                    return TickOutcome.quarantined(detail);
+                }
+            } catch (PatternUnavailableException unavailable) {
+                detail = unavailable.getMessage();
+                return TickOutcome.waiting(detail);
+            }
         }
         validatedPatternGeneration =
                 snapshot.graph()
@@ -1685,6 +1731,8 @@ public final class PhysicalCraftingTreeTransaction {
                                 resolvedSteps);
             }
             return valid;
+        } catch (PatternUnavailableException unavailable) {
+            throw unavailable;
         } catch (RuntimeException | LinkageError invalid) {
             return false;
         }
@@ -1731,19 +1779,32 @@ public final class PhysicalCraftingTreeTransaction {
         IPatternDetails pattern =
                 snapshot.pattern(
                         step.patternId());
+        if (pattern == null || pattern.getDefinition() == null) {
+            throw new PatternUnavailableException(
+                    "saved crafting-table pattern is temporarily unavailable: " + step.patternId());
+        }
         ExactPatternFormula formula =
-                pattern == null
-                        ? null
-                        : ExactPatternFormula.tryCreate(
-                                        pattern,
-                                        level,
-                                        step.selectedInputs())
-                                .orElse(
-                                        null);
-        // Pattern消失、加工Pattern化、保存済み候補の不一致を推測で補わない。
+                ExactPatternFormula.tryCreate(
+                                pattern,
+                                level,
+                                step.selectedInputs())
+                        .orElse(null);
+        // A present but changed definition is a proven identity conflict; it is not a retryable unload.
         if (formula == null) {
-            throw new IllegalStateException(
-                    "saved crafting-table pattern is no longer deterministic");
+            throw new PatternIdentityConflictException(
+                    "saved crafting-table pattern is no longer deterministic: " + step.patternId());
+        }
+        PatternAccountingIdentity current = PatternAccountingIdentity.from(
+                step,
+                (AEItemKey) pattern.getDefinition(),
+                formula.exactInputTotals(step.executions()),
+                formula.exactExpectedOutputTotals(step.executions()));
+        PatternAccountingIdentity saved = patternIdentities.get(step.patternId());
+        if (saved == null) {
+            patternIdentities.put(step.patternId(), current);
+        } else if (!saved.equals(current)) {
+            throw new PatternIdentityConflictException(
+                    "live crafting-table pattern identity changed: " + step.patternId());
         }
         return new ResolvedStep(
                 step,
@@ -2198,6 +2259,142 @@ public final class PhysicalCraftingTreeTransaction {
         }
         return immutableOrderedMap(
                 result);
+    }
+
+    private static Map<String, PatternAccountingIdentity> checkedPatternIdentities(
+            PreparedVectorBatch plan,
+            Map<String, PatternAccountingIdentity> source) {
+        Objects.requireNonNull(source, "patternIdentities");
+        if (source.size() > MAXIMUM_EXACT_KEYS) {
+            throw new IllegalArgumentException("too many saved pattern identities");
+        }
+        Map<String, PatternAccountingIdentity> result = new LinkedHashMap<>();
+        for (Map.Entry<String, PatternAccountingIdentity> entry : source.entrySet()) {
+            String id = Objects.requireNonNull(entry.getKey(), "pattern identity id");
+            PatternAccountingIdentity identity = Objects.requireNonNull(
+                    entry.getValue(),
+                    "pattern identity");
+            if (!id.equals(identity.patternId())
+                    || result.putIfAbsent(id, identity) != null) {
+                throw new IllegalArgumentException("invalid or duplicate pattern identity");
+            }
+        }
+        for (ExactCraftingStep step : plan.craftingSteps()) {
+            PatternAccountingIdentity identity = result.get(step.patternId());
+            if (identity != null && !identity.matchesStep(step)) {
+                throw new IllegalArgumentException(
+                        "saved pattern identity does not match its physical step");
+            }
+        }
+        return result;
+    }
+
+    private void ensurePatternIdentities(
+            Ae2CompiledCraftingGraphCache.Snapshot snapshot,
+            Level level) {
+        for (int index = 0; index < plan.craftingSteps().size(); index++) {
+            ExactCraftingStep step = plan.craftingSteps().get(index);
+            if (!patternIdentities.containsKey(step.patternId())) {
+                resolveStepFresh(snapshot, level, index);
+            }
+        }
+    }
+
+    private Map<AEItemKey, BigInteger> patternDefinitions(
+            Map<String, BigInteger> patternExecutions) {
+        Map<AEItemKey, BigInteger> definitions = new LinkedHashMap<>();
+        for (Map.Entry<String, BigInteger> entry : patternExecutions.entrySet()) {
+            PatternAccountingIdentity identity = patternIdentities.get(entry.getKey());
+            if (identity == null) {
+                throw new PatternUnavailableException(
+                        "saved accounting identity is not available for pattern " + entry.getKey());
+            }
+            if (definitions.putIfAbsent(identity.definition(), entry.getValue()) != null) {
+                throw new PatternIdentityConflictException(
+                        "exact accounting contains duplicate saved pattern definitions");
+            }
+        }
+        return Map.copyOf(definitions);
+    }
+
+    public static Map<String, PatternAccountingIdentity> capturePatternAccounting(
+            PreparedVectorBatch plan,
+            Ae2CompiledCraftingGraphCache.Snapshot snapshot,
+            Level level) {
+        Objects.requireNonNull(plan, "plan");
+        Objects.requireNonNull(snapshot, "snapshot");
+        Objects.requireNonNull(level, "level");
+        Map<String, PatternAccountingIdentity> result = new LinkedHashMap<>();
+        for (ExactCraftingStep step : plan.craftingSteps()) {
+            IPatternDetails pattern = snapshot.pattern(step.patternId());
+            if (pattern == null || pattern.getDefinition() == null) {
+                throw new PatternUnavailableException(
+                        "physical crafting pattern is temporarily unavailable: " + step.patternId());
+            }
+            ExactPatternFormula formula = ExactPatternFormula.tryCreate(
+                            pattern,
+                            level,
+                            step.selectedInputs())
+                    .orElseThrow(() -> new PatternIdentityConflictException(
+                            "physical crafting pattern is not deterministic: " + step.patternId()));
+            PatternAccountingIdentity identity = PatternAccountingIdentity.from(
+                    step,
+                    (AEItemKey) pattern.getDefinition(),
+                    formula.exactInputTotals(step.executions()),
+                    formula.exactExpectedOutputTotals(step.executions()));
+            if (result.putIfAbsent(step.patternId(), identity) != null) {
+                throw new IllegalArgumentException("duplicate physical pattern identity");
+            }
+        }
+        return Map.copyOf(result);
+    }
+
+    private static ListTag encodePatternIdentities(
+            Map<String, PatternAccountingIdentity> identities) {
+        ListTag result = new ListTag();
+        for (PatternAccountingIdentity identity : identities.values()) {
+            CompoundTag entry = new CompoundTag();
+            entry.putString("id", identity.patternId());
+            entry.put("definition", identity.definition().toTag());
+            entry.put("inputs", encodeCounts(identity.inputTotals()));
+            entry.put("outputs", encodeCounts(identity.expectedOutputs()));
+            result.add(entry);
+        }
+        return result;
+    }
+
+    private static Map<String, PatternAccountingIdentity> decodePatternIdentities(
+            CompoundTag owner,
+            PreparedVectorBatch plan) {
+        Tag raw = owner.get("patternIdentities");
+        if (!(raw instanceof ListTag list)
+                || (!list.isEmpty() && list.getElementType() != Tag.TAG_COMPOUND)
+                || list.size() != plan.craftingSteps().size()) {
+            throw new IllegalArgumentException("missing or malformed physical pattern identities");
+        }
+        Map<String, PatternAccountingIdentity> result = new LinkedHashMap<>();
+        for (int index = 0; index < list.size(); index++) {
+            CompoundTag entry = list.getCompound(index);
+            AEItemKey definition = AEItemKey.fromTag(entry.getCompound("definition"));
+            if (definition == null) {
+                throw new IllegalArgumentException("saved pattern identity has an unknown definition");
+            }
+            PatternAccountingIdentity identity = new PatternAccountingIdentity(
+                    entry.getString("id"),
+                    definition,
+                    decodeCounts(entry, "inputs"),
+                    decodeCounts(entry, "outputs"));
+            if (result.putIfAbsent(identity.patternId(), identity) != null) {
+                throw new IllegalArgumentException("duplicate saved pattern identity");
+            }
+        }
+        for (ExactCraftingStep step : plan.craftingSteps()) {
+            if (!result.containsKey(step.patternId())) {
+                throw new IllegalArgumentException(
+                        "saved pattern identities do not match the physical plan");
+            }
+        }
+        return result;
     }
 
     private static <K> Map<K, BigInteger> immutableOrderedMap(
@@ -3106,6 +3303,50 @@ public final class PhysicalCraftingTreeTransaction {
         }
     }
 
+    public record PatternAccountingIdentity(
+            String patternId,
+            AEItemKey definition,
+            Map<AEKey, BigInteger> inputTotals,
+            Map<AEKey, BigInteger> expectedOutputs) {
+        public PatternAccountingIdentity {
+            patternId = Objects.requireNonNull(patternId, "patternId").trim();
+            definition = Objects.requireNonNull(definition, "definition");
+            if (patternId.isEmpty()) {
+                throw new IllegalArgumentException("pattern identity id is blank");
+            }
+            inputTotals = checkedCounts(inputTotals, "pattern identity inputs", false);
+            expectedOutputs = checkedCounts(expectedOutputs, "pattern identity outputs", false);
+        }
+
+        private static PatternAccountingIdentity from(
+                ExactCraftingStep step,
+                AEItemKey definition,
+                Map<AEKey, BigInteger> inputTotals,
+                Map<AEKey, BigInteger> expectedOutputs) {
+            return new PatternAccountingIdentity(
+                    step.patternId(),
+                    definition,
+                    inputTotals,
+                    expectedOutputs);
+        }
+
+        private boolean matchesStep(ExactCraftingStep step) {
+            return patternId.equals(step.patternId());
+        }
+    }
+
+    public static final class PatternUnavailableException extends RuntimeException {
+        public PatternUnavailableException(String message) {
+            super(message);
+        }
+    }
+
+    private static final class PatternIdentityConflictException extends RuntimeException {
+        private PatternIdentityConflictException(String message) {
+            super(message);
+        }
+    }
+
     private record ResolvedStep(
             ExactCraftingStep step,
             IPatternDetails pattern,
@@ -3235,20 +3476,20 @@ public final class PhysicalCraftingTreeTransaction {
     }
 
     public record AccountingSnapshot(
-            Map<String, BigInteger> plannedPatternExecutions,
-            Map<String, BigInteger> dispatchedPatternExecutions,
+            Map<AEItemKey, BigInteger> plannedPatternDefinitions,
+            Map<AEItemKey, BigInteger> dispatchedPatternDefinitions,
             Map<AEKey, BigInteger> expectedOutputs,
             Map<AEKey, BigInteger> introducedOutputs,
             Map<AEKey, BigInteger> creditedOutputs,
             boolean finalOutputReturned) {
         public AccountingSnapshot {
-            plannedPatternExecutions = checkedCounts(
-                    plannedPatternExecutions,
-                    "plannedPatternExecutions",
+            plannedPatternDefinitions = checkedCounts(
+                    plannedPatternDefinitions,
+                    "plannedPatternDefinitions",
                     false);
-            dispatchedPatternExecutions = checkedCounts(
-                    dispatchedPatternExecutions,
-                    "dispatchedPatternExecutions",
+            dispatchedPatternDefinitions = checkedCounts(
+                    dispatchedPatternDefinitions,
+                    "dispatchedPatternDefinitions",
                     true);
             expectedOutputs = checkedCounts(
                     expectedOutputs,
@@ -3264,8 +3505,8 @@ public final class PhysicalCraftingTreeTransaction {
                     true);
             // 配送済みPatternと受領済み出力は、それぞれ計画総量を超えてはならない。
             if (!containsAll(
-                            plannedPatternExecutions,
-                            dispatchedPatternExecutions)
+                            plannedPatternDefinitions,
+                            dispatchedPatternDefinitions)
                     || !containsAll(
                             expectedOutputs,
                             introducedOutputs)

--- a/src/main/java/com/syaru/ae2craftingoptimizer/gtceu/GTCEuNativePatternBatchAdapter.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/gtceu/GTCEuNativePatternBatchAdapter.java
@@ -4,7 +4,6 @@ import com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer;
 import com.syaru.ae2craftingoptimizer.api.batch.PatternBatchBudget;
 import com.syaru.ae2craftingoptimizer.api.batch.PatternBatchContext;
 import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchRecoveryResult;
-import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchPayloadFingerprint;
 import com.syaru.ae2craftingoptimizer.api.batch.v2.NativeBatchReceipt;
 import com.syaru.ae2craftingoptimizer.api.batch.v2.NativeBatchReceiptStore;
 import com.syaru.ae2craftingoptimizer.api.batch.v2.PatternBatchCommit;
@@ -14,7 +13,7 @@ import com.syaru.ae2craftingoptimizer.batch.NativePatternBatchSupport;
 import com.syaru.ae2craftingoptimizer.batch.PatternProviderReceiptResolver;
 import com.syaru.ae2craftingoptimizer.batch.PatternProviderBatchEscrow;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
-import com.syaru.ae2craftingoptimizer.transaction.BatchTransactionRecord;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord;
 import java.util.UUID;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
@@ -154,7 +153,7 @@ public final class GTCEuNativePatternBatchAdapter implements TransactionalPatter
         }
         if (!receipt.patternFingerprint().equals(record.patternFingerprint())
                 || receipt.executions() != record.offeredExecutions()
-                || !receipt.payloadDigest().equals(BatchPayloadFingerprint.of(record))) {
+                || !receipt.payloadDigest().equals(record.payloadDigest())) {
             return new BatchRecoveryResult(
                     BatchRecoveryResult.TargetState.QUARANTINE,
                     0L,

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/Ae2UelmCompatibility.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/Ae2UelmCompatibility.java
@@ -1,0 +1,75 @@
+package com.syaru.ae2craftingoptimizer.integration;
+
+import java.util.Set;
+import net.minecraftforge.fml.ModList;
+
+/**
+ * Optional ownership boundary for AE2-UELM.
+ *
+ * <p>UELM is an AE2 fork/extension and may own AE2's long-amount, storage,
+ * and capacity surfaces. ACO keeps its normal optimizer and optional machine
+ * integrations, but does not patch those same AE2 surfaces when UELM is
+ * present.</p>
+ */
+public final class Ae2UelmCompatibility {
+    /** Known IDs used by UEL/UELM-style AE2 distributions. */
+    private static final Set<String> UELM_MOD_IDS = Set.of(
+            "ae2_uelm",
+            "ae2uelm",
+            "ae2_uel",
+            "ae2uel");
+
+    /** Mixins that modify the AE2-owned long/storage/capacity surface. */
+    private static final Set<String> UELM_OWNED_MIXINS = Set.of(
+            "CraftAmountMenuLongAmountMixin",
+            "CraftConfirmMenuLongAmountMixin",
+            "CraftAmountScreenLongAmountMixin",
+            "CraftConfirmScreenBigIntegerMixin",
+            "CraftConfirmTableRendererBigIntegerMixin",
+            "CraftingCpuClusterBigCapacityGuardMixin",
+            "NetworkCraftingSimulationStateBigIntegerSnapshotMixin",
+            "NetworkStorageBigIntegerSnapshotMixin",
+            "NetworkStorageMountsAccessor",
+            "NetworkCraftingSimulationStateAccessor",
+            "KeyCounterBigIntegerSidecarLifecycleMixin",
+            "ExtendedAePlusBigIntegerCellInventoryAccessor",
+            "ExtendedAePlusBigIntegerCellConsistencyMixin",
+            "ExtendedAePlusInfinityDataStorageConsistencyMixin");
+
+    private Ae2UelmCompatibility() {
+    }
+
+    /** Returns whether a UELM-compatible AE2 distribution is loaded. */
+    public static boolean isLoaded() {
+        for (String modId : UELM_MOD_IDS) {
+            if (ModList.get().isLoaded(modId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Returns whether the named ACO Mixin belongs to UELM's ownership surface. */
+    public static boolean ownsAe2SurfaceMixin(String mixinClassName) {
+        int separator = mixinClassName.lastIndexOf('.');
+        String simpleName = separator >= 0
+                ? mixinClassName.substring(separator + 1)
+                : mixinClassName;
+        return UELM_OWNED_MIXINS.contains(simpleName);
+    }
+
+    /** ACO must leave AE2 root amount handling to UELM when it is installed. */
+    public static boolean ownsAe2ExtendedAmountSurface() {
+        return isLoaded();
+    }
+
+    /** ACO must leave exact AE2 network storage snapshots to UELM when installed. */
+    public static boolean ownsAe2StorageSurface() {
+        return isLoaded();
+    }
+
+    /** Exposed for the Mixin plugin without touching optional mod classes. */
+    public static boolean isKnownUelmModId(String modId) {
+        return UELM_MOD_IDS.contains(modId);
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/Ae2UelmCompatibility.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/Ae2UelmCompatibility.java
@@ -4,52 +4,48 @@ import java.util.Set;
 import net.minecraftforge.fml.ModList;
 
 /**
- * Optional ownership boundary for AE2-UELM.
+ * Evidence-based compatibility boundary for AE2 Unofficial Extended Life Modern.
  *
- * <p>UELM is an AE2 fork/extension and may own AE2's long-amount, storage,
- * and capacity surfaces. ACO keeps its normal optimizer and optional machine
- * integrations, but does not patch those same AE2 surfaces when UELM is
- * present.</p>
+ * <p>UELM is a replacement AE2 distribution: it keeps the {@code ae2} mod id
+ * and identifies its Forge 1.20.1 build as {@code 15.5.0-uelm}. ACO therefore
+ * detects the loaded AE2 version instead of looking for a second mod id.</p>
  */
 public final class Ae2UelmCompatibility {
-    /** Known IDs used by UEL/UELM-style AE2 distributions. */
-    private static final Set<String> UELM_MOD_IDS = Set.of(
-            "ae2_uelm",
-            "ae2uelm",
-            "ae2_uel",
-            "ae2uel");
+    public static final String UPSTREAM_VERSION = "15.4.10";
+    public static final String UELM_VERSION = "15.5.0-uelm";
 
-    /** Mixins that modify the AE2-owned long/storage/capacity surface. */
+    /** Only the three int-based craft amount Mixins overlap with UELM. */
     private static final Set<String> UELM_OWNED_MIXINS = Set.of(
             "CraftAmountMenuLongAmountMixin",
             "CraftConfirmMenuLongAmountMixin",
-            "CraftAmountScreenLongAmountMixin",
-            "CraftConfirmScreenBigIntegerMixin",
-            "CraftConfirmTableRendererBigIntegerMixin",
-            "CraftingCpuClusterBigCapacityGuardMixin",
-            "NetworkCraftingSimulationStateBigIntegerSnapshotMixin",
-            "NetworkStorageBigIntegerSnapshotMixin",
-            "NetworkStorageMountsAccessor",
-            "NetworkCraftingSimulationStateAccessor",
-            "KeyCounterBigIntegerSidecarLifecycleMixin",
-            "ExtendedAePlusBigIntegerCellInventoryAccessor",
-            "ExtendedAePlusBigIntegerCellConsistencyMixin",
-            "ExtendedAePlusInfinityDataStorageConsistencyMixin");
+            "CraftAmountScreenLongAmountMixin");
 
     private Ae2UelmCompatibility() {
     }
 
-    /** Returns whether a UELM-compatible AE2 distribution is loaded. */
-    public static boolean isLoaded() {
-        for (String modId : UELM_MOD_IDS) {
-            if (ModList.get().isLoaded(modId)) {
-                return true;
-            }
-        }
-        return false;
+    /** Pure version predicate used by runtime detection and unit tests. */
+    public static boolean isUelmVersion(String version) {
+        return UELM_VERSION.equals(version);
     }
 
-    /** Returns whether the named ACO Mixin belongs to UELM's ownership surface. */
+    /** Pure supported-version predicate for the upstream and UELM profiles. */
+    public static boolean isSupportedAe2Version(String version) {
+        return UPSTREAM_VERSION.equals(version) || isUelmVersion(version);
+    }
+
+    /** Returns the version of the shared {@code ae2} mod id, if it is loaded. */
+    public static String loadedAe2Version() {
+        return ModList.get().getModContainerById("ae2")
+                .map(container -> container.getModInfo().getVersion().toString())
+                .orElse(null);
+    }
+
+    /** Returns true only for the published UELM version/profile. */
+    public static boolean isLoaded() {
+        return isUelmVersion(loadedAe2Version());
+    }
+
+    /** Returns whether the named ACO Mixin overlaps UELM's verified long surface. */
     public static boolean ownsAe2SurfaceMixin(String mixinClassName) {
         int separator = mixinClassName.lastIndexOf('.');
         String simpleName = separator >= 0
@@ -58,18 +54,13 @@ public final class Ae2UelmCompatibility {
         return UELM_OWNED_MIXINS.contains(simpleName);
     }
 
-    /** ACO must leave AE2 root amount handling to UELM when it is installed. */
+    /** ACO's legacy int-based root amount path is delegated to UELM. */
     public static boolean ownsAe2ExtendedAmountSurface() {
         return isLoaded();
     }
 
-    /** ACO must leave exact AE2 network storage snapshots to UELM when installed. */
+    /** UELM did not change the verified NetworkStorage/KeyCounter surface. */
     public static boolean ownsAe2StorageSurface() {
-        return isLoaded();
-    }
-
-    /** Exposed for the Mixin plugin without touching optional mod classes. */
-    public static boolean isKnownUelmModId(String modId) {
-        return UELM_MOD_IDS.contains(modId);
+        return false;
     }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/AqeBigCraftingExecutionManager.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/AqeBigCraftingExecutionManager.java
@@ -490,7 +490,11 @@ public final class AqeBigCraftingExecutionManager {
                         }
                         transaction =
                                 PhysicalCraftingTreeTransaction.create(
-                                        plan);
+                                        plan,
+                                        PhysicalCraftingTreeTransaction.capturePatternAccounting(
+                                                plan,
+                                                graphSnapshot,
+                                                cluster.getLevel()));
                         validateExactCpuPlan(
                                 context,
                                 transaction.accountingSnapshot(
@@ -579,6 +583,9 @@ public final class AqeBigCraftingExecutionManager {
                     state.updatePhysicalExecution(
                             transaction.save());
                     context.cpu().markDirty();
+                } catch (PhysicalCraftingTreeTransaction.PatternUnavailableException deferred) {
+                    // A legacy physical receipt can learn its immutable identity when the provider returns.
+                    continue;
                 } catch (RuntimeException | LinkageError accountingFailure) {
                     quarantineExactCpu(
                             context,
@@ -758,9 +765,7 @@ public final class AqeBigCraftingExecutionManager {
                 PhysicalCraftingTreeTransaction.AccountingSnapshot accounting,
                 Ae2CompiledCraftingGraphCache.Snapshot graphSnapshot) {
             Map<AEItemKey, BigInteger> plannedTasks =
-                    patternDefinitions(
-                            accounting.plannedPatternExecutions(),
-                            graphSnapshot);
+                    accounting.plannedPatternDefinitions();
             /*
              * 再構築した物理式は、提出時に実Jobへ載せた全taskと完全一致させる。
              * 確定作業台経路はEmitterを許さないため、初期待機出力も存在してはならない。
@@ -784,9 +789,7 @@ public final class AqeBigCraftingExecutionManager {
                     accounting,
                     graphSnapshot);
             Map<AEItemKey, BigInteger> dispatchedTasks =
-                    patternDefinitions(
-                            accounting.dispatchedPatternExecutions(),
-                            graphSnapshot);
+                    accounting.dispatchedPatternDefinitions();
             BigInteger remainingOutput =
                     accounting.finalOutputReturned()
                             ? BigInteger.ZERO
@@ -809,35 +812,6 @@ public final class AqeBigCraftingExecutionManager {
                                             exactRemaining)));
         }
 
-        private Map<AEItemKey, BigInteger> patternDefinitions(
-                Map<String, BigInteger> patternExecutions,
-                Ae2CompiledCraftingGraphCache.Snapshot graphSnapshot) {
-            Map<AEItemKey, BigInteger> definitions =
-                    new HashMap<>();
-            // 安定Pattern IDを現在検証済みSnapshotのEncoded Pattern itemへ一対一で戻す。
-            for (var entry : patternExecutions.entrySet()) {
-                IPatternDetails pattern =
-                        graphSnapshot.pattern(
-                                entry.getKey());
-                if (pattern == null
-                        || pattern.getDefinition() == null) {
-                    throw new IllegalArgumentException(
-                            "exact accounting references an unknown pattern");
-                }
-                /*
-                 * Receiptの安定IDと実TaskProgressを一対一で照合する。
-                 * 同じ定義を複数IDから合算すると、どの実Taskが進んだか証明できない。
-                 */
-                if (definitions.putIfAbsent(
-                                pattern.getDefinition(),
-                                entry.getValue())
-                        != null) {
-                    throw new IllegalArgumentException(
-                            "exact accounting contains duplicate pattern definitions");
-                }
-            }
-            return Map.copyOf(definitions);
-        }
 
         private boolean isExactStateStale(
                 ExactCraftingJobState state,
@@ -1135,7 +1109,11 @@ public final class AqeBigCraftingExecutionManager {
                 try {
                     PhysicalCraftingTreeTransaction transaction =
                             PhysicalCraftingTreeTransaction.create(
-                                    plan);
+                                    plan,
+                                    PhysicalCraftingTreeTransaction.capturePatternAccounting(
+                                            plan,
+                                            graphSnapshot,
+                                            cluster.getLevel()));
                     host.prepareVector(
                             candidate.jobId(),
                             plan.transactionId(),

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExperimentalCompatibilityValidator.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExperimentalCompatibilityValidator.java
@@ -35,7 +35,7 @@ public final class ExperimentalCompatibilityValidator {
             return;
         }
         List<String> failures = new ArrayList<>();
-        requireExactVersion(failures, "ae2", "15.4.10");
+        requireSupportedAe2Version(failures);
         if ((ACOConfig.enableTransactionalBatchingV2()
                         || ACOConfig.enableFairCraftingJobScheduler()
                         || ACOConfig.enableAtomicBigCapacityPlans()
@@ -126,6 +126,18 @@ public final class ExperimentalCompatibilityValidator {
                     "ACO experimental integration audit failed. Disable the affected experimental switch "
                             + "or install the exact supported dependency versions. Missing transformations: "
                             + String.join("; ", failures));
+        }
+    }
+
+    private static void requireSupportedAe2Version(List<String> failures) {
+        String installed = ModList.get().getModContainerById("ae2")
+                .map(container -> container.getModInfo().getVersion().toString())
+                .orElse(null);
+        if (!Ae2UelmCompatibility.isSupportedAe2Version(installed)) {
+            failures.add("ae2 version must be "
+                    + Ae2UelmCompatibility.UPSTREAM_VERSION + " or "
+                    + Ae2UelmCompatibility.UELM_VERSION
+                    + " for the experimental engine (installed " + installed + ")");
         }
     }
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOStartupReport.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOStartupReport.java
@@ -7,6 +7,7 @@ import com.syaru.ae2craftingoptimizer.api.batch.v2.PatternBatchV2Api;
 import com.syaru.ae2craftingoptimizer.api.big.BigCraftingEngineApi;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.integration.AppliedECompatibility;
+import com.syaru.ae2craftingoptimizer.integration.Ae2UelmCompatibility;
 import com.syaru.ae2craftingoptimizer.network.BigCraftingNetwork;
 import net.minecraftforge.fml.ModList;
 
@@ -113,6 +114,11 @@ final class ACOStartupReport {
                 ACOConfig.coalesceCraftingProviderRefreshes(),
                 ACOConfig.coalesceClientTerminalViewUpdates(),
                 ACOConfig.fixStuckAe2ScrollbarRepeat());
+        AE2CraftingOptimizer.LOGGER.info(
+                "ACO AE2-UELM compatibility: loaded {}, AE2 amount surface delegated {}, AE2 storage surface delegated {}",
+                Ae2UelmCompatibility.isLoaded(),
+                Ae2UelmCompatibility.ownsAe2ExtendedAmountSurface(),
+                Ae2UelmCompatibility.ownsAe2StorageSurface());
         AE2CraftingOptimizer.LOGGER.info(
                 "ACO ExtendedAE Circuit Cutter recipe cache: {}, max {} entries",
                 ACOConfig.cacheCircuitCutterRecipes(),

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mekanism/MekanismNativePatternBatchAdapter.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mekanism/MekanismNativePatternBatchAdapter.java
@@ -4,7 +4,6 @@ import com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer;
 import com.syaru.ae2craftingoptimizer.api.batch.PatternBatchBudget;
 import com.syaru.ae2craftingoptimizer.api.batch.PatternBatchContext;
 import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchRecoveryResult;
-import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchPayloadFingerprint;
 import com.syaru.ae2craftingoptimizer.api.batch.v2.NativeBatchReceipt;
 import com.syaru.ae2craftingoptimizer.api.batch.v2.NativeBatchReceiptStore;
 import com.syaru.ae2craftingoptimizer.api.batch.v2.PatternBatchCommit;
@@ -14,7 +13,7 @@ import com.syaru.ae2craftingoptimizer.batch.NativePatternBatchSupport;
 import com.syaru.ae2craftingoptimizer.batch.PatternProviderReceiptResolver;
 import com.syaru.ae2craftingoptimizer.batch.PatternProviderBatchEscrow;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
-import com.syaru.ae2craftingoptimizer.transaction.BatchTransactionRecord;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord;
 import java.util.UUID;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
@@ -155,7 +154,7 @@ public final class MekanismNativePatternBatchAdapter implements TransactionalPat
         }
         if (!receipt.patternFingerprint().equals(record.patternFingerprint())
                 || receipt.executions() != record.offeredExecutions()
-                || !receipt.payloadDigest().equals(BatchPayloadFingerprint.of(record))) {
+                || !receipt.payloadDigest().equals(record.payloadDigest())) {
             return new BatchRecoveryResult(
                     BatchRecoveryResult.TargetState.QUARANTINE,
                     0L,

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AcoMixinPlugin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AcoMixinPlugin.java
@@ -3,6 +3,7 @@ package com.syaru.ae2craftingoptimizer.mixin;
 import com.syaru.ae2craftingoptimizer.integration.Ae2UelmCompatibility;
 import java.util.List;
 import java.util.Set;
+import net.minecraftforge.fml.loading.FMLLoader;
 import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
@@ -12,12 +13,6 @@ import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
  * same behavior. The plugin has no hard reference to UELM classes.
  */
 public final class AcoMixinPlugin implements IMixinConfigPlugin {
-    private static final Set<String> UELM_MOD_IDS = Set.of(
-            "ae2_uelm",
-            "ae2uelm",
-            "ae2_uel",
-            "ae2uel");
-
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
         if (!isUelmLoadedDuringBootstrap()) {
@@ -28,15 +23,15 @@ public final class AcoMixinPlugin implements IMixinConfigPlugin {
 
     private static boolean isUelmLoadedDuringBootstrap() {
         try {
-            Class<?> loader = Class.forName("net.minecraftforge.fml.loading.FMLLoader");
-            Object loadingModList = loader.getMethod("getLoadingModList").invoke(null);
-            var isLoaded = loadingModList.getClass().getMethod("isLoaded", String.class);
-            for (String modId : UELM_MOD_IDS) {
-                if (Boolean.TRUE.equals(isLoaded.invoke(loadingModList, modId))) {
-                    return true;
-                }
+            var modFile = FMLLoader.getLoadingModList().getModFileById("ae2");
+            if (modFile == null) {
+                return false;
             }
-        } catch (ReflectiveOperationException | LinkageError ignored) {
+            return modFile.getMods().stream()
+                    .filter(mod -> "ae2".equals(mod.getModId()))
+                    .map(mod -> mod.getVersion().toString())
+                    .anyMatch(Ae2UelmCompatibility::isUelmVersion);
+        } catch (RuntimeException | LinkageError ignored) {
             // Unknown bootstrap state must keep ACO's normal behavior intact.
         }
         return false;

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AcoMixinPlugin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AcoMixinPlugin.java
@@ -1,0 +1,72 @@
+package com.syaru.ae2craftingoptimizer.mixin;
+
+import com.syaru.ae2craftingoptimizer.integration.Ae2UelmCompatibility;
+import java.util.List;
+import java.util.Set;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+/**
+ * Prevents ACO's AE2-owned surface Mixins from loading when AE2-UELM owns the
+ * same behavior. The plugin has no hard reference to UELM classes.
+ */
+public final class AcoMixinPlugin implements IMixinConfigPlugin {
+    private static final Set<String> UELM_MOD_IDS = Set.of(
+            "ae2_uelm",
+            "ae2uelm",
+            "ae2_uel",
+            "ae2uel");
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (!isUelmLoadedDuringBootstrap()) {
+            return true;
+        }
+        return !Ae2UelmCompatibility.ownsAe2SurfaceMixin(mixinClassName);
+    }
+
+    private static boolean isUelmLoadedDuringBootstrap() {
+        try {
+            Class<?> loader = Class.forName("net.minecraftforge.fml.loading.FMLLoader");
+            Object loadingModList = loader.getMethod("getLoadingModList").invoke(null);
+            var isLoaded = loadingModList.getClass().getMethod("isLoaded", String.class);
+            for (String modId : UELM_MOD_IDS) {
+                if (Boolean.TRUE.equals(isLoaded.invoke(loadingModList, modId))) {
+                    return true;
+                }
+            }
+        } catch (ReflectiveOperationException | LinkageError ignored) {
+            // Unknown bootstrap state must keep ACO's normal behavior intact.
+        }
+        return false;
+    }
+
+    @Override public void onLoad(String mixinPackage) {
+    }
+
+    @Override public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+    }
+
+    @Override public List<String> getMixins() {
+        return List.of();
+    }
+
+    @Override public void preApply(
+            String targetClassName,
+            ClassNode targetClass,
+            String mixinClassName,
+            IMixinInfo mixinInfo) {
+    }
+
+    @Override public void postApply(
+            String targetClassName,
+            ClassNode targetClass,
+            String mixinClassName,
+            IMixinInfo mixinInfo) {
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/TransactionalCraftingExecutorV2.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/TransactionalCraftingExecutorV2.java
@@ -317,7 +317,7 @@ public final class TransactionalCraftingExecutorV2 {
                         selection.adapter().rollback(selection.context(), prepared);
                         SourceRecoveryResult rollback = Ae2BatchSourceReconciler.INSTANCE.rollbackPrepared(
                                 serverLevel,
-                                transaction.record());
+                                transaction.record().toPublicView());
                         return finishRollback(
                                 transaction,
                                 rollback,
@@ -343,7 +343,7 @@ public final class TransactionalCraftingExecutorV2 {
                         commitStarted = false;
                         selection.adapter().rollback(selection.context(), prepared);
                         SourceRecoveryResult rollback = Ae2BatchSourceReconciler.INSTANCE.rollbackPrepared(
-                                serverLevel, transaction.record());
+                                serverLevel, transaction.record().toPublicView());
                         return finishRollback(
                                 transaction,
                                 rollback,
@@ -363,7 +363,7 @@ public final class TransactionalCraftingExecutorV2 {
                     owner.aco$markCraftingOwnerDirty();
 
                     SourceRecoveryResult accounting = Ae2BatchSourceReconciler.INSTANCE.accountAccepted(
-                            serverLevel, transaction.record());
+                            serverLevel, transaction.record().toPublicView());
                     if (accounting == SourceRecoveryResult.RETRY) {
                         safeReconciliation(
                                 transaction,
@@ -394,7 +394,7 @@ public final class TransactionalCraftingExecutorV2 {
                         try {
                             selection.adapter().rollback(selection.context(), prepared);
                             SourceRecoveryResult rollback = Ae2BatchSourceReconciler.INSTANCE.rollbackPrepared(
-                                    serverLevel, transaction.record());
+                                    serverLevel, transaction.record().toPublicView());
                             logFailure(logic.getClass(), failure);
                             return finishRollback(
                                     transaction,
@@ -741,7 +741,7 @@ public final class TransactionalCraftingExecutorV2 {
             PatternBatchContext context,
             BatchTransactionRecord record) {
         try {
-            Ae2BatchSourceReconciler.INSTANCE.forgetResolvedSource(level, record);
+            Ae2BatchSourceReconciler.INSTANCE.forgetResolvedSource(level, record.toPublicView());
         } catch (Throwable cleanupFailure) {
             AE2CraftingOptimizer.LOGGER.warn(
                     "ACO retained a terminal source receipt after journal completion {}: {}",

--- a/src/main/java/com/syaru/ae2craftingoptimizer/transaction/BatchRecoveryCompatibilityBridge.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/transaction/BatchRecoveryCompatibilityBridge.java
@@ -1,0 +1,165 @@
+package com.syaru.ae2craftingoptimizer.transaction;
+
+import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchRecoveryResult;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchSourceReconciler;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.SourceRecoveryResult;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.TransactionalPatternBatchAdapter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import net.minecraft.server.level.ServerLevel;
+
+/**
+ * Keeps 1.5.x recovery implementations callable without exposing the journal
+ * record from any public API type.
+ */
+final class BatchRecoveryCompatibilityBridge {
+    private BatchRecoveryCompatibilityBridge() {
+    }
+
+    static BatchRecoveryResult reconcileTarget(
+            TransactionalPatternBatchAdapter adapter,
+            ServerLevel level,
+            BatchTransactionRecord record) {
+        Method publicMethod = publicMethod(
+                adapter,
+                "reconcileTarget",
+                ServerLevel.class,
+                com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord.class);
+        if (publicMethod.getDeclaringClass() != TransactionalPatternBatchAdapter.class) {
+            return adapter.reconcileTarget(level, record.toPublicView());
+        }
+        return invokeLegacy(
+                adapter,
+                "reconcileTarget",
+                BatchRecoveryResult.class,
+                level,
+                record);
+    }
+
+    static SourceRecoveryResult rollbackPrepared(
+            BatchSourceReconciler source,
+            ServerLevel level,
+            BatchTransactionRecord record) {
+        Method publicMethod = publicMethod(
+                source,
+                "rollbackPrepared",
+                ServerLevel.class,
+                com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord.class);
+        if (publicMethod.getDeclaringClass() != BatchSourceReconciler.class) {
+            return source.rollbackPrepared(level, record.toPublicView());
+        }
+        return invokeLegacy(
+                source,
+                "rollbackPrepared",
+                SourceRecoveryResult.class,
+                level,
+                record);
+    }
+
+    static SourceRecoveryResult accountAccepted(
+            BatchSourceReconciler source,
+            ServerLevel level,
+            BatchTransactionRecord record) {
+        Method publicMethod = publicMethod(
+                source,
+                "accountAccepted",
+                ServerLevel.class,
+                com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord.class);
+        if (publicMethod.getDeclaringClass() != BatchSourceReconciler.class) {
+            return source.accountAccepted(level, record.toPublicView());
+        }
+        return invokeLegacy(
+                source,
+                "accountAccepted",
+                SourceRecoveryResult.class,
+                level,
+                record);
+    }
+
+    static void forgetTarget(
+            TransactionalPatternBatchAdapter adapter,
+            ServerLevel level,
+            BatchTransactionRecord record) {
+        Method publicMethod = publicMethod(
+                adapter,
+                "forgetResolvedTarget",
+                ServerLevel.class,
+                com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord.class);
+        if (publicMethod.getDeclaringClass() != TransactionalPatternBatchAdapter.class) {
+            adapter.forgetResolvedTarget(level, record.toPublicView());
+            return;
+        }
+        invokeLegacyVoid(adapter, "forgetResolvedTarget", level, record);
+    }
+
+    static void forgetSource(
+            BatchSourceReconciler source,
+            ServerLevel level,
+            BatchTransactionRecord record) {
+        Method publicMethod = publicMethod(
+                source,
+                "forgetResolvedSource",
+                ServerLevel.class,
+                com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord.class);
+        if (publicMethod.getDeclaringClass() != BatchSourceReconciler.class) {
+            source.forgetResolvedSource(level, record.toPublicView());
+            return;
+        }
+        invokeLegacyVoid(source, "forgetResolvedSource", level, record);
+    }
+
+    private static Method publicMethod(Object target, String name, Class<?>... parameterTypes) {
+        try {
+            return target.getClass().getMethod(name, parameterTypes);
+        } catch (NoSuchMethodException missing) {
+            throw new IllegalStateException("recovery implementation has no " + name, missing);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T invokeLegacy(
+            Object target,
+            String name,
+            Class<T> resultType,
+            ServerLevel level,
+            BatchTransactionRecord record) {
+        try {
+            Method method = target.getClass().getMethod(
+                    name,
+                    ServerLevel.class,
+                    BatchTransactionRecord.class);
+            return (T) method.invoke(target, level, record);
+        } catch (ReflectiveOperationException failure) {
+            throw unwrap(name, failure);
+        }
+    }
+
+    private static void invokeLegacyVoid(
+            Object target,
+            String name,
+            ServerLevel level,
+            BatchTransactionRecord record) {
+        try {
+            Method method = target.getClass().getMethod(
+                    name,
+                    ServerLevel.class,
+                    BatchTransactionRecord.class);
+            method.invoke(target, level, record);
+        } catch (ReflectiveOperationException failure) {
+            throw unwrap(name, failure);
+        }
+    }
+
+    private static RuntimeException unwrap(String name, ReflectiveOperationException failure) {
+        Throwable cause = failure instanceof InvocationTargetException invocation
+                ? invocation.getCause()
+                : failure;
+        if (cause instanceof RuntimeException runtime) {
+            return runtime;
+        }
+        if (cause instanceof Error error) {
+            throw error;
+        }
+        return new IllegalStateException("legacy recovery method failed: " + name, cause);
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/transaction/BatchTransactionCoordinator.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/transaction/BatchTransactionCoordinator.java
@@ -1,7 +1,6 @@
 package com.syaru.ae2craftingoptimizer.transaction;
 
 import com.syaru.ae2craftingoptimizer.api.batch.v2.PatternBatchCommit;
-import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchPayloadFingerprint;
 import com.syaru.ae2craftingoptimizer.api.batch.v2.PreparedPatternBatch;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import java.util.Objects;
@@ -79,7 +78,7 @@ public final class BatchTransactionCoordinator {
             if (commit.ownershipProof() == null
                     || !commit.ownershipProof().transactionId().equals(id)
                     || commit.ownershipProof().executions() != current.offeredExecutions()
-                    || !commit.ownershipProof().payloadDigest().equals(BatchPayloadFingerprint.of(current))) {
+                    || !commit.ownershipProof().payloadDigest().equals(current.payloadDigest())) {
                 throw new IllegalArgumentException(
                         "target acceptance requires a durable ownership proof for the exact transaction");
             }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/transaction/BatchTransactionRecord.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/transaction/BatchTransactionRecord.java
@@ -152,6 +152,31 @@ public final class BatchTransactionRecord {
         return receipt;
     }
 
+    /** Internal-to-public recovery bridge; the public API never imports this type. */
+    public com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord toPublicView() {
+        return com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord.snapshot(
+                id,
+                adapterId,
+                sourceId,
+                dimensionId,
+                targetPos,
+                patternFingerprint,
+                offeredExecutions,
+                acceptedExecutions,
+                createdTick,
+                updatedTick,
+                phase.name(),
+                extractedInputs,
+                expectedOutputs,
+                sourceData,
+                adapterData,
+                receipt);
+    }
+
+    public String payloadDigest() {
+        return toPublicView().payloadDigest();
+    }
+
     public BatchTransactionRecord transition(
             BatchTransactionPhase next,
             long accepted,

--- a/src/main/java/com/syaru/ae2craftingoptimizer/transaction/BatchTransactionRecovery.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/transaction/BatchTransactionRecovery.java
@@ -53,7 +53,10 @@ public final class BatchTransactionRecovery {
             return;
         }
         try {
-            BatchRecoveryResult target = adapter.reconcileTarget(level, record);
+            BatchRecoveryResult target = BatchRecoveryCompatibilityBridge.reconcileTarget(
+                    adapter,
+                    level,
+                    record);
             switch (target.targetState()) {
                 case RETRY -> {
                     return;
@@ -86,7 +89,7 @@ public final class BatchTransactionRecovery {
                 record,
                 gameTick,
                 adapter,
-                source.rollbackPrepared(level, record),
+                BatchRecoveryCompatibilityBridge.rollbackPrepared(source, level, record),
                 source,
                 level,
                 BatchTransactionPhase.ROLLED_BACK);
@@ -125,7 +128,7 @@ public final class BatchTransactionRecovery {
                 acceptedRecord,
                 gameTick,
                 adapter,
-                source.accountAccepted(level, acceptedRecord),
+                BatchRecoveryCompatibilityBridge.accountAccepted(source, level, acceptedRecord),
                 source,
                 level,
                 BatchTransactionPhase.ACCOUNTED);
@@ -169,14 +172,14 @@ public final class BatchTransactionRecovery {
             ServerLevel level,
             BatchTransactionRecord record) {
         try {
-            source.forgetResolvedSource(level, record);
+            BatchRecoveryCompatibilityBridge.forgetSource(source, level, record);
         } catch (Throwable cleanupFailure) {
             AE2CraftingOptimizer.LOGGER.warn(
                     "ACO retained a recovered terminal source receipt {}: {}",
                     record.id(), cleanupFailure.toString());
         }
         try {
-            adapter.forgetResolvedTarget(level, record);
+            BatchRecoveryCompatibilityBridge.forgetTarget(adapter, level, record);
         } catch (Throwable cleanupFailure) {
             AE2CraftingOptimizer.LOGGER.warn(
                     "ACO retained a recovered terminal target receipt {}: {}",

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -32,7 +32,7 @@ side = "BOTH"
 [[dependencies.ae2_crafting_optimizer]]
 modId = "ae2"
 mandatory = true
-versionRange = "[15.4.10,15.5.0)"
+versionRange = "[15.4.10,16.0.0)"
 ordering = "AFTER"
 side = "BOTH"
 

--- a/src/main/resources/ae2_crafting_optimizer.mixins.json
+++ b/src/main/resources/ae2_crafting_optimizer.mixins.json
@@ -1,6 +1,7 @@
 {
   "required": false,
   "minVersion": "0.8",
+  "plugin": "com.syaru.ae2craftingoptimizer.mixin.AcoMixinPlugin",
   "package": "com.syaru.ae2craftingoptimizer.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/ExternalBatchRecoveryFixture.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/ExternalBatchRecoveryFixture.java
@@ -1,0 +1,13 @@
+package com.syaru.ae2craftingoptimizer.api;
+
+import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord;
+
+/** Compile-only external adapter fixture: it imports no ACO implementation package. */
+public final class ExternalBatchRecoveryFixture {
+    private ExternalBatchRecoveryFixture() {
+    }
+
+    public static String canonicalDigest(BatchTransactionRecord record) {
+        return record.payloadDigest();
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/ExternalBatchRecoveryFixtureTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/ExternalBatchRecoveryFixtureTest.java
@@ -1,0 +1,36 @@
+package com.syaru.ae2craftingoptimizer.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord;
+import java.util.List;
+import java.util.UUID;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import org.junit.jupiter.api.Test;
+
+class ExternalBatchRecoveryFixtureTest {
+    @Test
+    void consumesOnlyThePublicRecoveryContract() {
+        BatchTransactionRecord record = BatchTransactionRecord.snapshot(
+                UUID.randomUUID(),
+                ResourceLocation.fromNamespaceAndPath("test", "adapter"),
+                ResourceLocation.fromNamespaceAndPath("test", "source"),
+                ResourceLocation.fromNamespaceAndPath("minecraft", "overworld"),
+                new BlockPos(1, 2, 3),
+                "pattern",
+                1L,
+                0L,
+                1L,
+                1L,
+                "PREPARED",
+                List.of(),
+                List.of(),
+                new CompoundTag(),
+                new CompoundTag(),
+                "");
+
+        assertEquals(record.payloadDigest(), ExternalBatchRecoveryFixture.canonicalDigest(record));
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/Ae2UelmCompatibilityTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/Ae2UelmCompatibilityTest.java
@@ -1,0 +1,27 @@
+package com.syaru.ae2craftingoptimizer.integration;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class Ae2UelmCompatibilityTest {
+    @Test
+    void recognizesKnownUelmIdsWithoutRequiringTheMod() {
+        assertTrue(Ae2UelmCompatibility.isKnownUelmModId("ae2_uelm"));
+        assertTrue(Ae2UelmCompatibility.isKnownUelmModId("ae2uelm"));
+        assertTrue(Ae2UelmCompatibility.isKnownUelmModId("ae2_uel"));
+        assertTrue(Ae2UelmCompatibility.isKnownUelmModId("ae2uel"));
+        assertFalse(Ae2UelmCompatibility.isKnownUelmModId("ae2"));
+    }
+
+    @Test
+    void delegatesOnlyTheAe2OwnedSurface() {
+        assertTrue(Ae2UelmCompatibility.ownsAe2SurfaceMixin(
+                "com.syaru.ae2craftingoptimizer.mixin.CraftAmountMenuLongAmountMixin"));
+        assertTrue(Ae2UelmCompatibility.ownsAe2SurfaceMixin(
+                "NetworkStorageBigIntegerSnapshotMixin"));
+        assertFalse(Ae2UelmCompatibility.ownsAe2SurfaceMixin(
+                "com.syaru.ae2craftingoptimizer.mixin.NeoEcoCraftingCpuExecutionBudgetMixin"));
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/Ae2UelmCompatibilityTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/Ae2UelmCompatibilityTest.java
@@ -7,21 +7,31 @@ import org.junit.jupiter.api.Test;
 
 class Ae2UelmCompatibilityTest {
     @Test
-    void recognizesKnownUelmIdsWithoutRequiringTheMod() {
-        assertTrue(Ae2UelmCompatibility.isKnownUelmModId("ae2_uelm"));
-        assertTrue(Ae2UelmCompatibility.isKnownUelmModId("ae2uelm"));
-        assertTrue(Ae2UelmCompatibility.isKnownUelmModId("ae2_uel"));
-        assertTrue(Ae2UelmCompatibility.isKnownUelmModId("ae2uel"));
-        assertFalse(Ae2UelmCompatibility.isKnownUelmModId("ae2"));
+    void recognizesThePublishedSharedIdVersionPair() {
+        assertTrue(Ae2UelmCompatibility.isUelmVersion("15.5.0-uelm"));
+        assertFalse(Ae2UelmCompatibility.isUelmVersion("15.5.0"));
+        assertFalse(Ae2UelmCompatibility.isUelmVersion("ae2_uelm"));
     }
 
     @Test
-    void delegatesOnlyTheAe2OwnedSurface() {
+    void acceptsBothSupportedDependencyProfiles() {
+        assertTrue(Ae2UelmCompatibility.isSupportedAe2Version("15.4.10"));
+        assertTrue(Ae2UelmCompatibility.isSupportedAe2Version("15.5.0-uelm"));
+        assertFalse(Ae2UelmCompatibility.isSupportedAe2Version("15.5.0"));
+    }
+
+    @Test
+    void delegatesOnlyTheVerifiedLongSurface() {
         assertTrue(Ae2UelmCompatibility.ownsAe2SurfaceMixin(
                 "com.syaru.ae2craftingoptimizer.mixin.CraftAmountMenuLongAmountMixin"));
         assertTrue(Ae2UelmCompatibility.ownsAe2SurfaceMixin(
+                "com.syaru.ae2craftingoptimizer.mixin.CraftConfirmMenuLongAmountMixin"));
+        assertTrue(Ae2UelmCompatibility.ownsAe2SurfaceMixin(
+                "com.syaru.ae2craftingoptimizer.mixin.CraftAmountScreenLongAmountMixin"));
+        assertFalse(Ae2UelmCompatibility.ownsAe2SurfaceMixin(
                 "NetworkStorageBigIntegerSnapshotMixin"));
         assertFalse(Ae2UelmCompatibility.ownsAe2SurfaceMixin(
                 "com.syaru.ae2craftingoptimizer.mixin.NeoEcoCraftingCpuExecutionBudgetMixin"));
+        assertFalse(Ae2UelmCompatibility.ownsAe2StorageSurface());
     }
 }

--- a/src/test/java/com/syaru/ae2craftingoptimizer/transaction/BatchTransactionRecordTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/transaction/BatchTransactionRecordTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchPayloadFingerprint;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.PreparedPatternBatch;
 import java.util.List;
 import java.util.UUID;
 import net.minecraft.core.BlockPos;
@@ -22,6 +24,22 @@ class BatchTransactionRecordTest {
         assertEquals(original.targetPos(), restored.targetPos());
         assertEquals(original.phase(), restored.phase());
         assertEquals(original.offeredExecutions(), restored.offeredExecutions());
+    }
+
+    @Test
+    void publicRecoveryDigestMatchesPreparedAndPersistedPayloads() {
+        BatchTransactionRecord original = record();
+        PreparedPatternBatch prepared = new PreparedPatternBatch(
+                original.id(),
+                original.offeredExecutions(),
+                original.extractedInputs(),
+                original.expectedOutputs(),
+                new CompoundTag());
+        BatchTransactionRecord restored = BatchTransactionRecord.load(original.save());
+
+        assertEquals(BatchPayloadFingerprint.of(prepared), original.payloadDigest());
+        assertEquals(original.payloadDigest(), original.toPublicView().payloadDigest());
+        assertEquals(original.payloadDigest(), restored.toPublicView().payloadDigest());
     }
 
     @Test


### PR DESCRIPTION
Fixes #32.

Formal Forge 1.20.1 support for AE2-UELM using the shared ae2 mod id. This branch detects 15.5.0-uelm, delegates only the verified long craft amount surface, preserves BigInteger storage paths, adds upstream/UELM Gradle profiles, and updates ACO to 1.5.8.

Verification: upstream and UELM Gradle check/build profiles passed.