### PR TITLE
fix: support Advanced AE 1.3.6 on Forge 1.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.10] - 2026-08-10
+
+### Fixed
+
+- Added Advanced AE `1.3.6-1.20.1` to the audited Forge compatibility range.
+- Kept Advanced AE `1.3.7` and later outside the range until their Mixin
+  target classes are audited.
+
 ## [1.5.9] - 2026-08-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ uses `aco<version>_1.20.1.jar`; the NeoForge line is maintained separately on
 - Applied Energistics 2 `15.4.10`
 - AE2 Unofficial Extended Life Modern `15.5.0-uelm` (optional replacement
   profile; keeps the `ae2` mod id)
-- Optional Advanced AE `1.3.5-1.20.1`
+- Optional Advanced AE `1.3.5-1.20.1` or `1.3.6-1.20.1`
 - Optional Neo ECO AE Extension `20.3.x`
 - Optional GTCEu Modern `7.5.3`
 - Optional Mekanism `10.4.16`

--- a/docs/EXPERIMENTAL_ENGINE.md
+++ b/docs/EXPERIMENTAL_ENGINE.md
@@ -28,7 +28,7 @@ The code was compiled against these exact integration targets:
 | Dependency | Verified version |
 | --- | --- |
 | Applied Energistics 2 | `15.4.10` |
-| Advanced AE | `1.3.5-1.20.1` |
+| Advanced AE | `1.3.5-1.20.1` or `1.3.6-1.20.1` |
 | GTCEu Modern | `7.5.3` |
 | Mekanism | `10.4.16.80` |
 | Applied Mekanistics | `1.4.3` |
@@ -39,8 +39,8 @@ verified version. A startup audit then verifies both registration and the
 required Accessor Mixin transformations; an explicitly enabled but unsupported
 combination fails with a targeted error instead of silently running a partial
 integration. Enabling the experimental master also requires AE2 exactly
-`15.4.10`; V2 or fair scheduling with Advanced AE loaded requires exactly
-`1.3.5-1.20.1`.
+`15.4.10`; V2 or fair scheduling with Advanced AE loaded requires one of the
+audited versions `1.3.5-1.20.1` or `1.3.6-1.20.1`.
 
 ## Configuration
 

--- a/docs/RESEARCH_FINAL_ENGINE.md
+++ b/docs/RESEARCH_FINAL_ENGINE.md
@@ -7,7 +7,7 @@ This document records the exact upstream code used for ACO's experimental engine
 | Project | Version | Source tag | Relevant artifact |
 | --- | --- | --- | --- |
 | Applied Energistics 2 | 15.4.10 | `forge/v15.4.10` | `appeng:appliedenergistics2-forge:15.4.10` |
-| Advanced AE | 1.3.5-1.20.1 | `1.3.5-1.20.1-forge` | CurseForge project 1084104, file 7939754 |
+| Advanced AE | 1.3.5-1.20.1 / 1.3.6-1.20.1 | `1.3.5-1.20.1-forge` / `1.3.6-1.20.1` | CurseForge project 1084104, files 7939754 / 8564205 |
 | GregTech CEu Modern | 7.5.3 | `v7.5.3-1.20.1` | `com.gregtechceu.gtceu:gtceu-1.20.1:7.5.3` |
 | Mekanism | 10.4.16.80 | `v1.20.1-10.4.16.80` | `mekanism:Mekanism:1.20.1-10.4.16.80` |
 
@@ -29,6 +29,19 @@ ACO declares the three add-ons as optional. Their integration classes must not b
 - Advanced AE's executing job still stores task and waiting counts as `long`.
 - ACO must keep BigInteger capacity and job state in a versioned sidecar and expose bounded execution windows to the original long-based executor.
 - Capacity reservation must be atomic across all active CPUs in one Quantum Computer cluster.
+
+## Advanced AE 1.3.6
+
+- The official Forge 1.20.1 artifact is CurseForge file `8564205`.
+- The top-level class entries in `1.3.6-1.20.1` are byte-for-byte unchanged from
+  the `1.3.5-1.20.1` artifact for every ACO-targeted class, including
+  `AdvCraftingCPULogic`, `ExecutingCraftingJob`, `AdvCraftingCPUCluster`,
+  `AdvPatternProviderLogic`, and `ReactionChamberEntity`.
+- The release changes the Curios slot texture and an embedded AE2 Addon Lib
+  fluid-slot class, neither of which is targeted by ACO's Advanced AE Mixins.
+- ACO therefore accepts `1.3.6-1.20.1` in the optional dependency range and in
+  the experimental startup audit. A later Advanced AE version still remains
+  unsupported until its target classes are audited.
 
 ## GTCEu 7.5.3
 

