### PR TITLE
fix: support Advanced AE 1.3.x series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ All notable changes to this project are documented here.
 ### Fixed
 
 - Added Advanced AE `1.3.6-1.20.1` to the audited Forge compatibility range.
-- Kept Advanced AE `1.3.7` and later outside the range until their Mixin
+- Expanded the audited Forge compatibility range to the Advanced AE
+  `1.3.x-1.20.1` series after comparing the available official artifacts.
+- Kept Advanced AE `1.4.x` and later outside the range until their Mixin
   target classes are audited.
 
 ## [1.5.9] - 2026-08-09

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ uses `aco<version>_1.20.1.jar`; the NeoForge line is maintained separately on
 - Applied Energistics 2 `15.4.10`
 - AE2 Unofficial Extended Life Modern `15.5.0-uelm` (optional replacement
   profile; keeps the `ae2` mod id)
-- Optional Advanced AE `1.3.5-1.20.1` or `1.3.6-1.20.1`
+- Optional Advanced AE `1.3.x-1.20.1` (Forge)
 - Optional Neo ECO AE Extension `20.3.x`
 - Optional GTCEu Modern `7.5.3`
 - Optional Mekanism `10.4.16`

--- a/docs/EXPERIMENTAL_ENGINE.md
+++ b/docs/EXPERIMENTAL_ENGINE.md
@@ -28,7 +28,7 @@ The code was compiled against these exact integration targets:
 | Dependency | Verified version |
 | --- | --- |
 | Applied Energistics 2 | `15.4.10` |
-| Advanced AE | `1.3.5-1.20.1` or `1.3.6-1.20.1` |
+| Advanced AE | `1.3.x-1.20.1` |
 | GTCEu Modern | `7.5.3` |
 | Mekanism | `10.4.16.80` |
 | Applied Mekanistics | `1.4.3` |
@@ -40,7 +40,7 @@ required Accessor Mixin transformations; an explicitly enabled but unsupported
 combination fails with a targeted error instead of silently running a partial
 integration. Enabling the experimental master also requires AE2 exactly
 `15.4.10`; V2 or fair scheduling with Advanced AE loaded requires one of the
-audited versions `1.3.5-1.20.1` or `1.3.6-1.20.1`.
+audited `1.3.x-1.20.1` versions.
 
 ## Configuration
 

--- a/docs/RESEARCH_FINAL_ENGINE.md
+++ b/docs/RESEARCH_FINAL_ENGINE.md
@@ -7,7 +7,7 @@ This document records the exact upstream code used for ACO's experimental engine
 | Project | Version | Source tag | Relevant artifact |
 | --- | --- | --- | --- |
 | Applied Energistics 2 | 15.4.10 | `forge/v15.4.10` | `appeng:appliedenergistics2-forge:15.4.10` |
-| Advanced AE | 1.3.5-1.20.1 / 1.3.6-1.20.1 | `1.3.5-1.20.1-forge` / `1.3.6-1.20.1` | CurseForge project 1084104, files 7939754 / 8564205 |
+| Advanced AE | 1.3.x-1.20.1 | `1.3.x-1.20.1-forge` | CurseForge project 1084104, audited files 7155096, 7159779, 7668689, 7849215, 7939754, 8564205 |
 | GregTech CEu Modern | 7.5.3 | `v7.5.3-1.20.1` | `com.gregtechceu.gtceu:gtceu-1.20.1:7.5.3` |
 | Mekanism | 10.4.16.80 | `v1.20.1-10.4.16.80` | `mekanism:Mekanism:1.20.1-10.4.16.80` |
 
@@ -39,8 +39,9 @@ ACO declares the three add-ons as optional. Their integration classes must not b
   `AdvPatternProviderLogic`, and `ReactionChamberEntity`.
 - The release changes the Curios slot texture and an embedded AE2 Addon Lib
   fluid-slot class, neither of which is targeted by ACO's Advanced AE Mixins.
-- ACO therefore accepts `1.3.6-1.20.1` in the optional dependency range and in
-  the experimental startup audit. A later Advanced AE version still remains
+- The available official 1.3.x Forge artifacts use the same ACO-targeted class
+  contracts. ACO therefore accepts the `1.3.x-1.20.1` series in the optional
+  dependency range and experimental startup audit, while 1.4.x remains
   unsupported until its target classes are audited.
 
 ## GTCEu 7.5.3

--- a/docs/TEAM_DEVELOPMENT_SPEC.md
+++ b/docs/TEAM_DEVELOPMENT_SPEC.md
@@ -200,7 +200,7 @@
 - ハード対象はForge `47.4.18+`、Minecraft `1.20.1`、AE2 `15.4.10-15.4.x` です。
 - 現行パック確認対象はGTCEu Modern `7.5.3` です。
 - 現行パック確認対象はMekanism `10.4.16.80` です。
