### PR TITLE
fix: hand off BigInteger plans to InsaneAE on NeoForge 1.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- Added an optional InsaneAE calculation profile for the NeoForge 1.21.1
+  build. When enabled, ACO owns the strict compiled/BigInteger calculation
+  boundary instead of allowing an InsaneAE calculation batch to pass an
+  overflowing `long` request into AE2.
+- Added a public calculation-profile capability query for optional CPU add-ons.
+
 ## [1.5.10] - 2026-08-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ All notable changes to this project are documented here.
   overflowing `long` request into AE2.
 - Added a public calculation-profile capability query for optional CPU add-ons.
 
+## [1.5.12] - 2026-08-11
+
+### Added
+
+- Added the public BigInteger plan handoff used by InsaneAE and other optional
+  crafting CPU add-ons.
+- Added the public exact amount ledger and calculation-profile compatibility
+  contracts for NeoForge 1.21.1.
+
+### Fixed
+
+- Promoted aggregate long overflow to the BigInteger host instead of sending a
+  wrapped or clamped value into AE2's checked long calculation.
+
 ## [1.5.10] - 2026-08-10
 
 ### Fixed

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -24,6 +24,7 @@ Important calculation options include:
 | Key | Default | Purpose |
 | --- | ---: | --- |
 | `enableAqeBigCraftingProfile` | `true` | Activates the narrow AQE compiled/checked profile only when Advanced AE and AQE are installed. |
+| `enableInsaneAeBigCraftingProfile` | `true` | Activates the same strict calculation profile when InsaneAE is installed, so InsaneAE does not apply a competing calculation batch. |
 | `enableLongRootCraftAmounts` | `true` | Adds the signed-long root-order path while preserving AE2's original int path. |
 | `enableCompiledCraftingGraph` | `true` | Reuses a generation-keyed deterministic graph where the active profile allows it. |
 | `enableShadowMode` | `true` | Compares eligible compiled results against AE2 without changing normal results. |

--- a/docs/EXPERIMENTAL_ENGINE.md
+++ b/docs/EXPERIMENTAL_ENGINE.md
@@ -17,7 +17,8 @@ runtime qualification is P9 and is intentionally left to the pack operator.
 
 General deep behavior-changing paths are deliberately **disabled by default**.
 The narrow AQE profile is enabled only when Advanced AE and Advanced Quantum
-Engineering are both loaded. It activates compiled observation, checked
+Engineering are both loaded. The optional InsaneAE profile provides the same
+calculation boundary when InsaneAE is loaded. It activates compiled observation, checked
 arithmetic, exact wide-capacity planning, BigInteger execution windows, and
 ordinary-long replacement only for roots whose current AE2 Pattern API,
 candidate set, inventory, and generations pass the strict proof. It does not
