### PR TITLE
ACO 1.5.9のNeoForge 1.21.1配布番号を整合

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.9] - 2026-08-10
+
+### Changed
+
+- Synchronized the NeoForge 1.21.1 artifact version with the Forge 1.20.1
+  ACO 1.5.9 maintenance release.
+- Kept the NeoForge runtime implementation unchanged because the repaired
+  Mixin-only accessor class-loading path exists only in the Forge 1.20.1
+  implementation.
+
 ## [1.5.7] - 2026-08-08
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ minecraft_version=1.21.1
 neo_version=21.1.247
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.7
+mod_version=1.5.9
 mod_group=com.syaru.ae2craftingoptimizer


### PR DESCRIPTION
## 変更内容

- NeoForge 1.21.1版のmod versionを1.5.9へ更新
- Forge 1.20.1固有修正であることをCHANGELOGへ明記
- NeoForge側の実行ロジックは変更なし

## 検証

- Java 21
- `gradlew clean build`
- Minecraftメタデータ: `[1.21.1,1.21.2)`
- 生成物: `aco1.5.9_1.21.1.jar`

Closes #35
