### PR TITLE
Fix AE2 terminal crash from direct Mixin accessor loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.9] - 2026-08-09
+
+### Fixed
+
+- Fixed an AE2 terminal crash caused by production code directly loading a
+  Mixin-only accessor class. Accessor contracts now live outside the Mixin
+  package while the Mixin interfaces retain the same runtime methods.
+- Added a build-time package-boundary check so normal code cannot introduce
+  the same illegal class load again.
+
+This release preserves the existing exact-storage, BigInteger, and UELM
+compatibility behavior from 1.5.8.
+
 ## [1.5.8] - Unreleased
 
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,36 @@ tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
 }
 
+tasks.register('verifyMixinPackageBoundary') {
+    doLast {
+        def sourceRoot = file('src/main/java')
+        def forbiddenReference = ~/com\.syaru\.ae2craftingoptimizer\.mixin\.[A-Za-z0-9_.$]+/
+        def violations = []
+
+        fileTree(sourceRoot).matching { include '**/*.java' }.files.each { sourceFile ->
+            def relativePath = sourceRoot.toPath().relativize(sourceFile.toPath()).toString()
+            if (relativePath.replace('\\', '/').startsWith('com/syaru/ae2craftingoptimizer/mixin/')) {
+                return
+            }
+            sourceFile.eachLine { line, lineNumber ->
+                if (line =~ forbiddenReference) {
+                    violations << "${relativePath}:${lineNumber}: ${line.trim()}"
+                }
+            }
+        }
+
+        if (!violations.isEmpty()) {
+            throw new GradleException(
+                    'Production code must not directly reference classes in the Mixin package:\n'
+                            + violations.join('\n'))
+        }
+    }
+}
+
+tasks.named('compileJava') {
+    dependsOn 'verifyMixinPackageBoundary'
+}
+
 test {
     useJUnitPlatform()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.8
+mod_version=1.5.9
 minecraft_version=1.20.1
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/access/DelegatingMEInventoryAccess.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/access/DelegatingMEInventoryAccess.java
@@ -1,0 +1,14 @@
+package com.syaru.ae2craftingoptimizer.access;
+
+import appeng.api.storage.MEStorage;
+
+/**
+ * Runtime contract exposed by the AE2 DelegatingMEInventory mixin.
+ *
+ * <p>This contract deliberately lives outside the mixin package. Regular
+ * integration code may reference it without asking Forge to load a mixin
+ * class directly.</p>
+ */
+public interface DelegatingMEInventoryAccess {
+    MEStorage aco$getDelegateStorage();
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/access/ExtendedAePlusBigIntegerCellInventoryAccess.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/access/ExtendedAePlusBigIntegerCellInventoryAccess.java
@@ -1,0 +1,31 @@
+package com.syaru.ae2craftingoptimizer.access;
+
+import appeng.api.stacks.AEKey;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import java.math.BigInteger;
+import java.util.UUID;
+
+/**
+ * Runtime contract exposed by the optional ExtendedAE Plus BigInteger-cell
+ * mixins. It is a normal interface so storage code never directly loads a
+ * Mixin-defined type.
+ */
+public interface ExtendedAePlusBigIntegerCellInventoryAccess {
+    Object2ObjectMap<AEKey, BigInteger> aco$getExactStoredAmounts();
+
+    int aco$getExactStoredTypeCount();
+
+    void aco$setExactStoredTypeCount(int value);
+
+    BigInteger aco$getExactStoredTotal();
+
+    void aco$setExactStoredTotal(BigInteger value);
+
+    void aco$saveExactChanges();
+
+    boolean aco$hasExactStorageUuid();
+
+    UUID aco$getExactStorageUuid();
+
+    UUID aco$assignExactStorageUuid();
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/access/MekanismCachedRecipeAccess.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/access/MekanismCachedRecipeAccess.java
@@ -1,0 +1,8 @@
+package com.syaru.ae2craftingoptimizer.access;
+
+import java.util.function.IntSupplier;
+
+/** Runtime contract for the optional Mekanism CachedRecipe accessor. */
+public interface MekanismCachedRecipeAccess {
+    IntSupplier aco$getBaselineMaxOperations();
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/access/NetworkStorageMountsAccess.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/access/NetworkStorageMountsAccess.java
@@ -1,0 +1,10 @@
+package com.syaru.ae2craftingoptimizer.access;
+
+import appeng.api.storage.MEStorage;
+import java.util.List;
+import java.util.NavigableMap;
+
+/** Runtime contract for the AE2 NetworkStorage priority mount accessor. */
+public interface NetworkStorageMountsAccess {
+    NavigableMap<Integer, List<MEStorage>> aco$getPriorityInventory();
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/access/NumberEntryWidgetAccess.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/access/NumberEntryWidgetAccess.java
@@ -1,0 +1,11 @@
+package com.syaru.ae2craftingoptimizer.access;
+
+import appeng.client.gui.widgets.ConfirmableTextField;
+import java.text.DecimalFormat;
+
+/** Runtime contract for the AE2 NumberEntryWidget accessor. */
+public interface NumberEntryWidgetAccess {
+    ConfirmableTextField aco$getTextField();
+
+    DecimalFormat aco$getDecimalFormat();
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/client/LongCraftAmountClientParser.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/client/LongCraftAmountClientParser.java
@@ -3,7 +3,7 @@ package com.syaru.ae2craftingoptimizer.client;
 import appeng.client.gui.MathExpressionParser;
 import appeng.client.gui.widgets.NumberEntryWidget;
 import com.syaru.ae2craftingoptimizer.craftingamount.LongCraftAmountRules;
-import com.syaru.ae2craftingoptimizer.mixin.NumberEntryWidgetAccessor;
+import com.syaru.ae2craftingoptimizer.access.NumberEntryWidgetAccess;
 import java.math.BigDecimal;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -17,7 +17,7 @@ public final class LongCraftAmountClientParser {
     }
 
     public static OptionalLong parseExact(NumberEntryWidget widget) {
-        NumberEntryWidgetAccessor accessor = (NumberEntryWidgetAccessor) (Object) widget;
+        NumberEntryWidgetAccess accessor = (NumberEntryWidgetAccess) (Object) widget;
         String expression = accessor.aco$getTextField().getValue();
         // AE2の「=現在総数」記法は数式本体から接頭辞だけを外して解析する。
         if (expression.startsWith("=")) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/BigIntegerStorageSnapshotBridge.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/BigIntegerStorageSnapshotBridge.java
@@ -4,10 +4,10 @@ import appeng.api.stacks.AEKey;
 import appeng.api.stacks.KeyCounter;
 import appeng.api.storage.MEStorage;
 import com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer;
+import com.syaru.ae2craftingoptimizer.access.DelegatingMEInventoryAccess;
+import com.syaru.ae2craftingoptimizer.access.ExtendedAePlusBigIntegerCellInventoryAccess;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.engine.BigKeyCounterSidecars;
-import com.syaru.ae2craftingoptimizer.mixin.DelegatingMEInventoryAccessor;
-import com.syaru.ae2craftingoptimizer.mixin.ExtendedAePlusBigIntegerCellInventoryAccessor;
 import java.math.BigInteger;
 import java.util.ArrayDeque;
 import java.util.LinkedHashMap;
@@ -80,7 +80,7 @@ public final class BigIntegerStorageSnapshotBridge {
         MEStorage exactStorage = unwrapDelegates(storage);
         // DriveWatcher等の内側にあるInfinityBigIntegerCellから、正確な内部Mapを読む。
         if (exactStorage
-                instanceof ExtendedAePlusBigIntegerCellInventoryAccessor accessor) {
+                instanceof ExtendedAePlusBigIntegerCellInventoryAccess accessor) {
             try {
                 Map<AEKey, BigInteger> copy = new LinkedHashMap<>();
                 /*
@@ -119,11 +119,11 @@ public final class BigIntegerStorageSnapshotBridge {
         // AE2やアドオンの委譲Storageだけを上限付きで辿り、任意Reflectionは使用しない。
         for (int depth = 0; depth < MAXIMUM_DELEGATE_DEPTH; depth++) {
             // BigIntegerセル本体へ到達したら、それ以上委譲先を探さない。
-            if (current instanceof ExtendedAePlusBigIntegerCellInventoryAccessor) {
+            if (current instanceof ExtendedAePlusBigIntegerCellInventoryAccess) {
                 return current;
             }
             // AE2標準DelegatingMEInventory以外は、安全に内部Storageを取得できないため停止する。
-            if (!(current instanceof DelegatingMEInventoryAccessor delegating)) {
+            if (!(current instanceof DelegatingMEInventoryAccess delegating)) {
                 return current;
             }
             MEStorage next = delegating.aco$getDelegateStorage();

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExactNetworkStorageBridge.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExactNetworkStorageBridge.java
@@ -7,11 +7,11 @@ import appeng.api.stacks.AEKey;
 import appeng.api.storage.MEStorage;
 import appeng.me.storage.NetworkStorage;
 import com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer;
+import com.syaru.ae2craftingoptimizer.access.DelegatingMEInventoryAccess;
+import com.syaru.ae2craftingoptimizer.access.ExtendedAePlusBigIntegerCellInventoryAccess;
+import com.syaru.ae2craftingoptimizer.access.NetworkStorageMountsAccess;
 import com.syaru.ae2craftingoptimizer.api.vector.ExactStorageMutationResult;
 import com.syaru.ae2craftingoptimizer.api.vector.ExactVectorStoragePolicy;
-import com.syaru.ae2craftingoptimizer.mixin.DelegatingMEInventoryAccessor;
-import com.syaru.ae2craftingoptimizer.mixin.ExtendedAePlusBigIntegerCellInventoryAccessor;
-import com.syaru.ae2craftingoptimizer.mixin.NetworkStorageMountsAccessor;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -142,7 +142,7 @@ public final class ExactNetworkStorageBridge {
         if (!(networkInventory
                         instanceof NetworkStorage)
                 || !(networkInventory
-                        instanceof NetworkStorageMountsAccessor accessor)) {
+                        instanceof NetworkStorageMountsAccess accessor)) {
             return Optional.empty();
         }
 
@@ -212,7 +212,7 @@ public final class ExactNetworkStorageBridge {
         if (!(networkInventory
                         instanceof NetworkStorage)
                 || !(networkInventory
-                        instanceof NetworkStorageMountsAccessor accessor)) {
+                        instanceof NetworkStorageMountsAccess accessor)) {
             return Optional.empty();
         }
         Map<AEKey, BigInteger> totals =
@@ -500,7 +500,7 @@ public final class ExactNetworkStorageBridge {
 
         MEStorage networkInventory = grid.getStorageService().getInventory();
         if (!(networkInventory instanceof NetworkStorage)
-                || !(networkInventory instanceof NetworkStorageMountsAccessor accessor)) {
+                || !(networkInventory instanceof NetworkStorageMountsAccess accessor)) {
             return null;
         }
         NavigableMap<Integer, List<MEStorage>> mounts =
@@ -635,10 +635,10 @@ public final class ExactNetworkStorageBridge {
         // AE2標準DelegatingMEInventoryの内側だけを辿り、任意Reflectionは行わない。
         for (int depth = 0; depth < MAXIMUM_DELEGATE_DEPTH; depth++) {
             if (current
-                    instanceof ExtendedAePlusBigIntegerCellInventoryAccessor accessor) {
+                    instanceof ExtendedAePlusBigIntegerCellInventoryAccess accessor) {
                 return new ResolvedExactStorage(accessor);
             }
-            if (!(current instanceof DelegatingMEInventoryAccessor delegating)) {
+            if (!(current instanceof DelegatingMEInventoryAccess delegating)) {
                 return null;
             }
             MEStorage next = delegating.aco$getDelegateStorage();
@@ -654,7 +654,7 @@ public final class ExactNetworkStorageBridge {
     private static AppliedStep apply(
             MutationStep step,
             Direction direction) {
-        ExtendedAePlusBigIntegerCellInventoryAccessor accessor = step.accessor();
+        ExtendedAePlusBigIntegerCellInventoryAccess accessor = step.accessor();
         /*
          * 空のInfinity Cellへ初めて直接挿入する場合だけ、ExtendedAE Plus自身の
          * UUID/SavedData生成処理を一度使う。数量Windowは作らない。
@@ -753,7 +753,7 @@ public final class ExactNetworkStorageBridge {
     }
 
     private static BigInteger authoritativeTotal(
-            ExtendedAePlusBigIntegerCellInventoryAccessor accessor,
+            ExtendedAePlusBigIntegerCellInventoryAccess accessor,
             Object2ObjectMap<AEKey, BigInteger> amounts) {
         BigInteger total =
                 ExactBigIntegerCellConsistency.authoritativeTotal(
@@ -792,7 +792,7 @@ public final class ExactNetworkStorageBridge {
     }
 
     private record MutationStep(
-            ExtendedAePlusBigIntegerCellInventoryAccessor accessor,
+            ExtendedAePlusBigIntegerCellInventoryAccess accessor,
             Object2ObjectMap<AEKey, BigInteger> amounts,
             AEKey key,
             BigInteger beforeAmount,
@@ -808,7 +808,7 @@ public final class ExactNetworkStorageBridge {
     }
 
     private record ResolvedExactStorage(
-            ExtendedAePlusBigIntegerCellInventoryAccessor accessor) {
+            ExtendedAePlusBigIntegerCellInventoryAccess accessor) {
         private Object2ObjectMap<AEKey, BigInteger> currentMap() {
             return accessor.aco$getExactStoredAmounts();
         }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExperimentalCompatibilityValidator.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExperimentalCompatibilityValidator.java
@@ -10,11 +10,11 @@ import com.syaru.ae2craftingoptimizer.access.CraftingOwnerTransactionAccess;
 import com.syaru.ae2craftingoptimizer.access.CraftingTaskProgressAccess;
 import com.syaru.ae2craftingoptimizer.access.BigCapacityPlanBoundaryAccess;
 import com.syaru.ae2craftingoptimizer.access.ExactCraftingInventoryAccess;
+import com.syaru.ae2craftingoptimizer.access.MekanismCachedRecipeAccess;
 import com.syaru.ae2craftingoptimizer.access.PatternProviderTransactionAccess;
 import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchSourceReceiptStore;
 import com.syaru.ae2craftingoptimizer.api.batch.v2.NativeBatchReceiptStore;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
-import com.syaru.ae2craftingoptimizer.mixin.MekanismCachedRecipeAccessor;
 import com.syaru.ae2craftingoptimizer.scheduler.FairSchedulerStateStore;
 import java.util.ArrayList;
 import java.util.List;
@@ -115,7 +115,7 @@ public final class ExperimentalCompatibilityValidator {
                 failures.add("Mekanism native adapter was not registered for the exact supported versions");
             }
             require(failures, "mekanism.api.recipes.cache.CachedRecipe",
-                    MekanismCachedRecipeAccessor.class);
+                    MekanismCachedRecipeAccess.class);
         }
         if (ACOConfig.enableGtceuNativeBatching()
                 && !OptionalNativeBatchIntegrations.gtceuRegistered()) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mekanism/MekanismNativeBatchBridge.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mekanism/MekanismNativeBatchBridge.java
@@ -6,7 +6,7 @@ import appeng.api.stacks.AEKey;
 import com.syaru.ae2craftingoptimizer.api.batch.PatternBatchContext;
 import com.syaru.ae2craftingoptimizer.batch.ExactMultisetMatcher;
 import com.syaru.ae2craftingoptimizer.batch.ExactPatternSnapshot;
-import com.syaru.ae2craftingoptimizer.mixin.MekanismCachedRecipeAccessor;
+import com.syaru.ae2craftingoptimizer.access.MekanismCachedRecipeAccess;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -126,7 +126,7 @@ public final class MekanismNativeBatchBridge {
     private static int nativeOperationLimit(IRecipeLookupHandler handler, MekanismRecipe recipe) {
         try {
             CachedRecipe<?> cachedRecipe = handler.createNewCachedRecipe(recipe, 0);
-            int baseline = ((MekanismCachedRecipeAccessor) (Object) cachedRecipe)
+            int baseline = ((MekanismCachedRecipeAccess) (Object) cachedRecipe)
                     .aco$getBaselineMaxOperations()
                     .getAsInt();
             if (baseline <= 0) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/DelegatingMEInventoryAccessor.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/DelegatingMEInventoryAccessor.java
@@ -2,12 +2,13 @@ package com.syaru.ae2craftingoptimizer.mixin;
 
 import appeng.api.storage.MEStorage;
 import appeng.me.storage.DelegatingMEInventory;
+import com.syaru.ae2craftingoptimizer.access.DelegatingMEInventoryAccess;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
 /** DriveWatcherなどAE2標準の委譲Storageから、実際のセルInventoryを安全に取得する。 */
 @Mixin(value = DelegatingMEInventory.class, remap = false)
-public interface DelegatingMEInventoryAccessor {
+public interface DelegatingMEInventoryAccessor extends DelegatingMEInventoryAccess {
     @Accessor("delegate")
     MEStorage aco$getDelegateStorage();
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/ExtendedAePlusBigIntegerCellInventoryAccessor.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/ExtendedAePlusBigIntegerCellInventoryAccessor.java
@@ -1,6 +1,7 @@
 package com.syaru.ae2craftingoptimizer.mixin;
 
 import appeng.api.stacks.AEKey;
+import com.syaru.ae2craftingoptimizer.access.ExtendedAePlusBigIntegerCellInventoryAccess;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import java.math.BigInteger;
 import java.util.UUID;
@@ -14,7 +15,8 @@ import org.spongepowered.asm.mixin.gen.Invoker;
 @Mixin(
         targets = "com.extendedae_plus.api.storage.InfinityBigIntegerCellInventory",
         remap = false)
-public interface ExtendedAePlusBigIntegerCellInventoryAccessor {
+public interface ExtendedAePlusBigIntegerCellInventoryAccessor
+        extends ExtendedAePlusBigIntegerCellInventoryAccess {
     @Invoker("getCellStoredMap")
     Object2ObjectMap<AEKey, BigInteger> aco$getExactStoredAmounts();
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/MekanismCachedRecipeAccessor.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/MekanismCachedRecipeAccessor.java
@@ -1,5 +1,6 @@
 package com.syaru.ae2craftingoptimizer.mixin;
 
+import com.syaru.ae2craftingoptimizer.access.MekanismCachedRecipeAccess;
 import java.util.function.IntSupplier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
@@ -7,7 +8,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Pseudo
 @Mixin(targets = "mekanism.api.recipes.cache.CachedRecipe", remap = false)
-public interface MekanismCachedRecipeAccessor {
+public interface MekanismCachedRecipeAccessor extends MekanismCachedRecipeAccess {
     @Accessor("baselineMaxOperations")
     IntSupplier aco$getBaselineMaxOperations();
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/NetworkStorageMountsAccessor.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/NetworkStorageMountsAccessor.java
@@ -2,6 +2,7 @@ package com.syaru.ae2craftingoptimizer.mixin;
 
 import appeng.api.storage.MEStorage;
 import appeng.me.storage.NetworkStorage;
+import com.syaru.ae2craftingoptimizer.access.NetworkStorageMountsAccess;
 import java.util.List;
 import java.util.NavigableMap;
 import org.spongepowered.asm.mixin.Mixin;
@@ -9,7 +10,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 /** NetworkStorage本来の優先順をExact BigInteger取引でも維持するための限定Accessor。 */
 @Mixin(value = NetworkStorage.class, remap = false)
-public interface NetworkStorageMountsAccessor {
+public interface NetworkStorageMountsAccessor extends NetworkStorageMountsAccess {
     @Accessor("priorityInventory")
     NavigableMap<Integer, List<MEStorage>> aco$getPriorityInventory();
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/NumberEntryWidgetAccessor.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/NumberEntryWidgetAccessor.java
@@ -2,6 +2,7 @@ package com.syaru.ae2craftingoptimizer.mixin;
 
 import appeng.client.gui.widgets.ConfirmableTextField;
 import appeng.client.gui.widgets.NumberEntryWidget;
+import com.syaru.ae2craftingoptimizer.access.NumberEntryWidgetAccess;
 import java.text.DecimalFormat;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
@@ -10,7 +11,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
  * CraftAmountScreenだけが入力を厳密に再検証するための読み取り専用Accessor。
  */
 @Mixin(value = NumberEntryWidget.class, remap = false)
-public interface NumberEntryWidgetAccessor {
+public interface NumberEntryWidgetAccessor extends NumberEntryWidgetAccess {
     @Accessor("textField")
     ConfirmableTextField aco$getTextField();
 


### PR DESCRIPTION
## Summary

Fixes #30.

The shared crash report (https://mclo.gs/Cuc7DIB) shows an IllegalClassLoadError while opening an AE2 terminal:

`
Illegal classload request for com.syaru.ae2craftingoptimizer.mixin.ExtendedAePlusBigIntegerCellInventoryAccessor
Mixin is defined in ae2_crafting_optimizer.mixins.json and cannot be referenced directly
at BigIntegerStorageSnapshotBridge.unwrapDelegates(BigIntegerStorageSnapshotBridge.java:122)
`

## Changes

- Move the runtime accessor contracts used by normal production code into the non-Mixin ccess package.
- Keep the existing Mixin accessor interfaces as runtime implementations of those contracts.
- Update storage, client amount parsing, compatibility validation, and Mekanism integration to use the contracts.
- Add a build-time package-boundary check that rejects direct references to com.syaru.ae2craftingoptimizer.mixin.* outside the Mixin package.
- Bump the Forge 1.20.1 artifact to ACO 1.5.9.

## Verification

- ./gradlew.bat clean build --no-daemon -PacoLocalModsDir=...
- All tests passed.
- Distribution artifact: co1.5.9_1.20.1.jar
- SHA-256: BC57EE9BCED052CD78E9D72CE28412F94767521C6B1AEB7E389F8298B7A98180

No Minecraft startup test was performed.