### PR TITLE
Fix BigInteger calculation handoff for InsaneAE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- Added an optional InsaneAE calculation profile. When enabled, ACO owns the
+  strict compiled/BigInteger calculation boundary instead of allowing the
+  InsaneAE calculation batch to pass an overflowing `long` request into AE2.
+- Added a public calculation-profile capability query for optional CPU add-ons.
+
 ## [1.5.11] - 2026-08-11
 
 ### Added

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -24,6 +24,7 @@ Important calculation options include:
 | Key | Default | Purpose |
 | --- | ---: | --- |
 | `enableAqeBigCraftingProfile` | `true` | Activates the narrow AQE compiled/checked profile only when Advanced AE and AQE are installed. |
+| `enableInsaneAeBigCraftingProfile` | `true` | Activates the same strict calculation profile when InsaneAE is installed, so InsaneAE does not apply a competing calculation batch. |
 | `enableLongRootCraftAmounts` | `true` | Adds the signed-long root-order path while preserving AE2's original int path. |
 | `enableCompiledCraftingGraph` | `true` | Reuses a generation-keyed deterministic graph where the active profile allows it. |
 | `enableShadowMode` | `true` | Compares eligible compiled results against AE2 without changing normal results. |

--- a/docs/EXPERIMENTAL_ENGINE.md
+++ b/docs/EXPERIMENTAL_ENGINE.md
@@ -11,7 +11,8 @@ runtime qualification is P9 and is intentionally left to the pack operator.
 
 General deep behavior-changing paths are deliberately **disabled by default**.
 The narrow AQE profile is enabled only when Advanced AE and Advanced Quantum
-Engineering are both loaded. It activates compiled observation, checked
+Engineering are both loaded. The optional InsaneAE profile provides the same
+calculation boundary when InsaneAE is loaded. It activates compiled observation, checked
 arithmetic, exact wide-capacity planning, BigInteger execution windows, and
 ordinary-long replacement only for roots whose current AE2 Pattern API,
 candidate set, inventory, and generations pass the strict proof. It does not