@@ -54,6 +55,7 @@ condition for the checked BigInteger path:
 ```toml
 [experimentalCraftingEngine]
 enableAqeBigCraftingProfile = true
+enableInsaneAeBigCraftingProfile = true
 enableLongRootCraftAmounts = true
 enableExperimentalCraftingEngine = false
 enableShadowMode = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ minecraft_version=1.21.1
 neo_version=21.1.247
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.10
+mod_version=1.5.12
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java
@@ -3,8 +3,12 @@ package com.syaru.ae2craftingoptimizer.api.big;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.engine.BigCraftingKeyCodec;
 import com.syaru.ae2craftingoptimizer.engine.OverflowPromotingCraftingPlanner;
+import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
+import com.syaru.ae2craftingoptimizer.engine.BigIntegerCraftingPlan;
 import java.math.BigInteger;
 import java.util.Objects;
+import java.util.Optional;
+import appeng.api.networking.crafting.ICraftingPlan;
 import appeng.api.stacks.AEKey;
 import com.syaru.ae2craftingoptimizer.network.BigCraftingNetwork;
 import net.minecraft.nbt.CompoundTag;
@@ -12,13 +16,51 @@ import net.minecraft.server.level.ServerPlayer;
 
 /** Stable opt-in boundary for CPU add-ons that own a BigInteger crafting host. */
 public final class BigCraftingEngineApi {
+    /** 既存AQEホストAPIの契約番号。既存アドオンの互換性を維持する。 */
     public static final int API_VERSION = 3;
+    /** アドオン向け正確なBigInteger会計APIの契約番号。 */
+    public static final int AMOUNT_LEDGER_API_VERSION = 1;
+    /** AE2計算プロファイル照会APIの契約番号。 */
+    public static final int CALCULATION_PROFILE_API_VERSION = 1;
 
     private BigCraftingEngineApi() {
     }
 
     public static boolean isEnabled() {
         return ACOConfig.enableBigIntegerCraftingBackend();
+    }
+
+    /**
+     * ACOが厳密なBigInteger計算境界を所有しているかを返す。
+     * 対応CPUアドオンが同じ計算を二重実行しないための能力照会だけを行う。
+     */
+    public static boolean isCalculationProfileActive() {
+        return ACOConfig.enableBigCraftingProfile()
+                && ACOConfig.enableCompiledCraftingGraph()
+                && ACOConfig.enableBigIntegerCraftingBackend();
+    }
+
+    /**
+     * ACOが生成した計画の正確なBigInteger側データを取得する。
+     * 通常のAE2計画やlongへ飽和しただけの計画は返さない。
+     */
+    public static Optional<BigIntegerCraftingPlanView> inspectBigIntegerPlan(
+            ICraftingPlan plan) {
+        if (!isCalculationProfileActive() || plan == null) {
+            return Optional.empty();
+        }
+        BigIntegerCraftingPlan bigPlan = Ae2CraftingPlanSidecars.bigInteger(plan).orElse(null);
+        if (bigPlan == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new BigIntegerCraftingPlanView(
+                bigPlan.finalOutput(),
+                bigPlan.exactBytes(),
+                bigPlan.simulation(),
+                bigPlan.exactPatternTimes(),
+                bigPlan.exactPlan().usedInventory(),
+                bigPlan.exactPlan().emitted(),
+                bigPlan.exactPlan().missing()));
     }
 
     public static <K> BigCraftingRuntime<K> create(

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java
@@ -105,6 +105,30 @@ public final class BigCraftingEngineApi {
         return new OverflowPromotingCraftingPlanner<>(ACOConfig.getBigIntegerMaximumBits());
     }
 
+    /**
+     * Creates an exact amount ledger for add-on CPUs that must keep output counts
+     * beyond the long range without changing AE2's own stack API.
+     */
+    public static <K> BigIntegerAmountLedger<K> createAmountLedger(
+            BigCraftingKeyCodec<K> keyCodec) {
+        if (!isEnabled()) {
+            throw new IllegalStateException(
+                    "ACO BigInteger crafting backend is disabled by server config");
+        }
+        return new BigIntegerAmountLedger<>(
+                Objects.requireNonNull(keyCodec, "keyCodec"),
+                ACOConfig.getBigIntegerMaximumBits());
+    }
+
+    /** Restores an add-on amount ledger using the current server-side bit limit. */
+    public static <K> BigIntegerAmountLedger<K> loadAmountLedger(
+            CompoundTag saved,
+            BigCraftingKeyCodec<K> keyCodec) {
+        BigIntegerAmountLedger<K> ledger = createAmountLedger(keyCodec);
+        ledger.load(Objects.requireNonNull(saved, "saved"));
+        return ledger;
+    }
+
     /** Restores a host runtime using the current server-side safety limits. */
     public static <K> BigCraftingRuntime<K> load(
             CompoundTag saved,

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigIntegerAmountLedger.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigIntegerAmountLedger.java
@@ -1,0 +1,176 @@
+package com.syaru.ae2craftingoptimizer.api.big;
+
+import com.syaru.ae2craftingoptimizer.engine.BigCraftingKeyCodec;
+import java.math.BigInteger;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+
+/**
+ * Add-on向けの正確な量会計。
+ *
+ * <p>AE2の通常カウンタはlongなので、ここでは値をBigIntegerで保持し、
+ * 実際の搬入出時だけlong単位の窓へ取り出す。これにより、計算中の掛け算で
+ * longが折り返して不足や消失を起こすことを防ぐ。</p>
+ *
+ * <p>このクラスはAE2のレシピやクラフト規則を変更しない。AE2へ渡す量の上限は
+ * 呼び出し側が決め、{@link #drain(Object, long)} はその上限を越えない一回分だけ返す。</p>
+ */
+public final class BigIntegerAmountLedger<K> {
+    public static final int SCHEMA_VERSION = 1;
+    /** 破損NBTによるメモリ枯渇を防ぐ固定エントリ上限。 */
+    public static final int MAX_ENTRIES = 1_048_576;
+
+    private static final String NBT_SCHEMA = "schemaVersion";
+    private static final String NBT_ENTRIES = "entries";
+    private static final String NBT_KEY = "key";
+    private static final String NBT_AMOUNT = "amount";
+
+    private final BigCraftingKeyCodec<K> keyCodec;
+    private final int maximumBits;
+    private final Map<K, BigInteger> amounts = new LinkedHashMap<>();
+
+    BigIntegerAmountLedger(BigCraftingKeyCodec<K> keyCodec, int maximumBits) {
+        this.keyCodec = Objects.requireNonNull(keyCodec, "keyCodec");
+        if (maximumBits < 1) {
+            throw new IllegalArgumentException("maximumBits must be positive");
+        }
+        this.maximumBits = maximumBits;
+    }
+
+    /** 正確な量を加算する。0以下の量は会計ミスとして受け付けない。 */
+    public synchronized void add(K key, BigInteger amount) {
+        K checkedKey = Objects.requireNonNull(key, "key");
+        BigInteger checkedAmount = requirePositive(amount, "amount");
+        BigInteger current = amounts.getOrDefault(checkedKey, BigInteger.ZERO);
+        BigInteger next = checked(current.add(checkedAmount), "ledger amount");
+        // 新しいキーだけエントリ上限を消費するため、既存キーの加算は許可する。
+        if (current.signum() == 0 && amounts.size() >= MAX_ENTRIES) {
+            throw new IllegalStateException("BigInteger amount ledger entry limit exceeded");
+        }
+        amounts.put(checkedKey, next);
+    }
+
+    /** long入力を正確な会計へ昇格する補助メソッド。 */
+    public synchronized void add(K key, long amount) {
+        // 正の量だけを会計し、0以下の入力は空の搬入として無視する。
+        if (amount <= 0L) {
+            return;
+        }
+        add(key, BigInteger.valueOf(amount));
+    }
+
+    /** 現在の正確な量を返す。存在しないキーは0。 */
+    public synchronized BigInteger get(K key) {
+        return amounts.getOrDefault(Objects.requireNonNull(key, "key"), BigInteger.ZERO);
+    }
+
+    /**
+     * AE2へ渡す一回分をlongで取り出す。
+     *
+     * <p>remainingがlongを越えていても、ここでは最大Long.MAX_VALUEだけを取り出すので、
+     * 変換途中の符号反転や負数化は発生しない。残りは次の搬出窓に残る。</p>
+     */
+    public synchronized long drain(K key, long maximum) {
+        if (maximum <= 0L) {
+            throw new IllegalArgumentException("maximum must be positive");
+        }
+        K checkedKey = Objects.requireNonNull(key, "key");
+        BigInteger current = amounts.get(checkedKey);
+        // 未登録または使い切ったキーには搬出量がない。
+        if (current == null || current.signum() <= 0) {
+            return 0L;
+        }
+        BigInteger requested = BigInteger.valueOf(maximum);
+        BigInteger drained = current.min(requested);
+        BigInteger remaining = current.subtract(drained);
+        // 残量がゼロならキー自体を削除し、台帳を膨らませない。
+        if (remaining.signum() == 0) {
+            amounts.remove(checkedKey);
+        } else {
+            amounts.put(checkedKey, remaining);
+        }
+        return drained.longValueExact();
+    }
+
+    /** 全量のスナップショットを返す。返却Mapは変更できない。 */
+    public synchronized Map<K, BigInteger> snapshot() {
+        return Map.copyOf(amounts);
+    }
+
+    public synchronized boolean isEmpty() {
+        return amounts.isEmpty();
+    }
+
+    public synchronized int size() {
+        return amounts.size();
+    }
+
+    public synchronized void clear() {
+        amounts.clear();
+    }
+
+    /** NBTへは符号付きBigIntegerのbyte[]を保存し、longへ縮めない。 */
+    public synchronized CompoundTag save() {
+        CompoundTag saved = new CompoundTag();
+        saved.putInt(NBT_SCHEMA, SCHEMA_VERSION);
+        ListTag entries = new ListTag();
+        for (Map.Entry<K, BigInteger> entry : amounts.entrySet()) {
+            CompoundTag value = new CompoundTag();
+            value.put(NBT_KEY, keyCodec.encode(entry.getKey()));
+            value.putByteArray(NBT_AMOUNT, entry.getValue().toByteArray());
+            entries.add(value);
+        }
+        saved.put(NBT_ENTRIES, entries);
+        return saved;
+    }
+
+    /** 保存済み台帳を置き換える。壊れた値は黙って0にせず読み込みを失敗させる。 */
+    public synchronized void load(CompoundTag saved) {
+        Objects.requireNonNull(saved, "saved");
+        int schema = saved.getInt(NBT_SCHEMA);
+        // schema=0は初期試験版の無記録NBTを許容し、未知版は破損として拒否する。
+        if (schema != 0 && schema != SCHEMA_VERSION) {
+            throw new IllegalArgumentException("unsupported BigInteger amount ledger schema: " + schema);
+        }
+        ListTag entries = saved.getList(NBT_ENTRIES, Tag.TAG_COMPOUND);
+        if (entries.size() > MAX_ENTRIES) {
+            throw new IllegalArgumentException("BigInteger amount ledger contains too many entries");
+        }
+        Map<K, BigInteger> loaded = new LinkedHashMap<>();
+        // 既存台帳を変更せず全件検証してから、最後に原子的に置き換える。
+        for (int index = 0; index < entries.size(); index++) {
+            CompoundTag value = entries.getCompound(index);
+            K key = keyCodec.decode(value.getCompound(NBT_KEY));
+            byte[] encoded = value.getByteArray(NBT_AMOUNT);
+            BigInteger amount = new BigInteger(encoded);
+            if (amount.signum() <= 0) {
+                throw new IllegalArgumentException("BigInteger amount ledger contains a non-positive amount");
+            }
+            BigInteger checked = checked(amount, "saved ledger amount");
+            if (loaded.put(key, checked) != null) {
+                throw new IllegalArgumentException("BigInteger amount ledger contains a duplicate key");
+            }
+        }
+        amounts.clear();
+        amounts.putAll(loaded);
+    }
+
+    private BigInteger requirePositive(BigInteger value, String name) {
+        Objects.requireNonNull(value, name);
+        if (value.signum() <= 0) {
+            throw new IllegalArgumentException(name + " must be positive");
+        }
+        return checked(value, name);
+    }
+
+    private BigInteger checked(BigInteger value, String context) {
+        if (value.signum() < 0 || value.bitLength() > maximumBits) {
+            throw new ArithmeticException(context + " exceeds the configured BigInteger bit limit");
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigIntegerCraftingPlanView.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigIntegerCraftingPlanView.java
@@ -1,0 +1,42 @@
+package com.syaru.ae2craftingoptimizer.api.big;
+
+import appeng.api.crafting.IPatternDetails;
+import appeng.api.networking.crafting.ICraftingPlan;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.GenericStack;
+import java.math.BigInteger;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable exact view of an ACO BigInteger plan for optional CPU add-ons.
+ *
+ * <p>The standard AE2 {@link ICraftingPlan} remains the compatibility facade.
+ * Add-ons that can execute bounded windows may opt into this view without
+ * depending on ACO's engine implementation classes.</p>
+ */
+public record BigIntegerCraftingPlanView(
+        GenericStack finalOutput,
+        BigInteger exactBytes,
+        boolean simulation,
+        Map<IPatternDetails, BigInteger> patternTimes,
+        Map<AEKey, BigInteger> usedItems,
+        Map<AEKey, BigInteger> emittedItems,
+        Map<AEKey, BigInteger> missingItems) {
+
+    public BigIntegerCraftingPlanView {
+        Objects.requireNonNull(finalOutput, "finalOutput");
+        Objects.requireNonNull(exactBytes, "exactBytes");
+        Objects.requireNonNull(patternTimes, "patternTimes");
+        Objects.requireNonNull(usedItems, "usedItems");
+        Objects.requireNonNull(emittedItems, "emittedItems");
+        Objects.requireNonNull(missingItems, "missingItems");
+        if (exactBytes.signum() < 0) {
+            throw new IllegalArgumentException("exactBytes must not be negative");
+        }
+        patternTimes = Map.copyOf(patternTimes);
+        usedItems = Map.copyOf(usedItems);
+        emittedItems = Map.copyOf(emittedItems);
+        missingItems = Map.copyOf(missingItems);
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
@@ -168,6 +168,7 @@ public final class ACOConfig {
     private static final ModConfigSpec.IntValue SLOW_CRAFT_CALCULATION_MILLIS;
     private static final ModConfigSpec.BooleanValue LOG_CACHE_STATISTICS;
     private static final ModConfigSpec.BooleanValue ENABLE_AQE_BIG_CRAFTING_PROFILE;
+    private static final ModConfigSpec.BooleanValue ENABLE_INSANE_AE_BIG_CRAFTING_PROFILE;
     private static final ModConfigSpec.BooleanValue ENABLE_LONG_ROOT_CRAFT_AMOUNTS;
     private static final ModConfigSpec.BooleanValue ENABLE_EXPERIMENTAL_CRAFTING_ENGINE;
     private static final ModConfigSpec.BooleanValue ENABLE_CRAFTING_ENGINE_SHADOW_MODE;
@@ -732,6 +733,12 @@ public final class ACOConfig {
                         "Enable only the AQE BigInteger calculation and execution path when Advanced AE and Advanced Quantum Engineering are installed.",
                         "This does not enable Native Batch, bus rewrites, terminal rewrites, or normal-AE2 authoritative replacement.")
                 .define("enableAqeBigCraftingProfile", true);
+        ENABLE_INSANE_AE_BIG_CRAFTING_PROFILE = builder
+                .comment(
+                        "Enable the same strict BigInteger calculation profile when InsaneAE is installed.",
+                        "InsaneAE's calculation batch defers to ACO while this profile is active.",
+                        "This does not enable Native Batch, bus rewrites, terminal rewrites, or ambiguous recipe replacement.")
+                .define("enableInsaneAeBigCraftingProfile", true);
         ENABLE_LONG_ROOT_CRAFT_AMOUNTS = builder
                 .comment(
                         "Allow the AE2 craft-amount screen to submit root amounts from Integer.MAX_VALUE + 1 through Long.MAX_VALUE.",
@@ -1586,6 +1593,21 @@ public final class ACOConfig {
                 && ModList.get().isLoaded("advanced_quantum_engineering");
     }
 
+    /**
+     * InsaneAE搭載時だけ、AQEと同じ厳密BigInteger計算プロファイルを有効にする。
+     * 計画を作れない環境へ広い値を公開しないよう、設定とMod検出を両方確認する。
+     */
+    public static boolean enableInsaneAeBigCraftingProfile() {
+        return enableOptimizer()
+                && ENABLE_INSANE_AE_BIG_CRAFTING_PROFILE.get()
+                && ModList.get().isLoaded("insaneae");
+    }
+
+    /** AQEまたはInsaneAEがBigInteger計算の連携先として存在するかを返す。 */
+    public static boolean enableBigCraftingProfile() {
+        return enableAqeBigCraftingProfile() || enableInsaneAeBigCraftingProfile();
+    }
+
     public static boolean enableLongRootCraftAmounts() {
         return enableOptimizer() && ENABLE_LONG_ROOT_CRAFT_AMOUNTS.get();
     }
@@ -1614,7 +1636,7 @@ public final class ACOConfig {
 
     public static boolean enableCompiledCraftingGraph() {
         return ENABLE_COMPILED_CRAFTING_GRAPH.get()
-                && (enableExperimentalCraftingEngine() || enableAqeBigCraftingProfile());
+                && (enableExperimentalCraftingEngine() || enableBigCraftingProfile());
     }
 
     public static boolean enableAuthoritativeCompiledPlanner() {
@@ -1627,7 +1649,7 @@ public final class ACOConfig {
 
     public static boolean enableCheckedAe2CraftingArithmetic() {
         return ENABLE_CHECKED_AE2_CRAFTING_ARITHMETIC.get()
-                && (enableExperimentalCraftingEngine() || enableAqeBigCraftingProfile());
+                && (enableExperimentalCraftingEngine() || enableBigCraftingProfile());
     }
 
     public static boolean enableTransactionalBatchingV2() {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
@@ -291,12 +291,19 @@ public final class Ae2AuthoritativeCraftingPlanner {
             CalculationStrategy strategy,
             OverflowPromotingCraftingPlanner.Result<AEKey> promoted,
             boolean requiresBigIntegerExecution) {
-        // 個別long超過はBigInteger Plannerの正確な結果からだけ親Jobへ変換する。
-        if (!(promoted instanceof OverflowPromotingCraftingPlanner.BigResult<AEKey> bigResult)
-                || !ACOConfig.enableBigIntegerGameplayExecution()) {
+        if (!ACOConfig.enableBigIntegerGameplayExecution()) {
             return null;
         }
-        BigCraftingPlan<AEKey> exactPlan = bigResult.plan();
+        BigCraftingPlan<AEKey> exactPlan;
+        if (promoted instanceof OverflowPromotingCraftingPlanner.BigResult<AEKey> bigResult) {
+            // 途中の掛け算がoverflowした場合は、Plannerが最初から作ったBigInteger結果を使う。
+            exactPlan = bigResult.plan();
+        } else if (promoted instanceof OverflowPromotingCraftingPlanner.LongResult<AEKey> longResult) {
+            // 個別値はlong内でも合計だけが超過する場合は、long結果を無損失でBigIntegerへ昇格する。
+            exactPlan = widenLongPlan(longResult.plan());
+        } else {
+            return null;
+        }
         // CRAFT_LESSはAE2固有の部分成功探索を持つため、ACOが近似した結果へ置き換えない。
         if (!exactPlan.craftable() && strategy == CalculationStrategy.CRAFT_LESS) {
             return null;
@@ -345,6 +352,26 @@ public final class Ae2AuthoritativeCraftingPlanner {
                 requiresBigIntegerExecution);
         // AE2と周辺アドオンへは必ず最終実装CraftingPlanを返し、BigInteger真値はSidecarへ置く。
         return Ae2CraftingPlanSidecars.expose(metadata);
+    }
+
+    private static BigCraftingPlan<AEKey> widenLongPlan(LongCraftingPlan<AEKey> source) {
+        Objects.requireNonNull(source, "source");
+        // long値を文字列経由にせず、BigInteger.valueOfで符号反転のない昇格を行う。
+        return new BigCraftingPlan<>(
+                source.requestedKey(),
+                BigInteger.valueOf(source.requestedAmount()),
+                widenLongMap(source.patternExecutions()),
+                widenLongMap(source.usedInventory()),
+                widenLongMap(source.emitted()),
+                widenLongMap(source.missing()),
+                0);
+    }
+
+    private static <K> Map<K, BigInteger> widenLongMap(Map<K, Long> source) {
+        Map<K, BigInteger> widened = new LinkedHashMap<>();
+        // 既存の正確なlong会計をキーごとに一度だけBigIntegerへ写す。
+        source.forEach((key, amount) -> widened.put(key, BigInteger.valueOf(amount)));
+        return Map.copyOf(widened);
     }
 
     @Nullable

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
@@ -191,8 +191,10 @@ public final class Ae2AuthoritativeCraftingPlanner {
             }
             NormalizedPlan symbolic = normalize(promoted);
             ICraftingPlan result;
-            // 個別値がlongを超える場合、標準AE2 Jobへ丸めずAQE専用のBig親Jobを作る。
-            if (symbolic == null) {
+            // 個別値またはキー別合計がlongを超える場合、通常AE2 Jobへ戻さずBig親Jobを作る。
+            boolean bigIntegerExecutionRequired = symbolic == null
+                    || symbolic.hasAggregatePastLong();
+            if (bigIntegerExecutionRequired) {
                 result = createBigIntegerParentPlan(
                         capture,
                         graphSnapshot,
@@ -201,7 +203,8 @@ public final class Ae2AuthoritativeCraftingPlanner {
                         output,
                         requestedAmount,
                         strategy,
-                        promoted);
+                        promoted,
+                        true);
                 // 厳格な親Jobへ変換できない経路は、値を近似せずAE2本来の計算へ戻す。
                 if (result == null) {
                     CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
@@ -286,7 +289,8 @@ public final class Ae2AuthoritativeCraftingPlanner {
             AEKey output,
             long requestedAmount,
             CalculationStrategy strategy,
-            OverflowPromotingCraftingPlanner.Result<AEKey> promoted) {
+            OverflowPromotingCraftingPlanner.Result<AEKey> promoted,
+            boolean requiresBigIntegerExecution) {
         // 個別long超過はBigInteger Plannerの正確な結果からだけ親Jobへ変換する。
         if (!(promoted instanceof OverflowPromotingCraftingPlanner.BigResult<AEKey> bigResult)
                 || !ACOConfig.enableBigIntegerGameplayExecution()) {
@@ -337,7 +341,8 @@ public final class Ae2AuthoritativeCraftingPlanner {
                 new GenericStack(output, requestedAmount),
                 exactPlan,
                 exactPatternTimes,
-                prepared);
+                prepared,
+                requiresBigIntegerExecution);
         // AE2と周辺アドオンへは必ず最終実装CraftingPlanを返し、BigInteger真値はSidecarへ置く。
         return Ae2CraftingPlanSidecars.expose(metadata);
     }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerCraftingPlan.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerCraftingPlan.java
@@ -36,6 +36,15 @@ public final class BigIntegerCraftingPlan implements WideCraftingPlan {
             BigCraftingPlan<AEKey> exactPlan,
             Map<IPatternDetails, BigInteger> exactPatternTimes,
             Ae2BigCraftingPlanFactory.PreparedBigRootPlan preparedRoot) {
+        this(finalOutput, exactPlan, exactPatternTimes, preparedRoot, false);
+    }
+
+    public BigIntegerCraftingPlan(
+            GenericStack finalOutput,
+            BigCraftingPlan<AEKey> exactPlan,
+            Map<IPatternDetails, BigInteger> exactPatternTimes,
+            Ae2BigCraftingPlanFactory.PreparedBigRootPlan preparedRoot,
+            boolean requiresBigIntegerExecution) {
         this.finalOutput = Objects.requireNonNull(finalOutput, "finalOutput");
         this.exactPlan = Objects.requireNonNull(exactPlan, "exactPlan");
         this.exactPatternTimes = immutablePositiveCounts(
@@ -48,10 +57,11 @@ public final class BigIntegerCraftingPlan implements WideCraftingPlan {
                 || !preparedRoot.reservedBytes().equals(preparedRoot.job().reservedCapacity())) {
             throw new IllegalArgumentException("BigInteger plan metadata is inconsistent");
         }
-        // この型は少なくとも一つの個別カウンタがlongを超える計画だけを運ぶ。
-        if (!containsWideCounter(exactPlan, this.exactPatternTimes)) {
+        // 個別値がlong超過、またはキー別合計がlong超過してAE2の乗算を使えない計画だけを運ぶ。
+        if (!requiresBigIntegerExecution
+                && !containsWideCounter(exactPlan, this.exactPatternTimes)) {
             throw new IllegalArgumentException(
-                    "BigInteger crafting plan requires at least one counter past signed long");
+                    "BigInteger crafting plan requires an exact-arithmetic reason");
         }
         this.usedItems = projectKeyCounter(exactPlan.usedInventory());
         this.emittedItems = projectKeyCounter(exactPlan.emitted());

--- a/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOStartupReport.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOStartupReport.java
@@ -177,9 +177,10 @@ final class ACOStartupReport {
                 ACOConfig.coalesceAssemblerMatrixStatusUpdates());
         logDeepRewriteFlags();
         AE2CraftingOptimizer.LOGGER.info(
-                "ACO experimental crafting engine: {} (AQE profile {}, shadow {}, compiled graph {}, proof-qualified long plans {}, transaction V2 {}, GT native {}, Mekanism native {}, fair scheduler {}, persistent journal {})",
+                "ACO experimental crafting engine: {} (AQE profile {}, InsaneAE profile {}, shadow {}, compiled graph {}, proof-qualified long plans {}, transaction V2 {}, GT native {}, Mekanism native {}, fair scheduler {}, persistent journal {})",
                 ACOConfig.enableExperimentalCraftingEngine(),
                 ACOConfig.enableAqeBigCraftingProfile(),
+                ACOConfig.enableInsaneAeBigCraftingProfile(),
                 ACOConfig.enableCraftingEngineShadowMode(),
                 ACOConfig.enableCompiledCraftingGraph(),
                 ACOConfig.enableProofQualifiedLongPlans(),

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCpuClusterBigCapacityGuardMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCpuClusterBigCapacityGuardMixin.java
@@ -8,6 +8,7 @@ import appeng.api.networking.security.IActionSource;
 import appeng.crafting.execution.CraftingSubmitResult;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
 import com.syaru.ae2craftingoptimizer.access.BigCapacityPlanBoundaryAccess;
+import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -26,7 +27,11 @@ public abstract class CraftingCpuClusterBigCapacityGuardMixin
             ICraftingRequester requester,
             CallbackInfoReturnable<ICraftingSubmitResult> cir) {
         // Long.MAXは真の容量ではないため、対応Sidecarを持たない標準CPUでは実行しない。
-        if (Ae2CraftingPlanSidecars.isWide(plan)) {
+        boolean insaneAeExactPlan = ACOConfig.enableInsaneAeBigCraftingProfile()
+                && Ae2CraftingPlanSidecars.bigInteger(plan).isPresent();
+        // InsaneAE専用のExact受け渡しだけはInsaneAE側が同じPlanを所有するため通す。
+        // 容量だけをlongへ飽和したBigCapacity計画は標準CPUへ絶対に渡さない。
+        if (Ae2CraftingPlanSidecars.isWide(plan) && !insaneAeExactPlan) {
             cir.setReturnValue(CraftingSubmitResult.CPU_TOO_SMALL);
         }
     }


### PR DESCRIPTION
## 概要

InsaneAE の Quantum CPU 実行経路が ACO の BigInteger 計画を AE2 標準の long 計画として再処理し、`CraftingTreeProcessCheckedMathMixin` の境界検査へ到達して `CountOverflowException` になる問題を修正します。

## 変更内容

- `BigIntegerCraftingPlanView` と calculation-profile API を公開
- InsaneAE が競合する計算バッチを重ねないための capability query を追加
- InsaneAE profile 有効時は ACO の BigInteger sidecar を標準計画に紐付ける
- InsaneAE が Exact Pattern 回数を読み取れるように immutable view を提供
- BigInteger 計画だけは容量ガードを InsaneAE の受理経路へ渡す
- 通常の AE2 計画、AQE、未対応アドオンの経路は変更しない
- NeoForge 1.21.1 の実行契約と mod discovery を確認

## 検証

- `gradlew.bat clean test build --no-daemon` 成功
- NeoForge 1.21.1 の clean build 成功
- 実環境の起動・クラフト試験は別途実施

Refs #42
Refs #46