-- 現行パック確認対象はAdvanced AE `1.3.5` と `1.3.6` です。1.3.6はACOのMixin対象クラス差分を確認済みです。
+- 現行パック確認対象はAdvanced AE `1.3.x` 系列です。同系列の公開版でACOのMixin対象クラス差分を確認済みです。
 - 現行パック確認対象はExtendedAE `1.4.15` です。
 - 現行パック確認対象はAE2 Overclocked `1.2.3-fix3` です。
 - Neo ECO AE Extension `20.3.0` は任意のcompile-only検証対象です。

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExperimentalCompatibilityValidator.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExperimentalCompatibilityValidator.java
@@ -25,9 +25,8 @@ import net.minecraftforge.fml.ModList;
  * 対応外バージョンで処理を推測して続行せず、原因を列挙してFail-fastする。
  */
 public final class ExperimentalCompatibilityValidator {
-    private static final List<String> SUPPORTED_ADVANCED_AE_VERSIONS = List.of(
-            "1.3.5-1.20.1",
-            "1.3.6-1.20.1");
+    private static final String SUPPORTED_ADVANCED_AE_VERSION_PREFIX = "1.3.";
+    private static final String SUPPORTED_ADVANCED_AE_VERSION_SUFFIX = "-1.20.1";
 
     private ExperimentalCompatibilityValidator() {
     }
@@ -45,7 +44,11 @@ public final class ExperimentalCompatibilityValidator {
                         || ACOConfig.enableAtomicBigCapacityPlans()
                         || ACOConfig.enableBigIntegerGameplayExecution())
                 && ModList.get().isLoaded("advanced_ae")) {
-            requireSupportedVersions(failures, "advanced_ae", SUPPORTED_ADVANCED_AE_VERSIONS);
+            requireSupportedVersionSeries(
+                    failures,
+                    "advanced_ae",
+                    SUPPORTED_ADVANCED_AE_VERSION_PREFIX,
+                    SUPPORTED_ADVANCED_AE_VERSION_SUFFIX);
         }
         // Wide計画を有効にする時は、受理側と拒否側の両境界Mixinを起動時に証明する。
         if (ACOConfig.enableAtomicBigCapacityPlans()) {
@@ -145,16 +148,20 @@ public final class ExperimentalCompatibilityValidator {
         }
     }
 
-    private static void requireSupportedVersions(
+    private static void requireSupportedVersionSeries(
             List<String> failures,
             String modId,
-            List<String> supportedVersions) {
+            String versionPrefix,
+            String versionSuffix) {
         String installed = ModList.get().getModContainerById(modId)
                 .map(container -> container.getModInfo().getVersion().toString())
                 .orElse(null);
-        // 実行中のバージョンが、Mixin対象のクラス差分を監査済みの範囲に含まれるか確認する。
-        if (!supportedVersions.contains(installed)) {
-            failures.add(modId + " version must be one of " + String.join(", ", supportedVersions)
+        // 実行中のバージョンが、監査済みの同一Minecraft系列かを接頭辞と接尾辞で確認する。
+        boolean supported = installed != null
+                && installed.startsWith(versionPrefix)
+                && installed.endsWith(versionSuffix);
+        if (!supported) {
+            failures.add(modId + " version must match " + versionPrefix + "*" + versionSuffix
                     + " for the experimental engine (installed " + installed + ")");
         }
     }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -53,7 +53,7 @@ side = "BOTH"
 [[dependencies.ae2_crafting_optimizer]]
 modId = "advanced_ae"
 mandatory = false
-versionRange = "[1.3.5-1.20.1,1.3.7-1.20.1)"
+versionRange = "[1.3.0-1.20.1,1.4.0-1.20.1)"
 ordering = "AFTER"
 side = "BOTH"
 


### PR DESCRIPTION
## 概要
Advanced AE Forge 1.20.1の1.3.x系列をACOの対応範囲へ追加します。

Closes #39

## 変更
- `mods.toml`を`[1.3.0-1.20.1,1.4.0-1.20.1)`へ変更。
- 実験機能の監査を`1.3.*-1.20.1`の系列判定へ変更。
- 1.4.x以降は対象外のまま維持。
- 調査資料と変更履歴を更新。

## 調査
公式の1.3.0、1.3.2〜1.3.6について、ACO対象のクラフトCPU、ExecutingCraftingJob、CPU Cluster、Pattern Provider、Reaction Chamberクラスを比較し、同一系列内の差分がないことを確認しました。

## 検証
- `git diff --check`: 成功
- `./gradlew.bat clean test build`: 成功
- 出力: `aco1.5.10_1.20.1.jar`
- Minecraft起動確認: 未実施