--- a/docs/TEAM_DEVELOPMENT_SPEC.md
+++ b/docs/TEAM_DEVELOPMENT_SPEC.md
@@ -200,7 +200,7 @@
 - ハード対象はForge `47.4.18+`、Minecraft `1.20.1`、AE2 `15.4.10-15.4.x` です。
 - 現行パック確認対象はGTCEu Modern `7.5.3` です。
 - 現行パック確認対象はMekanism `10.4.16.80` です。
-- 現行パック確認対象はAdvanced AE `1.3.5` です。
+- 現行パック確認対象はAdvanced AE `1.3.5` と `1.3.6` です。1.3.6はACOのMixin対象クラス差分を確認済みです。
 - 現行パック確認対象はExtendedAE `1.4.15` です。
 - 現行パック確認対象はAE2 Overclocked `1.2.3-fix3` です。
 - Neo ECO AE Extension `20.3.0` は任意のcompile-only検証対象です。

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.9
+mod_version=1.5.10
 minecraft_version=1.20.1
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExperimentalCompatibilityValidator.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExperimentalCompatibilityValidator.java
@@ -25,6 +25,10 @@ import net.minecraftforge.fml.ModList;
  * 対応外バージョンで処理を推測して続行せず、原因を列挙してFail-fastする。
  */
 public final class ExperimentalCompatibilityValidator {
+    private static final List<String> SUPPORTED_ADVANCED_AE_VERSIONS = List.of(
+            "1.3.5-1.20.1",
+            "1.3.6-1.20.1");
+
     private ExperimentalCompatibilityValidator() {
     }
 
@@ -41,7 +45,7 @@ public final class ExperimentalCompatibilityValidator {
                         || ACOConfig.enableAtomicBigCapacityPlans()
                         || ACOConfig.enableBigIntegerGameplayExecution())
                 && ModList.get().isLoaded("advanced_ae")) {
-            requireExactVersion(failures, "advanced_ae", "1.3.5-1.20.1");
+            requireSupportedVersions(failures, "advanced_ae", SUPPORTED_ADVANCED_AE_VERSIONS);
         }
         // Wide計画を有効にする時は、受理側と拒否側の両境界Mixinを起動時に証明する。
         if (ACOConfig.enableAtomicBigCapacityPlans()) {
@@ -141,15 +145,16 @@ public final class ExperimentalCompatibilityValidator {
         }
     }
 
-    private static void requireExactVersion(
+    private static void requireSupportedVersions(
             List<String> failures,
             String modId,
-            String expectedVersion) {
+            List<String> supportedVersions) {
         String installed = ModList.get().getModContainerById(modId)
                 .map(container -> container.getModInfo().getVersion().toString())
                 .orElse(null);
-        if (!expectedVersion.equals(installed)) {
-            failures.add(modId + " version must be exactly " + expectedVersion
+        // 実行中のバージョンが、Mixin対象のクラス差分を監査済みの範囲に含まれるか確認する。
+        if (!supportedVersions.contains(installed)) {
+            failures.add(modId + " version must be one of " + String.join(", ", supportedVersions)
                     + " for the experimental engine (installed " + installed + ")");
         }
     }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -53,7 +53,7 @@ side = "BOTH"
 [[dependencies.ae2_crafting_optimizer]]
 modId = "advanced_ae"
 mandatory = false
-versionRange = "[1.3.5-1.20.1,1.3.6-1.20.1)"
+versionRange = "[1.3.5-1.20.1,1.3.7-1.20.1)"
 ordering = "AFTER"
 side = "BOTH"
 


### PR DESCRIPTION
## 概要
Advanced AE 1.3.6（Forge 1.20.1）をACOの対応範囲へ追加します。

Closes #37

## 変更内容
- `mods.toml` のAdvanced AE範囲を `[1.3.5-1.20.1,1.3.7-1.20.1)` へ拡張。
- 実験機能の起動時バージョン監査を `1.3.5-1.20.1` / `1.3.6-1.20.1` の許可リストへ変更。
- README、実験エンジン資料、調査資料、開発仕様へ1.3.6対応を記録。

## 互換性調査
CurseForgeのAdvanced AE 1.3.5（file 7939754）と1.3.6（file 8564205）を比較し、ACOがMixinする以下のクラスにバイト差分がないことを確認しました。

- `AdvCraftingCPULogic`
- `ExecutingCraftingJob`
- `AdvCraftingCPUCluster`
- `AdvPatternProviderLogic`
- `ReactionChamberEntity`

1.3.6の差分はCuriosスロットテクスチャと内蔵AE2 Addon LibのFluid GUIクラスで、ACOのAdvanced AE対象Mixin外です。1.3.7以降は引き続き拒否します。

## 検証
- `git diff --check`: 成功
- `./gradlew.bat clean test build`: 成功
- Minecraftクライアント/サーバー起動確認: このPRでは未実施