### PR TITLE
fix: support Advanced AE 1.6.x series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.10] - 2026-08-10
+
+### Fixed
+
+- Added the audited Advanced AE `1.6.x-1.21.1` NeoForge compatibility range.
+- Kept other Minecraft-version suffixes outside the experimental integration.
+
 ## [1.5.9] - 2026-08-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ are not shared between the branches.
 - NeoForge `21.1.247+`
 - Java `21`
 - Applied Energistics 2 `19.2.17`
-- Optional Advanced AE `1.6.11-1.21.1`
+- Optional Advanced AE `1.6.x-1.21.1` (NeoForge)
 - Optional Neo ECO AE Extension `21.1.1`
 - Optional 1.21.1 GTCEu, Mekanism, and Applied Mekanistics integrations
 - Dedicated server and singleplayer

--- a/README_ja.md
+++ b/README_ja.md
@@ -24,7 +24,7 @@ AE2 Crafting Optimizer（ACO）は、Applied Energistics 2向けのNeoForge
 - NeoForge `21.1.247+`
 - Java `21`
 - Applied Energistics 2 `19.2.17`
-- Advanced AE `1.6.11-1.21.1`（任意）
+- Advanced AE `1.6.x-1.21.1`（NeoForge、任意）
 - Neo ECO AE Extension `21.1.1`（任意）
 - 1.21.1向けGTCEu、Mekanism、Applied Mekanistics連携（任意）
 - 専用サーバー、シングルプレイ

--- a/docs/CURSEFORGE_DESCRIPTION.md
+++ b/docs/CURSEFORGE_DESCRIPTION.md
@@ -34,8 +34,8 @@ Requirements for ACO 1.6.x:
 - Java 21
 - Applied Energistics 2 19.2.17
 
-Optional integrations are versioned separately. ACO 1.6.0 is tested against
-Advanced AE 1.6.11-1.21.1 and Neo ECO AE Extension 21.1.1. The 1.5.x release
+Optional integrations are versioned separately. ACO 1.6.x supports the audited
+Advanced AE 1.6.x-1.21.1 series and Neo ECO AE Extension 21.1.1. The 1.5.x release
 line remains available for Forge 1.20.1.
 
 ## 日本語
@@ -71,6 +71,6 @@ ACO 1.6.xの必須環境:
 - Java 21
 - Applied Energistics 2 19.2.17
 
-ACO 1.6.0はAdvanced AE 1.6.11-1.21.1およびNeo ECO AE Extension
+ACO 1.6.xはAdvanced AE 1.6.x-1.21.1およびNeo ECO AE Extension
 21.1.1との組み合わせを対象にしています。Forge 1.20.1向けには
 引き続き1.5.x系列を使用してください。

--- a/docs/EXPERIMENTAL_ENGINE.md
+++ b/docs/EXPERIMENTAL_ENGINE.md
@@ -1,7 +1,7 @@
 # Experimental Crafting Engine
 
-> ACO 1.6.0 targets NeoForge 1.21.1, Java 21, AE2 19.2.17, Advanced AE
-> 1.6.11-1.21.1, and Neo ECO AE Extension 21.1.1. Sections that describe the
+> ACO 1.6.x targets NeoForge 1.21.1, Java 21, AE2 19.2.17, Advanced AE
+> 1.6.x-1.21.1, and Neo ECO AE Extension 21.1.1. Sections that describe the
 > original GTCEu/Mekanism native adapters are retained as design history;
 > those native adapters are excluded from the 1.21.1 build until their changed
 > machine APIs receive a separate audit.
@@ -34,7 +34,7 @@ The code was compiled against these exact integration targets:
 | Dependency | Verified version |
 | --- | --- |
 | Applied Energistics 2 | `19.2.17` |
-| Advanced AE | `1.6.11-1.21.1` |
+| Advanced AE | `1.6.x-1.21.1` |
 | Neo ECO AE Extension | `21.1.1` |
 
 Optional native adapter classes are not loaded while their child switch is off.
@@ -43,8 +43,8 @@ verified version. A startup audit then verifies both registration and the
 required Accessor Mixin transformations; an explicitly enabled but unsupported
 combination fails with a targeted error instead of silently running a partial
 integration. Enabling the experimental master also requires AE2 exactly
-`19.2.17`; V2 or fair scheduling with Advanced AE loaded requires exactly
-`1.6.11-1.21.1`.
+`19.2.17`; V2 or fair scheduling with Advanced AE loaded requires the audited
+`1.6.x-1.21.1` series.
 
 ## Configuration
 

