### PR TITLE
fix: promote long multiplication overflow to BigInteger

### DIFF
--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
@@ -115,18 +115,18 @@ public final class Ae2AuthoritativeCraftingPlanner {
 
             BigKeyCounterSidecars.Snapshot inventoryMetadata =
                     BigKeyCounterSidecars.snapshot(capture.inventorySnapshot()).orElse(null);
-            // Adapter失敗を含む不完全Snapshotは、飽和値から不足数を推測せずAE2へ戻す。
-            if (inventoryMetadata != null && !inventoryMetadata.complete()) {
-                return null;
-            }
             CompiledRootProgram.BigInventorySnapshot<AEKey> exactPlanningInventory =
                     Ae2ReferencedInventory.captureExactNetworkSnapshot(
                             program,
                             capture.inventorySnapshot(),
                             output);
             CompiledRootProgram.InventorySnapshot<AEKey> planningInventory = null;
-            // 正確なSidecarが無い通常AE2環境だけ、従来のlong Snapshotを使用する。
+            // 参照キーを個別に証明できない場合だけ、通常AE2のlong Snapshotへ戻す。
             if (exactPlanningInventory == null) {
+                // 不完全Sidecarを飽和longとしてBig計画へ渡すと、在庫不足を誤って充足扱いにする。
+                if (inventoryMetadata != null && !inventoryMetadata.complete()) {
+                    return null;
+                }
                 planningInventory = Ae2ReferencedInventory.captureNetworkSnapshot(
                         program,
                         capture.inventorySnapshot(),

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2ReferencedInventory.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2ReferencedInventory.java
@@ -27,7 +27,8 @@ final class Ae2ReferencedInventory {
 
     /**
      * NetworkCraftingSimulationStateへ伝播した正確なSidecarから、参照キーだけを固定する。
-     * Sidecarが不完全ならnullを返し、呼出側はAE2標準またはlong経路へ戻る。
+     * Sidecar全体が不完全でも、計画が参照するキーを個別に証明できれば採用する。
+     * 参照キーのどれかが不明な場合だけnullを返し、呼出側は安全な経路へ戻る。
      */
     @Nullable
     static CompiledRootProgram.BigInventorySnapshot<AEKey> captureExactNetworkSnapshot(
@@ -36,8 +37,8 @@ final class Ae2ReferencedInventory {
             AEKey requestedOutput) {
         BigKeyCounterSidecars.Snapshot exact =
                 BigKeyCounterSidecars.snapshot(networkSnapshot).orElse(null);
-        // 一部storageの正確値を取得できなかったSnapshotは、在庫を推測せず採用しない。
-        if (exact == null || !exact.complete()) {
+        // 無関係なキーのアダプター失敗だけで、対象クラフト全体を捨てない。
+        if (exact == null || !hasExactReferencedKeys(program, exact, requestedOutput)) {
             return null;
         }
         return program.captureBigInventory(
@@ -80,8 +81,8 @@ final class Ae2ReferencedInventory {
         KeyCounter cached = grid.getStorageService().getCachedInventory();
         BigKeyCounterSidecars.Snapshot exact =
                 BigKeyCounterSidecars.snapshot(cached).orElse(null);
-        // 再検証時にSidecarが失われた場合は、丸めたlong値で一致扱いにしない。
-        if (exact == null || !exact.complete()) {
+        // 再検証時も、計画が参照するキーだけはBigInteger正本で一致を確認する。
+        if (exact == null || !hasExactReferencedKeys(program, exact, requestedOutput)) {
             return false;
         }
         return program.inventoryMatches(
@@ -90,6 +91,20 @@ final class Ae2ReferencedInventory {
                         ? BigInteger.ZERO
                         : liveExactAmount(grid, source, cached, exact, key),
                 ACOConfig.getBigIntegerMaximumBits());
+    }
+
+    private static boolean hasExactReferencedKeys(
+            CompiledRootProgram<AEKey> program,
+            BigKeyCounterSidecars.Snapshot exact,
+            AEKey requestedOutput) {
+        for (int node = 0; node < program.nodeCount(); node++) {
+            AEKey key = program.keyAt(node);
+            // AE2は注文の完成品を在庫計算から除外するため、出力自身は検証対象にしない。
+            if (!key.equals(requestedOutput) && !exact.isExact(key)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static long liveAmount(IGrid grid, IActionSource source, AEKey key) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigKeyCounterSidecars.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigKeyCounterSidecars.java
@@ -7,9 +7,11 @@ import java.lang.ref.WeakReference;
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * AE2のlong {@link KeyCounter}へ対応する、正確なBigInteger在庫Snapshot。
@@ -41,13 +43,24 @@ public final class BigKeyCounterSidecars {
             }
 
             Map<AEKey, BigInteger> merged = new LinkedHashMap<>(current.amounts());
+            Set<AEKey> exactKeys = new LinkedHashSet<>(current.exactKeys());
             // 同一キーをBigIntegerで加算し、long境界を越えても負数へ巻き戻さない。
             for (Map.Entry<AEKey, BigInteger> entry : contribution.amounts().entrySet()) {
                 merged.merge(entry.getKey(), entry.getValue(), BigInteger::add);
+                // 現在値と今回の寄与の両方が正確なキーだけ、合計値も正確と証明できる。
+                if (current.isExact(entry.getKey())
+                        && contribution.isExact(entry.getKey())) {
+                    exactKeys.add(entry.getKey());
+                } else {
+                    exactKeys.remove(entry.getKey());
+                }
             }
             SIDECARS.put(
                     new IdentityWeakReference(target, COLLECTED_COUNTERS),
-                    new Snapshot(merged, current.complete() && contribution.complete()));
+                    new Snapshot(
+                            merged,
+                            current.complete() && contribution.complete(),
+                            exactKeys));
         }
     }
 
@@ -69,7 +82,14 @@ public final class BigKeyCounterSidecars {
                 visible.put(entry.getKey(), entry.getValue());
             }
         }
-        put(target, new Snapshot(visible, sourceSnapshot.complete()));
+        Set<AEKey> exactVisible = new LinkedHashSet<>();
+        for (AEKey key : sourceSnapshot.exactKeys()) {
+            // 画面側Counterに存在しないキーを正確在庫として復活させない。
+            if (visible.containsKey(key)) {
+                exactVisible.add(key);
+            }
+        }
+        put(target, new Snapshot(visible, sourceSnapshot.complete(), exactVisible));
     }
 
     /** long FacadeとBigInteger Sidecarを一つの独立したKeyCounterへ複製する。 */
@@ -114,7 +134,7 @@ public final class BigKeyCounterSidecars {
                 amounts.put(entry.getKey(), BigInteger.valueOf(amount));
             }
         }
-        return new Snapshot(amounts, complete);
+        return new Snapshot(amounts, complete, amounts.keySet());
     }
 
     /** 単体テスト間でstatic Sidecarを共有しないためのreset。 */
@@ -146,9 +166,18 @@ public final class BigKeyCounterSidecars {
     }
 
     /** 一回の在庫集計に対応する不変BigInteger Map。 */
-    public record Snapshot(Map<AEKey, BigInteger> amounts, boolean complete) {
+    public record Snapshot(
+            Map<AEKey, BigInteger> amounts,
+            boolean complete,
+            Set<AEKey> exactKeys) {
+        /** 既存アダプター向けの簡略コンストラクター。false時はキー単位の証明も持たない。 */
+        public Snapshot(Map<AEKey, BigInteger> amounts, boolean complete) {
+            this(amounts, complete, complete ? amounts.keySet() : Set.of());
+        }
+
         public Snapshot {
             Objects.requireNonNull(amounts, "amounts");
+            Objects.requireNonNull(exactKeys, "exactKeys");
             Map<AEKey, BigInteger> checked = new LinkedHashMap<>();
             // 不正な負数やnullをSidecarへ入れず、計画時の在庫過大評価を防ぐ。
             for (Map.Entry<AEKey, BigInteger> entry : amounts.entrySet()) {
@@ -166,10 +195,27 @@ public final class BigKeyCounterSidecars {
                 }
             }
             amounts = Map.copyOf(checked);
+
+            Set<AEKey> checkedExactKeys = new LinkedHashSet<>();
+            for (AEKey key : exactKeys) {
+                Objects.requireNonNull(key, "exact inventory key");
+                // 0量はMapへ保持しないため、正確性集合にも登録しない。
+                if (checked.containsKey(key)) {
+                    checkedExactKeys.add(key);
+                }
+            }
+            exactKeys = Set.copyOf(checkedExactKeys);
         }
 
         public BigInteger amount(AEKey key) {
             return amounts.getOrDefault(Objects.requireNonNull(key, "key"), BigInteger.ZERO);
+        }
+
+        /** 指定キーの値が、ネットワーク内の不完全な別キーに影響されず確定しているか返す。 */
+        public boolean isExact(AEKey key) {
+            Objects.requireNonNull(key, "key");
+            // 完全Snapshotでは、Mapにないキーの0も正確に証明できる。
+            return complete || exactKeys.contains(key);
         }
 
         public boolean containsWideValue() {

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/CompiledRootProgramTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/CompiledRootProgramTest.java
@@ -66,6 +66,26 @@ class CompiledRootProgramTest {
     }
 
     @Test
+    void promotesPatternInputWhenEightTimesTwoToTheSixtiethWouldOverflowLong() {
+        var program = compile(
+                List.of(pattern("output", "gas", 8L, "output", 1L)),
+                "output");
+        var inventory = program.captureLongInventory(ignored -> 0L);
+        BigInteger requested = BigInteger.ONE.shiftLeft(60);
+
+        var result = new OverflowPromotingCraftingPlanner<String>().plan(
+                program,
+                requested,
+                inventory,
+                PlanningGuard.none());
+
+        var big = assertInstanceOf(OverflowPromotingCraftingPlanner.BigResult.class, result);
+        assertEquals(
+                BigInteger.ONE.shiftLeft(63),
+                big.plan().missing().get("gas"));
+    }
+
+    @Test
     void keepsTwoLongMaximumChemicalInputsExactAfterPromotion() {
         var output = new CompiledPattern<>(
                 "pressurized-reaction",

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/BigIntegerStorageSnapshotBridgeTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/BigIntegerStorageSnapshotBridgeTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 class BigIntegerStorageSnapshotBridgeTest {
     private static final TestKey TEST_KEY = new TestKey();
+    private static final TestKey UNRELATED_KEY = new TestKey();
     private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
     /** tick番号自体に意味を持たせず、同一tick判定だけを検証する固定値。 */
     private static final long CACHE_TEST_TICK = 42L;
@@ -120,6 +121,29 @@ class BigIntegerStorageSnapshotBridgeTest {
         BigKeyCounterSidecars.Snapshot exact =
                 BigKeyCounterSidecars.snapshot(network).orElseThrow();
         assertFalse(exact.complete());
+    }
+
+    @Test
+    void keepsExactnessForAReferencedKeyWhenAnUnrelatedContributionIsIncomplete() {
+        KeyCounter network = new KeyCounter();
+
+        BigKeyCounterSidecars.merge(
+                network,
+                new BigKeyCounterSidecars.Snapshot(
+                        Map.of(TEST_KEY, BigInteger.TEN),
+                        true));
+        // 別キーのadapter失敗だけを再現し、TEST_KEYの正確値まで無効化しないことを確認する。
+        BigKeyCounterSidecars.merge(
+                network,
+                new BigKeyCounterSidecars.Snapshot(
+                        Map.of(UNRELATED_KEY, BigInteger.ONE),
+                        false));
+
+        BigKeyCounterSidecars.Snapshot snapshot =
+                BigKeyCounterSidecars.snapshot(network).orElseThrow();
+        assertFalse(snapshot.complete());
+        assertTrue(snapshot.isExact(TEST_KEY));
+        assertFalse(snapshot.isExact(UNRELATED_KEY));
     }
 
     @Test


### PR DESCRIPTION
## 概要

Issue #44 の `8 * 2^60 = 2^63` 境界で、ACOのBigInteger昇格前にAE2標準のlong計算へ戻る問題を修正します。

## 原因

BigInteger在庫Sidecarをネットワーク全体の `complete` フラグだけで判定していたため、無関係なストレージの不完全な寄与が一つあると、クラフト対象キーの正確な在庫まで破棄されていました。結果としてACOのBigInteger計画を採用できず、AE2の `CraftingTreeProcess` がlong乗算を実行して `CountOverflowException` になっていました。

## 変更内容

- BigInteger在庫Sidecarへキー単位の `exactKeys` を追加
- 対象Compiled Rootが参照するキーだけを正確性検証
- 無関係な不完全寄与があっても対象キーのBigInteger計画を継続
- 対象キーが不明な場合は飽和longをBigInteger正本として扱わない安全なFallbackを維持
- `8 * 2^60` が `2^63` へ昇格する回帰テストを追加
- 不完全な無関係キーがあっても正確キーを保持するSidecarテストを追加

## 検証

- `gradlew.bat clean test --no-daemon` 成功
- `gradlew.bat clean build --no-daemon` 成功
- 実ゲーム起動・サーバー接続試験はこのPRでは未実施

Fixes #44