@@ -50,6 +51,7 @@ condition for the checked BigInteger path:
 ```toml
 [experimentalCraftingEngine]
 enableAqeBigCraftingProfile = true
+enableInsaneAeBigCraftingProfile = true
 enableLongRootCraftAmounts = true
 enableExperimentalCraftingEngine = false
 enableShadowMode = true

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java
@@ -3,8 +3,12 @@ package com.syaru.ae2craftingoptimizer.api.big;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.engine.BigCraftingKeyCodec;
 import com.syaru.ae2craftingoptimizer.engine.OverflowPromotingCraftingPlanner;
+import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
+import com.syaru.ae2craftingoptimizer.engine.BigIntegerCraftingPlan;
 import java.math.BigInteger;
 import java.util.Objects;
+import java.util.Optional;
+import appeng.api.networking.crafting.ICraftingPlan;
 import appeng.api.stacks.AEKey;
 import com.syaru.ae2craftingoptimizer.network.BigCraftingNetwork;
 import net.minecraft.nbt.CompoundTag;
@@ -16,12 +20,52 @@ public final class BigCraftingEngineApi {
     public static final int API_VERSION = 3;
     /** Version of the exact amount-ledger surface added for crafting add-ons. */
     public static final int AMOUNT_LEDGER_API_VERSION = 1;
+    /** Version of the optional AE2 calculation-profile query used by CPU add-ons. */
+    public static final int CALCULATION_PROFILE_API_VERSION = 1;
 
     private BigCraftingEngineApi() {
     }
 
     public static boolean isEnabled() {
         return ACOConfig.enableBigIntegerCraftingBackend();
+    }
+
+    /**
+     * Returns whether ACO currently owns the strict AE2 calculation boundary.
+     *
+     * <p>An add-on may use this query to avoid applying its own calculation
+     * shortcut over ACO's planner. This is deliberately a capability query;
+     * it does not expose or mutate a crafting plan.</p>
+     */
+    public static boolean isCalculationProfileActive() {
+        return ACOConfig.enableBigCraftingProfile()
+                && ACOConfig.enableCompiledCraftingGraph()
+                && ACOConfig.enableBigIntegerCraftingBackend();
+    }
+
+    /**
+     * Returns the exact plan sidecar for an ACO-created plan.
+     *
+     * <p>The returned view is empty for ordinary AE2 plans. This identity check
+     * prevents an add-on from treating a saturated or unrelated plan as exact.</p>
+     */
+    public static Optional<BigIntegerCraftingPlanView> inspectBigIntegerPlan(
+            ICraftingPlan plan) {
+        if (!isCalculationProfileActive() || plan == null) {
+            return Optional.empty();
+        }
+        BigIntegerCraftingPlan bigPlan = Ae2CraftingPlanSidecars.bigInteger(plan).orElse(null);
+        if (bigPlan == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new BigIntegerCraftingPlanView(
+                bigPlan.finalOutput(),
+                bigPlan.exactBytes(),
+                bigPlan.simulation(),
+                bigPlan.exactPatternTimes(),
+                bigPlan.exactPlan().usedInventory(),
+                bigPlan.exactPlan().emitted(),
+                bigPlan.exactPlan().missing()));
     }
 
     public static <K> BigCraftingRuntime<K> create(

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigIntegerCraftingPlanView.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigIntegerCraftingPlanView.java
@@ -1,0 +1,42 @@
+package com.syaru.ae2craftingoptimizer.api.big;
+
+import appeng.api.crafting.IPatternDetails;
+import appeng.api.networking.crafting.ICraftingPlan;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.GenericStack;
+import java.math.BigInteger;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable exact view of an ACO BigInteger plan for optional CPU add-ons.
+ *
+ * <p>The standard AE2 {@link ICraftingPlan} remains the compatibility facade.
+ * Add-ons that can execute bounded windows may opt into this view without
+ * depending on ACO's engine implementation classes.</p>
+ */
+public record BigIntegerCraftingPlanView(
+        GenericStack finalOutput,
+        BigInteger exactBytes,
+        boolean simulation,
+        Map<IPatternDetails, BigInteger> patternTimes,
+        Map<AEKey, BigInteger> usedItems,
+        Map<AEKey, BigInteger> emittedItems,
+        Map<AEKey, BigInteger> missingItems) {
+
+    public BigIntegerCraftingPlanView {
+        Objects.requireNonNull(finalOutput, "finalOutput");
+        Objects.requireNonNull(exactBytes, "exactBytes");
+        Objects.requireNonNull(patternTimes, "patternTimes");
+        Objects.requireNonNull(usedItems, "usedItems");
+        Objects.requireNonNull(emittedItems, "emittedItems");
+        Objects.requireNonNull(missingItems, "missingItems");
+        if (exactBytes.signum() < 0) {
+            throw new IllegalArgumentException("exactBytes must not be negative");
+        }
+        patternTimes = Map.copyOf(patternTimes);
+        usedItems = Map.copyOf(usedItems);
+        emittedItems = Map.copyOf(emittedItems);
+        missingItems = Map.copyOf(missingItems);
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
@@ -169,6 +169,7 @@ public final class ACOConfig {
     private static final ForgeConfigSpec.IntValue SLOW_CRAFT_CALCULATION_MILLIS;
     private static final ForgeConfigSpec.BooleanValue LOG_CACHE_STATISTICS;
     private static final ForgeConfigSpec.BooleanValue ENABLE_AQE_BIG_CRAFTING_PROFILE;
+    private static final ForgeConfigSpec.BooleanValue ENABLE_INSANE_AE_BIG_CRAFTING_PROFILE;
     private static final ForgeConfigSpec.BooleanValue ENABLE_LONG_ROOT_CRAFT_AMOUNTS;
     private static final ForgeConfigSpec.BooleanValue ENABLE_EXPERIMENTAL_CRAFTING_ENGINE;
     private static final ForgeConfigSpec.BooleanValue ENABLE_CRAFTING_ENGINE_SHADOW_MODE;
@@ -733,6 +734,12 @@ public final class ACOConfig {
                         "Enable only the AQE BigInteger calculation and execution path when Advanced AE and Advanced Quantum Engineering are installed.",
                         "This does not enable Native Batch, bus rewrites, terminal rewrites, or normal-AE2 authoritative replacement.")
                 .define("enableAqeBigCraftingProfile", true);
+        ENABLE_INSANE_AE_BIG_CRAFTING_PROFILE = builder
+                .comment(
+                        "Enable the same strict BigInteger calculation profile when InsaneAE is installed.",
+                        "InsaneAE's calculation batch mixin defers to ACO while this profile is active.",
+                        "This does not enable Native Batch, bus rewrites, terminal rewrites, or ambiguous recipe replacement.")
+                .define("enableInsaneAeBigCraftingProfile", true);
         ENABLE_LONG_ROOT_CRAFT_AMOUNTS = builder
                 .comment(
                         "Allow the AE2 craft-amount screen to submit root amounts from Integer.MAX_VALUE + 1 through Long.MAX_VALUE.",
@@ -1587,6 +1594,21 @@ public final class ACOConfig {
                 && ModList.get().isLoaded("advanced_quantum_engineering");
     }
 
+    /**
+     * InsaneAE搭載時だけ、AQEと同じ厳密BigInteger計算プロファイルを有効にする。
+     * 計画を作れない環境へ広い値を公開しないよう、設定とMod検出を両方確認する。
+     */
+    public static boolean enableInsaneAeBigCraftingProfile() {
+        return enableOptimizer()
+                && ENABLE_INSANE_AE_BIG_CRAFTING_PROFILE.get()
+                && ModList.get().isLoaded("insaneae");
+    }
+
+    /** AQEまたはInsaneAEがBigInteger計算の連携先として存在するか。 */
+    public static boolean enableBigCraftingProfile() {
+        return enableAqeBigCraftingProfile() || enableInsaneAeBigCraftingProfile();
+    }
+
     public static boolean enableLongRootCraftAmounts() {
         return enableOptimizer()
                 && !Ae2UelmCompatibility.ownsAe2ExtendedAmountSurface()
@@ -1617,7 +1639,7 @@ public final class ACOConfig {
 
     public static boolean enableCompiledCraftingGraph() {
         return ENABLE_COMPILED_CRAFTING_GRAPH.get()
-                && (enableExperimentalCraftingEngine() || enableAqeBigCraftingProfile());
+                && (enableExperimentalCraftingEngine() || enableBigCraftingProfile());
     }
 
     public static boolean enableAuthoritativeCompiledPlanner() {
@@ -1630,7 +1652,7 @@ public final class ACOConfig {
 
     public static boolean enableCheckedAe2CraftingArithmetic() {
         return ENABLE_CHECKED_AE2_CRAFTING_ARITHMETIC.get()
-                && (enableExperimentalCraftingEngine() || enableAqeBigCraftingProfile());
+                && (enableExperimentalCraftingEngine() || enableBigCraftingProfile());
     }
 
     public static boolean enableTransactionalBatchingV2() {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
@@ -115,18 +115,18 @@ public final class Ae2AuthoritativeCraftingPlanner {
 
             BigKeyCounterSidecars.Snapshot inventoryMetadata =
                     BigKeyCounterSidecars.snapshot(capture.inventorySnapshot()).orElse(null);
-            // Adapter失敗を含む不完全Snapshotは、飽和値から不足数を推測せずAE2へ戻す。
-            if (inventoryMetadata != null && !inventoryMetadata.complete()) {
-                return null;
-            }
             CompiledRootProgram.BigInventorySnapshot<AEKey> exactPlanningInventory =
                     Ae2ReferencedInventory.captureExactNetworkSnapshot(
                             program,
                             capture.inventorySnapshot(),
                             output);
             CompiledRootProgram.InventorySnapshot<AEKey> planningInventory = null;
-            // 正確なSidecarが無い通常AE2環境だけ、従来のlong Snapshotを使用する。
+            // 参照キーを個別に証明できない場合だけ、通常AE2のlong Snapshotへ戻す。
             if (exactPlanningInventory == null) {
+                // 不完全Sidecarを飽和longとしてBig計画へ渡すと、在庫不足を誤って充足扱いにする。
+                if (inventoryMetadata != null && !inventoryMetadata.complete()) {
+                    return null;
+                }
                 planningInventory = Ae2ReferencedInventory.captureNetworkSnapshot(
                         program,
                         capture.inventorySnapshot(),

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2ReferencedInventory.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2ReferencedInventory.java
@@ -27,7 +27,8 @@ final class Ae2ReferencedInventory {
 
     /**
      * NetworkCraftingSimulationStateへ伝播した正確なSidecarから、参照キーだけを固定する。
-     * Sidecarが不完全ならnullを返し、呼出側はAE2標準またはlong経路へ戻る。
+     * Sidecar全体が不完全でも、計画が参照するキーを個別に証明できれば採用する。
+     * 参照キーのどれかが不明な場合だけnullを返し、呼出側は安全な経路へ戻る。
      */
     @Nullable
     static CompiledRootProgram.BigInventorySnapshot<AEKey> captureExactNetworkSnapshot(
@@ -36,8 +37,8 @@ final class Ae2ReferencedInventory {
             AEKey requestedOutput) {
         BigKeyCounterSidecars.Snapshot exact =
                 BigKeyCounterSidecars.snapshot(networkSnapshot).orElse(null);
-        // 一部storageの正確値を取得できなかったSnapshotは、在庫を推測せず採用しない。
-        if (exact == null || !exact.complete()) {
+        // 無関係なキーのアダプター失敗だけで、対象クラフト全体を捨てない。
+        if (exact == null || !hasExactReferencedKeys(program, exact, requestedOutput)) {
             return null;
         }
         return program.captureBigInventory(
@@ -80,8 +81,8 @@ final class Ae2ReferencedInventory {
         KeyCounter cached = grid.getStorageService().getCachedInventory();
         BigKeyCounterSidecars.Snapshot exact =
                 BigKeyCounterSidecars.snapshot(cached).orElse(null);
-        // 再検証時にSidecarが失われた場合は、丸めたlong値で一致扱いにしない。
-        if (exact == null || !exact.complete()) {
+        // 再検証時も、計画が参照するキーだけはBigInteger正本で一致を確認する。
+        if (exact == null || !hasExactReferencedKeys(program, exact, requestedOutput)) {
             return false;
         }
         return program.inventoryMatches(
@@ -90,6 +91,20 @@ final class Ae2ReferencedInventory {
                         ? BigInteger.ZERO
                         : liveExactAmount(grid, source, cached, exact, key),
                 ACOConfig.getBigIntegerMaximumBits());
+    }
+
+    private static boolean hasExactReferencedKeys(
+            CompiledRootProgram<AEKey> program,
+            BigKeyCounterSidecars.Snapshot exact,
+            AEKey requestedOutput) {
+        for (int node = 0; node < program.nodeCount(); node++) {
+            AEKey key = program.keyAt(node);
+            // AE2は注文の完成品を在庫計算から除外するため、出力自身は検証対象にしない。
+            if (!key.equals(requestedOutput) && !exact.isExact(key)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static long liveAmount(IGrid grid, IActionSource source, AEKey key) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigKeyCounterSidecars.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigKeyCounterSidecars.java
@@ -7,9 +7,11 @@ import java.lang.ref.WeakReference;
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * AE2のlong {@link KeyCounter}へ対応する、正確なBigInteger在庫Snapshot。
@@ -41,13 +43,24 @@ public final class BigKeyCounterSidecars {
             }
 
             Map<AEKey, BigInteger> merged = new LinkedHashMap<>(current.amounts());
+            Set<AEKey> exactKeys = new LinkedHashSet<>(current.exactKeys());
             // 同一キーをBigIntegerで加算し、long境界を越えても負数へ巻き戻さない。
             for (Map.Entry<AEKey, BigInteger> entry : contribution.amounts().entrySet()) {
                 merged.merge(entry.getKey(), entry.getValue(), BigInteger::add);
+                // 現在値と今回の寄与の両方が正確なキーだけ、合計値も正確と証明できる。
+                if (current.isExact(entry.getKey())
+                        && contribution.isExact(entry.getKey())) {
+                    exactKeys.add(entry.getKey());
+                } else {
+                    exactKeys.remove(entry.getKey());
+                }
             }
             SIDECARS.put(
                     new IdentityWeakReference(target, COLLECTED_COUNTERS),
-                    new Snapshot(merged, current.complete() && contribution.complete()));
+                    new Snapshot(
+                            merged,
+                            current.complete() && contribution.complete(),
+                            exactKeys));
         }
     }
 
@@ -69,7 +82,14 @@ public final class BigKeyCounterSidecars {
                 visible.put(entry.getKey(), entry.getValue());
             }
         }
-        put(target, new Snapshot(visible, sourceSnapshot.complete()));
+        Set<AEKey> exactVisible = new LinkedHashSet<>();
+        for (AEKey key : sourceSnapshot.exactKeys()) {
+            // 画面側Counterに存在しないキーを正確在庫として復活させない。
+            if (visible.containsKey(key)) {
+                exactVisible.add(key);
+            }
+        }
+        put(target, new Snapshot(visible, sourceSnapshot.complete(), exactVisible));
     }
 
     /** long FacadeとBigInteger Sidecarを一つの独立したKeyCounterへ複製する。 */
@@ -114,7 +134,7 @@ public final class BigKeyCounterSidecars {
                 amounts.put(entry.getKey(), BigInteger.valueOf(amount));
             }
         }
-        return new Snapshot(amounts, complete);
+        return new Snapshot(amounts, complete, amounts.keySet());
     }
 
     /** 単体テスト間でstatic Sidecarを共有しないためのreset。 */
@@ -146,9 +166,18 @@ public final class BigKeyCounterSidecars {
     }
 
     /** 一回の在庫集計に対応する不変BigInteger Map。 */
-    public record Snapshot(Map<AEKey, BigInteger> amounts, boolean complete) {
+    public record Snapshot(
+            Map<AEKey, BigInteger> amounts,
+            boolean complete,
+            Set<AEKey> exactKeys) {
+        /** 既存アダプター向けの簡略コンストラクター。false時はキー単位の証明も持たない。 */
+        public Snapshot(Map<AEKey, BigInteger> amounts, boolean complete) {
+            this(amounts, complete, complete ? amounts.keySet() : Set.of());
+        }
+
         public Snapshot {
             Objects.requireNonNull(amounts, "amounts");
+            Objects.requireNonNull(exactKeys, "exactKeys");
             Map<AEKey, BigInteger> checked = new LinkedHashMap<>();
             // 不正な負数やnullをSidecarへ入れず、計画時の在庫過大評価を防ぐ。
             for (Map.Entry<AEKey, BigInteger> entry : amounts.entrySet()) {
@@ -166,10 +195,27 @@ public final class BigKeyCounterSidecars {
                 }
             }
             amounts = Map.copyOf(checked);
+
+            Set<AEKey> checkedExactKeys = new LinkedHashSet<>();
+            for (AEKey key : exactKeys) {
+                Objects.requireNonNull(key, "exact inventory key");
+                // 0量はMapへ保持しないため、正確性集合にも登録しない。
+                if (checked.containsKey(key)) {
+                    checkedExactKeys.add(key);
+                }
+            }
+            exactKeys = Set.copyOf(checkedExactKeys);
         }
 
         public BigInteger amount(AEKey key) {
             return amounts.getOrDefault(Objects.requireNonNull(key, "key"), BigInteger.ZERO);
+        }
+
+        /** 指定キーの値が、ネットワーク内の不完全な別キーに影響されず確定しているか返す。 */
+        public boolean isExact(AEKey key) {
+            Objects.requireNonNull(key, "key");
+            // 完全Snapshotでは、Mapにないキーの0も正確に証明できる。
+            return complete || exactKeys.contains(key);
         }
 
         public boolean containsWideValue() {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOStartupReport.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOStartupReport.java
@@ -181,9 +181,10 @@ final class ACOStartupReport {
                 ACOConfig.coalesceAssemblerMatrixStatusUpdates());
         logDeepRewriteFlags();
         AE2CraftingOptimizer.LOGGER.info(
-                "ACO experimental crafting engine: {} (AQE profile {}, shadow {}, compiled graph {}, proof-qualified long plans {}, transaction V2 {}, GT native {}, Mekanism native {}, fair scheduler {}, persistent journal {})",
+                "ACO experimental crafting engine: {} (AQE profile {}, InsaneAE profile {}, shadow {}, compiled graph {}, proof-qualified long plans {}, transaction V2 {}, GT native {}, Mekanism native {}, fair scheduler {}, persistent journal {})",
                 ACOConfig.enableExperimentalCraftingEngine(),
                 ACOConfig.enableAqeBigCraftingProfile(),
+                ACOConfig.enableInsaneAeBigCraftingProfile(),
                 ACOConfig.enableCraftingEngineShadowMode(),
                 ACOConfig.enableCompiledCraftingGraph(),
                 ACOConfig.enableProofQualifiedLongPlans(),

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCpuClusterBigCapacityGuardMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCpuClusterBigCapacityGuardMixin.java
@@ -8,6 +8,7 @@ import appeng.api.networking.security.IActionSource;
 import appeng.crafting.execution.CraftingSubmitResult;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
 import com.syaru.ae2craftingoptimizer.access.BigCapacityPlanBoundaryAccess;
+import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -26,7 +27,11 @@ public abstract class CraftingCpuClusterBigCapacityGuardMixin
             ICraftingRequester requester,
             CallbackInfoReturnable<ICraftingSubmitResult> cir) {
         // Long.MAXは真の容量ではないため、対応Sidecarを持たない標準CPUでは実行しない。
-        if (Ae2CraftingPlanSidecars.isWide(plan)) {
+        boolean insaneAeExactPlan = ACOConfig.enableInsaneAeBigCraftingProfile()
+                && Ae2CraftingPlanSidecars.bigInteger(plan).isPresent();
+        // InsaneAE専用のExact受け渡しだけはInsaneAE側が同じPlanを所有するため通す。
+        // 容量だけをlongへ飽和したBigCapacity計画は標準CPUへ絶対に渡さない。
+        if (Ae2CraftingPlanSidecars.isWide(plan) && !insaneAeExactPlan) {
             cir.setReturnValue(CraftingSubmitResult.CPU_TOO_SMALL);
         }
     }

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/CompiledRootProgramTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/CompiledRootProgramTest.java
@@ -66,6 +66,26 @@ class CompiledRootProgramTest {
     }
 
     @Test
+    void promotesPatternInputWhenEightTimesTwoToTheSixtiethWouldOverflowLong() {
+        var program = compile(
+                List.of(pattern("output", "gas", 8L, "output", 1L)),
+                "output");
+        var inventory = program.captureLongInventory(ignored -> 0L);
+        BigInteger requested = BigInteger.ONE.shiftLeft(60);
+
+        var result = new OverflowPromotingCraftingPlanner<String>().plan(
+                program,
+                requested,
+                inventory,
+                PlanningGuard.none());
+
+        var big = assertInstanceOf(OverflowPromotingCraftingPlanner.BigResult.class, result);
+        assertEquals(
+                BigInteger.ONE.shiftLeft(63),
+                big.plan().missing().get("gas"));
+    }
+
+    @Test
     void keepsTwoLongMaximumChemicalInputsExactAfterPromotion() {
         var output = new CompiledPattern<>(
                 "pressurized-reaction",

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/BigIntegerStorageSnapshotBridgeTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/BigIntegerStorageSnapshotBridgeTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 class BigIntegerStorageSnapshotBridgeTest {
     private static final TestKey TEST_KEY = new TestKey();
+    private static final TestKey UNRELATED_KEY = new TestKey();
     private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
     /** tick番号自体に意味を持たせず、同一tick判定だけを検証する固定値。 */
     private static final long CACHE_TEST_TICK = 42L;
@@ -120,6 +121,29 @@ class BigIntegerStorageSnapshotBridgeTest {
         BigKeyCounterSidecars.Snapshot exact =
                 BigKeyCounterSidecars.snapshot(network).orElseThrow();
         assertFalse(exact.complete());
+    }
+
+    @Test
+    void keepsExactnessForAReferencedKeyWhenAnUnrelatedContributionIsIncomplete() {
+        KeyCounter network = new KeyCounter();
+
+        BigKeyCounterSidecars.merge(
+                network,
+                new BigKeyCounterSidecars.Snapshot(
+                        Map.of(TEST_KEY, BigInteger.TEN),
+                        true));
+        // 別キーのadapter失敗だけを再現し、TEST_KEYの正確値まで無効化しないことを確認する。
+        BigKeyCounterSidecars.merge(
+                network,
+                new BigKeyCounterSidecars.Snapshot(
+                        Map.of(UNRELATED_KEY, BigInteger.ONE),
+                        false));
+
+        BigKeyCounterSidecars.Snapshot snapshot =
+                BigKeyCounterSidecars.snapshot(network).orElseThrow();
+        assertFalse(snapshot.complete());
+        assertTrue(snapshot.isExact(TEST_KEY));
+        assertFalse(snapshot.isExact(UNRELATED_KEY));
     }
 
     @Test


### PR DESCRIPTION
## 概要

InsaneAE の Quantum CPU 実行経路が ACO の BigInteger 計画を AE2 標準の long 計画として再処理し、`CraftingTreeProcessCheckedMathMixin` の境界検査へ到達して `CountOverflowException` になる問題を修正します。

## 変更内容

- `BigIntegerCraftingPlanView` と calculation-profile API を公開
- InsaneAE が競合する計算バッチを重ねないための capability query を追加
- InsaneAE profile 有効時は ACO の BigInteger sidecar を標準計画に紐付ける
- InsaneAE が Exact Pattern 回数を読み取れるように immutable view を提供
- BigInteger 計画だけは容量ガードを InsaneAE の受理経路へ渡す
- 通常の AE2 計画、AQE、未対応アドオンの経路は変更しない

## 検証

- `gradlew.bat clean build --no-daemon` 成功
- ACO の単体テスト成功
- 実環境の起動・クラフト試験は別途実施

Closes #46
Refs #42