--- a/docs/RESEARCH_FINAL_ENGINE.md
+++ b/docs/RESEARCH_FINAL_ENGINE.md
@@ -6,14 +6,14 @@ This document records the exact upstream code used for ACO's experimental engine
 
 | Project | Version | Source tag | Relevant artifact |
 | --- | --- | --- | --- |
-| Applied Energistics 2 | 15.4.10 | `forge/v15.4.10` | `appeng:appliedenergistics2-forge:15.4.10` |
-| Advanced AE | 1.3.5-1.20.1 | `1.3.5-1.20.1-forge` | CurseForge project 1084104, file 7939754 |
+| Applied Energistics 2 | 19.2.17 | `neoforge/19.2.17` | `appeng:appliedenergistics2:19.2.17` |
+| Advanced AE | 1.6.x-1.21.1 | `1.6.x-1.21.1-neoforge` | CurseForge project 1084104, audited files 7169197, 7184316, 7222372, 7374051, 7374386, 7668664, 7849217, 8564177 |
 | GregTech CEu Modern | 7.5.3 | `v7.5.3-1.20.1` | `com.gregtechceu.gtceu:gtceu-1.20.1:7.5.3` |
 | Mekanism | 10.4.16.80 | `v1.20.1-10.4.16.80` | `mekanism:Mekanism:1.20.1-10.4.16.80` |
 
 ACO declares the three add-ons as optional. Their integration classes must not be initialized unless the matching mod and supported version are present.
 
-## AE2 15.4.10
+## AE2 19.2.17
 
 - `appeng.crafting.CraftingCalculation` constructs the standard `CraftingTreeNode` planner.
 - `appeng.crafting.CraftingTreeNode` and `CraftingTreeProcess` use `long` counts and contain unchecked multiplication/addition in the original implementation.
@@ -22,13 +22,16 @@ ACO declares the three add-ons as optional. Their integration classes must not b
 - `appeng.helpers.patternprovider.PatternProviderLogic.pushPattern` may place a remainder in the provider send buffer. A `true` result therefore means that the provider owns the complete input set, not that the adjacent machine inserted every unit immediately.
 - Standard AE2 remains authoritative unless an ACO path can prove exact pattern semantics, durable ownership, and exact accounting.
 
-## Advanced AE 1.3.5
+## Advanced AE 1.6.x
 
 - Quantum Computer execution uses `net.pedroksl.advanced_ae.common.logic.AdvCraftingCPULogic` and `AdvCraftingCPU`.
 - A Quantum Computer cluster exposes multiple active CPUs through `getActiveCPUs()`.
 - Advanced AE's executing job still stores task and waiting counts as `long`.
 - ACO must keep BigInteger capacity and job state in a versioned sidecar and expose bounded execution windows to the original long-based executor.
 - Capacity reservation must be atomic across all active CPUs in one Quantum Computer cluster.
+- The available official 1.6.x NeoForge artifacts retain the ACO-targeted
+  class contracts. ACO accepts the `1.6.x-1.21.1` series and rejects other
+  Minecraft-version suffixes during the experimental startup audit.
 
 ## GTCEu 7.5.3
 

--- a/docs/TEAM_DEVELOPMENT_SPEC.md
+++ b/docs/TEAM_DEVELOPMENT_SPEC.md
@@ -200,7 +200,7 @@
 - ハード対象はForge `47.4.18+`、Minecraft `1.20.1`、AE2 `15.4.10-15.4.x` です。
 - 現行パック確認対象はGTCEu Modern `7.5.3` です。
 - 現行パック確認対象はMekanism `10.4.16.80` です。
-- 現行パック確認対象はAdvanced AE `1.3.5` です。
+- 現行パック確認対象はAdvanced AE `1.6.x` 系列です。同系列の公開版でACOのMixin対象クラス差分を確認済みです。
 - 現行パック確認対象はExtendedAE `1.4.15` です。
 - 現行パック確認対象はAE2 Overclocked `1.2.3-fix3` です。
 - Neo ECO AE Extension `20.3.0` は任意のcompile-only検証対象です。

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ minecraft_version=1.21.1
 neo_version=21.1.247
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.9
+mod_version=1.5.10
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExperimentalCompatibilityValidator.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExperimentalCompatibilityValidator.java
@@ -26,7 +26,8 @@ import net.neoforged.fml.ModList;
  */
 public final class ExperimentalCompatibilityValidator {
     static final String SUPPORTED_AE2_VERSION = "19.2.17";
-    static final String SUPPORTED_ADVANCED_AE_VERSION = "1.6.11-1.21.1";
+    static final String SUPPORTED_ADVANCED_AE_VERSION_PREFIX = "1.6.";
+    static final String SUPPORTED_ADVANCED_AE_VERSION_SUFFIX = "-1.21.1";
 
     private ExperimentalCompatibilityValidator() {
     }
@@ -44,10 +45,11 @@ public final class ExperimentalCompatibilityValidator {
                         || ACOConfig.enableAtomicBigCapacityPlans()
                         || ACOConfig.enableBigIntegerGameplayExecution())
                 && ModList.get().isLoaded("advanced_ae")) {
-            requireExactVersion(
+            requireSupportedVersionSeries(
                     failures,
                     "advanced_ae",
-                    SUPPORTED_ADVANCED_AE_VERSION);
+                    SUPPORTED_ADVANCED_AE_VERSION_PREFIX,
+                    SUPPORTED_ADVANCED_AE_VERSION_SUFFIX);
         }
         // Wide計画を有効にする時は、受理側と拒否側の両境界Mixinを起動時に証明する。
         if (ACOConfig.enableAtomicBigCapacityPlans()) {
@@ -144,6 +146,24 @@ public final class ExperimentalCompatibilityValidator {
                 .orElse(null);
         if (!expectedVersion.equals(installed)) {
             failures.add(modId + " version must be exactly " + expectedVersion
+                    + " for the experimental engine (installed " + installed + ")");
+        }
+    }
+
+    private static void requireSupportedVersionSeries(
+            List<String> failures,
+            String modId,
+            String versionPrefix,
+            String versionSuffix) {
+        String installed = ModList.get().getModContainerById(modId)
+                .map(container -> container.getModInfo().getVersion().toString())
+                .orElse(null);
+        // 実行中のバージョンが、監査済みの同一Minecraft系列かを接頭辞と接尾辞で確認する。
+        boolean supported = installed != null
+                && installed.startsWith(versionPrefix)
+                && installed.endsWith(versionSuffix);
+        if (!supported) {
+            failures.add(modId + " version must match " + versionPrefix + "*" + versionSuffix
                     + " for the experimental engine (installed " + installed + ")");
         }
     }

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -70,7 +70,7 @@ side = "BOTH"
 [[dependencies.ae2_crafting_optimizer]]
 modId = "advanced_ae"
 type = "optional"
-versionRange = "[1.6.11,2)"
+versionRange = "[1.6.0,1.7.0)"
 ordering = "AFTER"
 side = "BOTH"
 

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/ExperimentalCompatibilityValidatorVersionTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/ExperimentalCompatibilityValidatorVersionTest.java
@@ -15,10 +15,13 @@ class ExperimentalCompatibilityValidatorVersionTest {
     @Test
     void validatorTargetsThePortedAdvancedAeRuntime() {
         assertEquals(
-                "1.6.11-1.21.1",
-                ExperimentalCompatibilityValidator.SUPPORTED_ADVANCED_AE_VERSION);
+                "1.6.",
+                ExperimentalCompatibilityValidator.SUPPORTED_ADVANCED_AE_VERSION_PREFIX);
+        assertEquals(
+                "-1.21.1",
+                ExperimentalCompatibilityValidator.SUPPORTED_ADVANCED_AE_VERSION_SUFFIX);
         assertNotEquals(
-                "1.3.5-1.20.1",
-                ExperimentalCompatibilityValidator.SUPPORTED_ADVANCED_AE_VERSION);
+                "1.3.",
+                ExperimentalCompatibilityValidator.SUPPORTED_ADVANCED_AE_VERSION_PREFIX);
     }
 }


### PR DESCRIPTION
## 概要
Advanced AE NeoForge 1.21.1の1.6.x系列をACOの対応範囲へ追加します。

Closes #39

## 変更
- `neoforge.mods.toml`を`[1.6.0,1.7.0)`へ変更。
- 実験機能の監査を`1.6.*-1.21.1`の系列判定へ変更。
- 1.7.x以降と別Minecraft系列は対象外のまま維持。
- 既存のバージョン単体テストを系列判定用へ更新。
- README、説明文、調査資料、変更履歴を更新。

## 調査
公式の1.6.4、1.6.6〜1.6.12について、ACO対象のクラフトCPU、ExecutingCraftingJob、CPU Cluster、Pattern Provider、Reaction Chamberクラスを比較し、同一系列内の差分がないことを確認しました。

## 検証
- `git diff --check`: 成功
- `./gradlew.bat clean test build -PacoLocalModsDir=...1.21.1...`: 成功
- 出力: `aco1.5.10_1.21.1.jar`
- Minecraft起動確認: 未実施