### PR TITLE
fix: hand off BigInteger plans to InsaneAE on Forge 1.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- Added an optional InsaneAE calculation profile. When enabled, ACO owns the
+  strict compiled/BigInteger calculation boundary instead of allowing the
+  InsaneAE calculation batch to pass an overflowing `long` request into AE2.
+- Added a public calculation-profile capability query for optional CPU add-ons.
+
 ## [1.5.11] - 2026-08-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ All notable changes to this project are documented here.
   InsaneAE calculation batch to pass an overflowing `long` request into AE2.
 - Added a public calculation-profile capability query for optional CPU add-ons.
 
+## [1.5.12] - 2026-08-11
+
+### Added
+
+- Added the public BigInteger plan handoff used by InsaneAE and other optional
+  crafting CPU add-ons.
+- Added the public exact amount ledger and calculation-profile compatibility
+  contracts for Forge 1.20.1.
+
+### Fixed
+
+- Promoted aggregate long overflow to the BigInteger host instead of sending a
+  wrapped or clamped value into AE2's checked long calculation.
+
 ## [1.5.11] - 2026-08-11
 
 ### Added

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -24,6 +24,7 @@ Important calculation options include:
 | Key | Default | Purpose |
 | --- | ---: | --- |
 | `enableAqeBigCraftingProfile` | `true` | Activates the narrow AQE compiled/checked profile only when Advanced AE and AQE are installed. |
+| `enableInsaneAeBigCraftingProfile` | `true` | Activates the same strict calculation profile when InsaneAE is installed, so InsaneAE does not apply a competing calculation batch. |
 | `enableLongRootCraftAmounts` | `true` | Adds the signed-long root-order path while preserving AE2's original int path. |
 | `enableCompiledCraftingGraph` | `true` | Reuses a generation-keyed deterministic graph where the active profile allows it. |
 | `enableShadowMode` | `true` | Compares eligible compiled results against AE2 without changing normal results. |

--- a/docs/EXPERIMENTAL_ENGINE.md
+++ b/docs/EXPERIMENTAL_ENGINE.md
@@ -11,7 +11,8 @@ runtime qualification is P9 and is intentionally left to the pack operator.
 
 General deep behavior-changing paths are deliberately **disabled by default**.
 The narrow AQE profile is enabled only when Advanced AE and Advanced Quantum
-Engineering are both loaded. It activates compiled observation, checked
+Engineering are both loaded. The optional InsaneAE profile provides the same
+calculation boundary when InsaneAE is loaded. It activates compiled observation, checked
 arithmetic, exact wide-capacity planning, BigInteger execution windows, and
 ordinary-long replacement only for roots whose current AE2 Pattern API,
 candidate set, inventory, and generations pass the strict proof. It does not
@@ -50,6 +51,7 @@ condition for the checked BigInteger path:
 ```toml
 [experimentalCraftingEngine]
 enableAqeBigCraftingProfile = true
+enableInsaneAeBigCraftingProfile = true
 enableLongRootCraftAmounts = true
 enableExperimentalCraftingEngine = false
 enableShadowMode = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.11
+mod_version=1.5.12
 minecraft_version=1.20.1
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java
@@ -3,8 +3,12 @@ package com.syaru.ae2craftingoptimizer.api.big;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.engine.BigCraftingKeyCodec;
 import com.syaru.ae2craftingoptimizer.engine.OverflowPromotingCraftingPlanner;
+import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
+import com.syaru.ae2craftingoptimizer.engine.BigIntegerCraftingPlan;
 import java.math.BigInteger;
 import java.util.Objects;
+import java.util.Optional;
+import appeng.api.networking.crafting.ICraftingPlan;
 import appeng.api.stacks.AEKey;
 import com.syaru.ae2craftingoptimizer.network.BigCraftingNetwork;
 import net.minecraft.nbt.CompoundTag;
@@ -16,12 +20,52 @@ public final class BigCraftingEngineApi {
     public static final int API_VERSION = 3;
     /** Version of the exact amount-ledger surface added for crafting add-ons. */
     public static final int AMOUNT_LEDGER_API_VERSION = 1;
+    /** Version of the optional AE2 calculation-profile query used by CPU add-ons. */
+    public static final int CALCULATION_PROFILE_API_VERSION = 1;
 
     private BigCraftingEngineApi() {
     }
 
     public static boolean isEnabled() {
         return ACOConfig.enableBigIntegerCraftingBackend();
+    }
+
+    /**
+     * Returns whether ACO currently owns the strict AE2 calculation boundary.
+     *
+     * <p>An add-on may use this query to avoid applying its own calculation
+     * shortcut over ACO's planner. This is deliberately a capability query;
+     * it does not expose or mutate a crafting plan.</p>
+     */
+    public static boolean isCalculationProfileActive() {
+        return ACOConfig.enableBigCraftingProfile()
+                && ACOConfig.enableCompiledCraftingGraph()
+                && ACOConfig.enableBigIntegerCraftingBackend();
+    }
+
+    /**
+     * Returns the exact plan sidecar for an ACO-created plan.
+     *
+     * <p>The returned view is empty for ordinary AE2 plans. This identity check
+     * prevents an add-on from treating a saturated or unrelated plan as exact.</p>
+     */
+    public static Optional<BigIntegerCraftingPlanView> inspectBigIntegerPlan(
+            ICraftingPlan plan) {
+        if (!isCalculationProfileActive() || plan == null) {
+            return Optional.empty();
+        }
+        BigIntegerCraftingPlan bigPlan = Ae2CraftingPlanSidecars.bigInteger(plan).orElse(null);
+        if (bigPlan == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new BigIntegerCraftingPlanView(
+                bigPlan.finalOutput(),
+                bigPlan.exactBytes(),
+                bigPlan.simulation(),
+                bigPlan.exactPatternTimes(),
+                bigPlan.exactPlan().usedInventory(),
+                bigPlan.exactPlan().emitted(),
+                bigPlan.exactPlan().missing()));
     }
 
     public static <K> BigCraftingRuntime<K> create(

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostBackendState.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostBackendState.java
@@ -1,0 +1,11 @@
+package com.syaru.ae2craftingoptimizer.api.big;
+
+/** BigInteger Hostの原子的な状態表示に使う安定ラベル。 */
+public enum BigCraftingHostBackendState {
+    ACTIVE,
+    PAUSED,
+    DEGRADED,
+    CLOSING,
+    CLOSED,
+    UNAVAILABLE
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRegistration.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRegistration.java
@@ -1,0 +1,23 @@
+package com.syaru.ae2craftingoptimizer.api.big;
+
+import java.util.UUID;
+
+/** 一つのCPU所有者とBigCraftingHostRuntimeを結ぶ世代付き登録ハンドル。 */
+public interface BigCraftingHostRegistration extends AutoCloseable {
+    Object ownerIdentity();
+
+    UUID runtimeIdentity();
+
+    long generation();
+
+    boolean isClosed();
+
+    BigCraftingHostSnapshot snapshot(long revision, BigCraftingHostBackendState backendState);
+
+    /** その世代の終了時に一度だけ実行する後始末を登録する。 */
+    void onClose(Runnable cleanup);
+
+    /** 古い世代から新しい世代を閉じない、冪等な終了操作。 */
+    @Override
+    void close();
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRegistry.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRegistry.java
@@ -1,42 +1,214 @@
 package com.syaru.ae2craftingoptimizer.api.big;
 
 import appeng.api.stacks.AEKey;
+import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.LinkedHashMap;
-import java.util.WeakHashMap;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-/** Weak owner-to-runtime registry for optional CPU add-ons. */
+/** CPU所有者ごとのBigInteger Hostを、GCではなく明示的なライフサイクルで管理する。 */
 public final class BigCraftingHostRegistry {
-    private static final Map<Object, BigCraftingHostRuntime<AEKey>> HOSTS = new WeakHashMap<>();
+    private static final Map<Object, Registration> HOSTS = new IdentityHashMap<>();
+    private static long nextGeneration;
 
     private BigCraftingHostRegistry() {
     }
 
-    public static synchronized void register(Object owner, BigCraftingHostRuntime<AEKey> runtime) {
+    /** 同一所有者の旧世代を閉じてから新しい登録ハンドルを返す。 */
+    public static BigCraftingHostRegistration register(
+            Object owner,
+            BigCraftingHostRuntime<AEKey> runtime) {
         Objects.requireNonNull(owner, "owner");
         Objects.requireNonNull(runtime, "runtime");
-        BigCraftingHostRuntime<AEKey> existing = HOSTS.putIfAbsent(owner, runtime);
-        if (existing != null && existing != runtime) {
-            throw new IllegalStateException("crafting host owner is already registered");
+        Registration previous;
+        Registration replacement;
+        synchronized (HOSTS) {
+            previous = HOSTS.remove(owner);
+            if (previous != null) {
+                previous.markClosed();
+            }
+            replacement = new Registration(owner, runtime, ++nextGeneration);
+            HOSTS.put(owner, replacement);
+        }
+        if (previous != null) {
+            previous.closeRuntime();
+        }
+        return replacement;
+    }
+
+    public static Optional<BigCraftingHostRuntime<AEKey>> find(Object owner) {
+        Objects.requireNonNull(owner, "owner");
+        synchronized (HOSTS) {
+            Registration registration = HOSTS.get(owner);
+            return registration == null || registration.isClosed()
+                    ? Optional.empty()
+                    : Optional.of(registration.runtime());
         }
     }
 
-    public static synchronized Optional<BigCraftingHostRuntime<AEKey>> find(Object owner) {
-        return Optional.ofNullable(HOSTS.get(Objects.requireNonNull(owner, "owner")));
+    public static Optional<BigCraftingHostRegistration> findRegistration(Object owner) {
+        Objects.requireNonNull(owner, "owner");
+        synchronized (HOSTS) {
+            Registration registration = HOSTS.get(owner);
+            return registration == null || registration.isClosed()
+                    ? Optional.empty()
+                    : Optional.of(registration);
+        }
     }
 
-    /** Server-tick integrations iterate an immutable snapshot so weak-map cleanup cannot race the loop. */
-    public static synchronized Map<Object, BigCraftingHostRuntime<AEKey>> snapshot() {
-        return Map.copyOf(new LinkedHashMap<>(HOSTS));
+    /** 実行中のServer tickが安全に走査できる不変Snapshotを返す。 */
+    public static Map<Object, BigCraftingHostRuntime<AEKey>> snapshot() {
+        synchronized (HOSTS) {
+            Map<Object, BigCraftingHostRuntime<AEKey>> copy = new IdentityHashMap<>();
+            HOSTS.forEach((owner, registration) -> {
+                if (!registration.isClosed()) {
+                    copy.put(owner, registration.runtime());
+                }
+            });
+            return Map.copyOf(copy);
+        }
     }
 
-    public static synchronized void unregister(Object owner) {
-        HOSTS.remove(Objects.requireNonNull(owner, "owner"));
+    /** 旧APIの明示解除。新規コードは登録ハンドルをcloseする。 */
+    public static void unregister(Object owner) {
+        Registration removed;
+        synchronized (HOSTS) {
+            removed = HOSTS.remove(Objects.requireNonNull(owner, "owner"));
+            if (removed != null) {
+                removed.markClosed();
+            }
+        }
+        if (removed != null) {
+            removed.closeRuntime();
+        }
     }
 
-    public static synchronized void clear() {
-        HOSTS.clear();
+    /** サーバー終了時に全Hostを閉じ、所有者への強参照を解放する。 */
+    public static void clear() {
+        List<Registration> removed;
+        synchronized (HOSTS) {
+            removed = List.copyOf(HOSTS.values());
+            HOSTS.clear();
+            removed.forEach(Registration::markClosed);
+        }
+        RuntimeException firstFailure = null;
+        for (Registration registration : removed) {
+            try {
+                registration.closeRuntime();
+            } catch (RuntimeException failure) {
+                if (firstFailure == null) {
+                    firstFailure = failure;
+                }
+            }
+        }
+        if (firstFailure != null) {
+            throw firstFailure;
+        }
+    }
+
+    public static int registrationCount() {
+        synchronized (HOSTS) {
+            return HOSTS.size();
+        }
+    }
+
+    private static final class Registration implements BigCraftingHostRegistration {
+        private final Object owner;
+        private final BigCraftingHostRuntime<AEKey> runtime;
+        private final long generation;
+        private final AtomicBoolean closed = new AtomicBoolean();
+        private final CopyOnWriteArrayList<Runnable> closeActions = new CopyOnWriteArrayList<>();
+
+        private Registration(Object owner, BigCraftingHostRuntime<AEKey> runtime, long generation) {
+            this.owner = owner;
+            this.runtime = runtime;
+            this.generation = generation;
+        }
+
+        @Override
+        public Object ownerIdentity() { return owner; }
+
+        @Override
+        public UUID runtimeIdentity() { return runtime.runtimeId(); }
+
+        @Override
+        public long generation() { return generation; }
+
+        @Override
+        public boolean isClosed() { return closed.get(); }
+
+        @Override
+        public BigCraftingHostSnapshot snapshot(
+                long revision,
+                BigCraftingHostBackendState backendState) {
+            synchronized (HOSTS) {
+                if (HOSTS.get(owner) != this || isClosed()) {
+                    throw new IllegalStateException("crafting host registration is stale");
+                }
+                return runtime.snapshot(revision, backendState);
+            }
+        }
+
+        @Override
+        public void onClose(Runnable cleanup) {
+            Objects.requireNonNull(cleanup, "cleanup");
+            if (isClosed()) {
+                cleanup.run();
+                return;
+            }
+            closeActions.add(cleanup);
+            if (isClosed() && closeActions.remove(cleanup)) {
+                cleanup.run();
+            }
+        }
+
+        @Override
+        public void close() {
+            boolean removed = false;
+            synchronized (HOSTS) {
+                if (!closed.get() && HOSTS.get(owner) == this) {
+                    HOSTS.remove(owner);
+                    removed = true;
+                }
+                closed.set(true);
+            }
+            if (removed) {
+                closeRuntime();
+            }
+        }
+
+        private void markClosed() {
+            closed.set(true);
+        }
+
+        private void closeRuntime() {
+            RuntimeException firstFailure = null;
+            for (Runnable action : closeActions) {
+                try {
+                    action.run();
+                } catch (RuntimeException failure) {
+                    if (firstFailure == null) {
+                        firstFailure = failure;
+                    }
+                }
+            }
+            closeActions.clear();
+            try {
+                runtime.close();
+            } catch (RuntimeException failure) {
+                if (firstFailure == null) {
+                    firstFailure = failure;
+                }
+            }
+            if (firstFailure != null) {
+                throw firstFailure;
+            }
+        }
+
+        private BigCraftingHostRuntime<AEKey> runtime() { return runtime; }
     }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRuntime.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRuntime.java
@@ -22,7 +22,7 @@ import net.minecraft.nbt.Tag;
  * {@link #reserveExternal}系で容量を予約する。ACOコマンド由来の独立親Jobだけが内部の
  * {@link BigCraftingRuntime}を使用する。双方を同じ容量から差し引き、二重予約を防ぐ。</p>
  */
-public final class BigCraftingHostRuntime<K> {
+public final class BigCraftingHostRuntime<K> implements AutoCloseable {
     public static final int SCHEMA_VERSION = 2;
     public static final int MAX_EXTERNAL_RESERVATIONS = 65_536;
     public static final int MAX_EXTERNAL_EXECUTIONS = 16_384;
@@ -41,6 +41,7 @@ public final class BigCraftingHostRuntime<K> {
     private BigInteger externalReserved = BigInteger.ZERO;
     private long externalCountBytes;
     private final BigCraftingRuntime<K> bigRuntime;
+    private boolean closed;
 
     BigCraftingHostRuntime(
             BigInteger physicalCapacity,
@@ -93,6 +94,7 @@ public final class BigCraftingHostRuntime<K> {
 
     /** 通常AE2・Advanced AE Job用の容量を原子的に予約する。 */
     public synchronized boolean reserveExternal(UUID jobId, BigInteger amount) {
+        ensureOpen();
         Objects.requireNonNull(jobId, "jobId");
         BigInteger checked = checkedPositive(amount, "external reservation", maximumBits);
         if (externalReservations.containsKey(jobId)) {
@@ -132,6 +134,7 @@ public final class BigCraftingHostRuntime<K> {
     public synchronized boolean promoteExternalReservation(
             UUID jobId,
             BigInteger exactAmount) {
+        ensureOpen();
         Objects.requireNonNull(jobId, "jobId");
         BigInteger checked = checkedPositive(exactAmount, "promoted external reservation", maximumBits);
         BigInteger previous = externalReservations.get(jobId);
@@ -174,6 +177,7 @@ public final class BigCraftingHostRuntime<K> {
      * 構造の容量が戻るかJobが完了するまで新規Jobを受理しない。</p>
      */
     public synchronized void replaceExternalReservations(Map<UUID, BigInteger> replacement) {
+        ensureOpen();
         Objects.requireNonNull(replacement, "external reservations");
         Map<UUID, BigInteger> unmanaged = new LinkedHashMap<>();
         replacement.forEach((jobId, amount) -> {
@@ -202,11 +206,13 @@ public final class BigCraftingHostRuntime<K> {
     }
 
     public synchronized void resizePhysicalCapacity(BigInteger replacement) {
+        ensureOpen();
         physicalCapacity = checkedCapacity(replacement, maximumBits);
         rebalanceBigRuntimeCapacity();
     }
 
     public synchronized boolean submit(BigCraftingJob<K> job) {
+        ensureOpen();
         Objects.requireNonNull(job, "job");
         if (available().compareTo(job.reservedCapacity()) < 0) {
             return false;
@@ -216,18 +222,21 @@ public final class BigCraftingHostRuntime<K> {
     }
 
     public synchronized List<BigCraftingRuntime.ExecutionLease<K>> schedule(long operationBudget) {
+        ensureOpen();
         return bigRuntime.schedule(operationBudget);
     }
 
     public synchronized List<BigCraftingRuntime.ExecutionLease<K>> schedule(
             long operationBudget,
             int maximumWindows) {
+        ensureOpen();
         return bigRuntime.schedule(operationBudget, maximumWindows);
     }
 
     /** Exact Vector対応設備へ渡せる、まだ子Windowを持たない親Job一覧。 */
     public synchronized List<BigCraftingRuntime.VectorCandidate<K>>
             vectorCandidates() {
+        ensureOpen();
         return bigRuntime.vectorCandidates();
     }
 
@@ -238,6 +247,7 @@ public final class BigCraftingHostRuntime<K> {
                     UUID transactionId,
                     String executorId,
                     String planFingerprint) {
+        ensureOpen();
         return bigRuntime.prepareVector(
                 jobId, transactionId, executorId, planFingerprint);
     }
@@ -252,6 +262,7 @@ public final class BigCraftingHostRuntime<K> {
                     CompoundTag executionState,
                     int progressNumerator,
                     int progressDenominator) {
+        ensureOpen();
         return bigRuntime.prepareVector(
                 jobId,
                 transactionId,
@@ -314,6 +325,7 @@ public final class BigCraftingHostRuntime<K> {
             BigCraftingRuntime.ExecutionLease<K> lease,
             UUID childCpuId,
             BigInteger childReservedCapacity) {
+        ensureOpen();
         Objects.requireNonNull(lease, "lease");
         Objects.requireNonNull(childCpuId, "childCpuId");
         BigInteger checkedCapacity = checkedPositive(
@@ -423,6 +435,33 @@ public final class BigCraftingHostRuntime<K> {
 
     public synchronized List<BigCraftingRuntime.RecoveredExecution<K>> unresolvedExecutions() {
         return bigRuntime.unresolvedExecutions();
+    }
+
+    /** 容量と予約を同一モニター内で読み取り、呼び出し側へ不変Snapshotを渡す。 */
+    public synchronized BigCraftingHostSnapshot snapshot(
+            long revision,
+            BigCraftingHostBackendState backendState) {
+        return BigCraftingHostSnapshot.of(
+                runtimeId(),
+                revision,
+                physicalCapacity,
+                reserved(),
+                externalReserved,
+                bigRuntime.reserved(),
+                externalReservations.size(),
+                bigRuntime.jobIds().size(),
+                externalExecutions.size(),
+                backendState);
+    }
+
+    /** 新規受付を止める。永続化されたJobや所有権の削除は呼び出し側が行う。 */
+    @Override
+    public synchronized void close() {
+        closed = true;
+    }
+
+    public synchronized boolean isClosed() {
+        return closed;
     }
 
     public synchronized void commitRecovered(
@@ -786,6 +825,12 @@ public final class BigCraftingHostRuntime<K> {
             return true;
         }
         return false;
+    }
+
+    private void ensureOpen() {
+        if (closed) {
+            throw new IllegalStateException("Big Crafting Host runtime is closed");
+        }
     }
 
     private record CheckedReservations(

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostSnapshot.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostSnapshot.java
@@ -1,0 +1,121 @@
+package com.syaru.ae2craftingoptimizer.api.big;
+
+import java.math.BigInteger;
+import java.util.Objects;
+import java.util.UUID;
+
+/** 一回の会計世代から取得した、分割読み取りを避ける不変Snapshot。 */
+public final class BigCraftingHostSnapshot {
+    private final UUID runtimeId;
+    private final long revision;
+    private final BigInteger physicalCapacity;
+    private final BigInteger reserved;
+    private final BigInteger available;
+    private final BigInteger externalReserved;
+    private final BigInteger bigReserved;
+    private final long standardJobCount;
+    private final long bigJobCount;
+    private final long managedChildJobCount;
+    private final boolean overcommitted;
+    private final BigCraftingHostBackendState backendState;
+
+    private BigCraftingHostSnapshot(
+            UUID runtimeId,
+            long revision,
+            BigInteger physicalCapacity,
+            BigInteger reserved,
+            BigInteger available,
+            BigInteger externalReserved,
+            BigInteger bigReserved,
+            long standardJobCount,
+            long bigJobCount,
+            long managedChildJobCount,
+            boolean overcommitted,
+            BigCraftingHostBackendState backendState) {
+        this.runtimeId = runtimeId;
+        this.revision = revision;
+        this.physicalCapacity = physicalCapacity;
+        this.reserved = reserved;
+        this.available = available;
+        this.externalReserved = externalReserved;
+        this.bigReserved = bigReserved;
+        this.standardJobCount = standardJobCount;
+        this.bigJobCount = bigJobCount;
+        this.managedChildJobCount = managedChildJobCount;
+        this.overcommitted = overcommitted;
+        this.backendState = backendState;
+    }
+
+    public static BigCraftingHostSnapshot of(
+            UUID runtimeId,
+            long revision,
+            BigInteger physicalCapacity,
+            BigInteger reserved,
+            BigInteger externalReserved,
+            BigInteger bigReserved,
+            long standardJobCount,
+            long bigJobCount,
+            long managedChildJobCount,
+            BigCraftingHostBackendState backendState) {
+        Objects.requireNonNull(runtimeId, "runtimeId");
+        if (revision < 0L) {
+            throw new IllegalArgumentException("revision must not be negative");
+        }
+        requireNonNegative(physicalCapacity, "physicalCapacity");
+        requireNonNegative(reserved, "reserved");
+        requireNonNegative(externalReserved, "externalReserved");
+        requireNonNegative(bigReserved, "bigReserved");
+        if (externalReserved.add(bigReserved).compareTo(reserved) > 0) {
+            throw new IllegalArgumentException(
+                    "external and BigInteger reservations exceed total reservation");
+        }
+        requireNonNegative(standardJobCount, "standardJobCount");
+        requireNonNegative(bigJobCount, "bigJobCount");
+        requireNonNegative(managedChildJobCount, "managedChildJobCount");
+        Objects.requireNonNull(backendState, "backendState");
+
+        boolean overcommitted = reserved.compareTo(physicalCapacity) > 0;
+        BigInteger available = overcommitted
+                ? BigInteger.ZERO
+                : physicalCapacity.subtract(reserved);
+        return new BigCraftingHostSnapshot(
+                runtimeId,
+                revision,
+                physicalCapacity,
+                reserved,
+                available,
+                externalReserved,
+                bigReserved,
+                standardJobCount,
+                bigJobCount,
+                managedChildJobCount,
+                overcommitted,
+                backendState);
+    }
+
+    public UUID runtimeId() { return runtimeId; }
+    public long revision() { return revision; }
+    public BigInteger physicalCapacity() { return physicalCapacity; }
+    public BigInteger reserved() { return reserved; }
+    public BigInteger available() { return available; }
+    public BigInteger externalReserved() { return externalReserved; }
+    public BigInteger bigReserved() { return bigReserved; }
+    public long standardJobCount() { return standardJobCount; }
+    public long bigJobCount() { return bigJobCount; }
+    public long managedChildJobCount() { return managedChildJobCount; }
+    public boolean overcommitted() { return overcommitted; }
+    public BigCraftingHostBackendState backendState() { return backendState; }
+
+    private static void requireNonNegative(BigInteger value, String name) {
+        Objects.requireNonNull(value, name);
+        if (value.signum() < 0) {
+            throw new IllegalArgumentException(name + " must not be negative");
+        }
+    }
+
+    private static void requireNonNegative(long value, String name) {
+        if (value < 0L) {
+            throw new IllegalArgumentException(name + " must not be negative");
+        }
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigIntegerCraftingPlanView.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigIntegerCraftingPlanView.java
@@ -1,0 +1,42 @@
+package com.syaru.ae2craftingoptimizer.api.big;
+
+import appeng.api.crafting.IPatternDetails;
+import appeng.api.networking.crafting.ICraftingPlan;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.GenericStack;
+import java.math.BigInteger;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable exact view of an ACO BigInteger plan for optional CPU add-ons.
+ *
+ * <p>The standard AE2 {@link ICraftingPlan} remains the compatibility facade.
+ * Add-ons that can execute bounded windows may opt into this view without
+ * depending on ACO's engine implementation classes.</p>
+ */
+public record BigIntegerCraftingPlanView(
+        GenericStack finalOutput,
+        BigInteger exactBytes,
+        boolean simulation,
+        Map<IPatternDetails, BigInteger> patternTimes,
+        Map<AEKey, BigInteger> usedItems,
+        Map<AEKey, BigInteger> emittedItems,
+        Map<AEKey, BigInteger> missingItems) {
+
+    public BigIntegerCraftingPlanView {
+        Objects.requireNonNull(finalOutput, "finalOutput");
+        Objects.requireNonNull(exactBytes, "exactBytes");
+        Objects.requireNonNull(patternTimes, "patternTimes");
+        Objects.requireNonNull(usedItems, "usedItems");
+        Objects.requireNonNull(emittedItems, "emittedItems");
+        Objects.requireNonNull(missingItems, "missingItems");
+        if (exactBytes.signum() < 0) {
+            throw new IllegalArgumentException("exactBytes must not be negative");
+        }
+        patternTimes = Map.copyOf(patternTimes);
+        usedItems = Map.copyOf(usedItems);
+        emittedItems = Map.copyOf(emittedItems);
+        missingItems = Map.copyOf(missingItems);
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
@@ -169,6 +169,7 @@ public final class ACOConfig {
     private static final ForgeConfigSpec.IntValue SLOW_CRAFT_CALCULATION_MILLIS;
     private static final ForgeConfigSpec.BooleanValue LOG_CACHE_STATISTICS;
     private static final ForgeConfigSpec.BooleanValue ENABLE_AQE_BIG_CRAFTING_PROFILE;
+    private static final ForgeConfigSpec.BooleanValue ENABLE_INSANE_AE_BIG_CRAFTING_PROFILE;
     private static final ForgeConfigSpec.BooleanValue ENABLE_LONG_ROOT_CRAFT_AMOUNTS;
     private static final ForgeConfigSpec.BooleanValue ENABLE_EXPERIMENTAL_CRAFTING_ENGINE;
     private static final ForgeConfigSpec.BooleanValue ENABLE_CRAFTING_ENGINE_SHADOW_MODE;
@@ -733,6 +734,12 @@ public final class ACOConfig {
                         "Enable only the AQE BigInteger calculation and execution path when Advanced AE and Advanced Quantum Engineering are installed.",
                         "This does not enable Native Batch, bus rewrites, terminal rewrites, or normal-AE2 authoritative replacement.")
                 .define("enableAqeBigCraftingProfile", true);
+        ENABLE_INSANE_AE_BIG_CRAFTING_PROFILE = builder
+                .comment(
+                        "Enable the same strict BigInteger calculation profile when InsaneAE is installed.",
+                        "InsaneAE's calculation batch mixin defers to ACO while this profile is active.",
+                        "This does not enable Native Batch, bus rewrites, terminal rewrites, or ambiguous recipe replacement.")
+                .define("enableInsaneAeBigCraftingProfile", true);
         ENABLE_LONG_ROOT_CRAFT_AMOUNTS = builder
                 .comment(
                         "Allow the AE2 craft-amount screen to submit root amounts from Integer.MAX_VALUE + 1 through Long.MAX_VALUE.",
@@ -1587,6 +1594,21 @@ public final class ACOConfig {
                 && ModList.get().isLoaded("advanced_quantum_engineering");
     }
 
+    /**
+     * InsaneAE搭載時だけ、AQEと同じ厳密BigInteger計算プロファイルを有効にする。
+     * 計画を作れない環境へ広い値を公開しないよう、設定とMod検出を両方確認する。
+     */
+    public static boolean enableInsaneAeBigCraftingProfile() {
+        return enableOptimizer()
+                && ENABLE_INSANE_AE_BIG_CRAFTING_PROFILE.get()
+                && ModList.get().isLoaded("insaneae");
+    }
+
+    /** AQEまたはInsaneAEがBigInteger計算の連携先として存在するか。 */
+    public static boolean enableBigCraftingProfile() {
+        return enableAqeBigCraftingProfile() || enableInsaneAeBigCraftingProfile();
+    }
+
     public static boolean enableLongRootCraftAmounts() {
         return enableOptimizer()
                 && !Ae2UelmCompatibility.ownsAe2ExtendedAmountSurface()
@@ -1617,7 +1639,7 @@ public final class ACOConfig {
 
     public static boolean enableCompiledCraftingGraph() {
         return ENABLE_COMPILED_CRAFTING_GRAPH.get()
-                && (enableExperimentalCraftingEngine() || enableAqeBigCraftingProfile());
+                && (enableExperimentalCraftingEngine() || enableBigCraftingProfile());
     }
 
     public static boolean enableAuthoritativeCompiledPlanner() {
@@ -1630,7 +1652,7 @@ public final class ACOConfig {
 
     public static boolean enableCheckedAe2CraftingArithmetic() {
         return ENABLE_CHECKED_AE2_CRAFTING_ARITHMETIC.get()
-                && (enableExperimentalCraftingEngine() || enableAqeBigCraftingProfile());
+                && (enableExperimentalCraftingEngine() || enableBigCraftingProfile());
     }
 
     public static boolean enableTransactionalBatchingV2() {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
@@ -240,12 +240,19 @@ public final class Ae2AuthoritativeCraftingPlanner {
             CalculationStrategy strategy,
             OverflowPromotingCraftingPlanner.Result<AEKey> promoted,
             boolean requiresBigIntegerExecution) {
-        // 個別long超過はBigInteger Plannerの正確な結果からだけ親Jobへ変換する。
-        if (!(promoted instanceof OverflowPromotingCraftingPlanner.BigResult<AEKey> bigResult)
-                || !ACOConfig.enableBigIntegerGameplayExecution()) {
+        if (!ACOConfig.enableBigIntegerGameplayExecution()) {
             return null;
         }
-        BigCraftingPlan<AEKey> exactPlan = bigResult.plan();
+        BigCraftingPlan<AEKey> exactPlan;
+        if (promoted instanceof OverflowPromotingCraftingPlanner.BigResult<AEKey> bigResult) {
+            // 途中の掛け算がoverflowした場合は、Plannerが最初から作ったBigInteger結果を使う。
+            exactPlan = bigResult.plan();
+        } else if (promoted instanceof OverflowPromotingCraftingPlanner.LongResult<AEKey> longResult) {
+            // 個別値はlong内でも合計だけが超過する場合は、long結果を無損失でBigIntegerへ昇格する。
+            exactPlan = widenLongPlan(longResult.plan());
+        } else {
+            return null;
+        }
         // CRAFT_LESSはAE2固有の部分成功探索を持つため、ACOが近似した結果へ置き換えない。
         if (!exactPlan.craftable() && strategy == CalculationStrategy.CRAFT_LESS) {
             return null;
@@ -294,6 +301,26 @@ public final class Ae2AuthoritativeCraftingPlanner {
                 requiresBigIntegerExecution);
         // AE2と周辺アドオンへは必ず最終実装CraftingPlanを返し、BigInteger真値はSidecarへ置く。
         return Ae2CraftingPlanSidecars.expose(metadata);
+    }
+
+    private static BigCraftingPlan<AEKey> widenLongPlan(LongCraftingPlan<AEKey> source) {
+        Objects.requireNonNull(source, "source");
+        // long値を文字列経由にせず、BigInteger.valueOfで符号反転のない昇格を行う。
+        return new BigCraftingPlan<>(
+                source.requestedKey(),
+                BigInteger.valueOf(source.requestedAmount()),
+                widenLongMap(source.patternExecutions()),
+                widenLongMap(source.usedInventory()),
+                widenLongMap(source.emitted()),
+                widenLongMap(source.missing()),
+                0);
+    }
+
+    private static <K> Map<K, BigInteger> widenLongMap(Map<K, Long> source) {
+        Map<K, BigInteger> widened = new LinkedHashMap<>();
+        // 既存の正確なlong会計をキーごとに一度だけBigIntegerへ写す。
+        source.forEach((key, amount) -> widened.put(key, BigInteger.valueOf(amount)));
+        return Map.copyOf(widened);
     }
 
     @Nullable

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
@@ -162,8 +162,10 @@ public final class Ae2AuthoritativeCraftingPlanner {
             }
             NormalizedPlan symbolic = normalize(promoted);
             ICraftingPlan result;
-            // 個別値がlongを超える場合、標準AE2 Jobへ丸めずAQE専用のBig親Jobを作る。
-            if (symbolic == null) {
+            // 個別値またはキー別合計がlongを超える場合、通常AE2 Jobへ戻さずBig親Jobを作る。
+            boolean bigIntegerExecutionRequired = symbolic == null
+                    || symbolic.hasAggregatePastLong();
+            if (bigIntegerExecutionRequired) {
                 result = createBigIntegerParentPlan(
                         capture,
                         graphSnapshot,
@@ -172,7 +174,8 @@ public final class Ae2AuthoritativeCraftingPlanner {
                         output,
                         requestedAmount,
                         strategy,
-                        promoted);
+                        promoted,
+                        true);
                 // 厳格な親Jobへ変換できない経路は、値を近似せずAE2本来の計算へ戻す。
                 if (result == null) {
                     return null;
@@ -235,7 +238,8 @@ public final class Ae2AuthoritativeCraftingPlanner {
             AEKey output,
             long requestedAmount,
             CalculationStrategy strategy,
-            OverflowPromotingCraftingPlanner.Result<AEKey> promoted) {
+            OverflowPromotingCraftingPlanner.Result<AEKey> promoted,
+            boolean requiresBigIntegerExecution) {
         // 個別long超過はBigInteger Plannerの正確な結果からだけ親Jobへ変換する。
         if (!(promoted instanceof OverflowPromotingCraftingPlanner.BigResult<AEKey> bigResult)
                 || !ACOConfig.enableBigIntegerGameplayExecution()) {
@@ -286,7 +290,8 @@ public final class Ae2AuthoritativeCraftingPlanner {
                 new GenericStack(output, requestedAmount),
                 exactPlan,
                 exactPatternTimes,
-                prepared);
+                prepared,
+                requiresBigIntegerExecution);
         // AE2と周辺アドオンへは必ず最終実装CraftingPlanを返し、BigInteger真値はSidecarへ置く。
         return Ae2CraftingPlanSidecars.expose(metadata);
     }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
@@ -115,18 +115,18 @@ public final class Ae2AuthoritativeCraftingPlanner {
 
             BigKeyCounterSidecars.Snapshot inventoryMetadata =
                     BigKeyCounterSidecars.snapshot(capture.inventorySnapshot()).orElse(null);
-            // Adapter失敗を含む不完全Snapshotは、飽和値から不足数を推測せずAE2へ戻す。
-            if (inventoryMetadata != null && !inventoryMetadata.complete()) {
-                return null;
-            }
             CompiledRootProgram.BigInventorySnapshot<AEKey> exactPlanningInventory =
                     Ae2ReferencedInventory.captureExactNetworkSnapshot(
                             program,
                             capture.inventorySnapshot(),
                             output);
             CompiledRootProgram.InventorySnapshot<AEKey> planningInventory = null;
-            // 正確なSidecarが無い通常AE2環境だけ、従来のlong Snapshotを使用する。
+            // 参照キーを個別に証明できない場合だけ、通常AE2のlong Snapshotへ戻す。
             if (exactPlanningInventory == null) {
+                // 不完全Sidecarを飽和longとしてBig計画へ渡すと、在庫不足を誤って充足扱いにする。
+                if (inventoryMetadata != null && !inventoryMetadata.complete()) {
+                    return null;
+                }
                 planningInventory = Ae2ReferencedInventory.captureNetworkSnapshot(
                         program,
                         capture.inventorySnapshot(),

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2ReferencedInventory.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2ReferencedInventory.java
@@ -27,7 +27,8 @@ final class Ae2ReferencedInventory {
 
     /**
      * NetworkCraftingSimulationStateへ伝播した正確なSidecarから、参照キーだけを固定する。
-     * Sidecarが不完全ならnullを返し、呼出側はAE2標準またはlong経路へ戻る。
+     * Sidecar全体が不完全でも、計画が参照するキーを個別に証明できれば採用する。
+     * 参照キーのどれかが不明な場合だけnullを返し、呼出側は安全な経路へ戻る。
      */
     @Nullable
     static CompiledRootProgram.BigInventorySnapshot<AEKey> captureExactNetworkSnapshot(
@@ -36,8 +37,8 @@ final class Ae2ReferencedInventory {
             AEKey requestedOutput) {
         BigKeyCounterSidecars.Snapshot exact =
                 BigKeyCounterSidecars.snapshot(networkSnapshot).orElse(null);
-        // 一部storageの正確値を取得できなかったSnapshotは、在庫を推測せず採用しない。
-        if (exact == null || !exact.complete()) {
+        // 無関係なキーのアダプター失敗だけで、対象クラフト全体を捨てない。
+        if (exact == null || !hasExactReferencedKeys(program, exact, requestedOutput)) {
             return null;
         }
         return program.captureBigInventory(
@@ -80,8 +81,8 @@ final class Ae2ReferencedInventory {
         KeyCounter cached = grid.getStorageService().getCachedInventory();
         BigKeyCounterSidecars.Snapshot exact =
                 BigKeyCounterSidecars.snapshot(cached).orElse(null);
-        // 再検証時にSidecarが失われた場合は、丸めたlong値で一致扱いにしない。
-        if (exact == null || !exact.complete()) {
+        // 再検証時も、計画が参照するキーだけはBigInteger正本で一致を確認する。
+        if (exact == null || !hasExactReferencedKeys(program, exact, requestedOutput)) {
             return false;
         }
         return program.inventoryMatches(
@@ -90,6 +91,20 @@ final class Ae2ReferencedInventory {
                         ? BigInteger.ZERO
                         : liveExactAmount(grid, source, cached, exact, key),
                 ACOConfig.getBigIntegerMaximumBits());
+    }
+
+    private static boolean hasExactReferencedKeys(
+            CompiledRootProgram<AEKey> program,
+            BigKeyCounterSidecars.Snapshot exact,
+            AEKey requestedOutput) {
+        for (int node = 0; node < program.nodeCount(); node++) {
+            AEKey key = program.keyAt(node);
+            // AE2は注文の完成品を在庫計算から除外するため、出力自身は検証対象にしない。
+            if (!key.equals(requestedOutput) && !exact.isExact(key)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static long liveAmount(IGrid grid, IActionSource source, AEKey key) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerCraftingPlan.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerCraftingPlan.java
@@ -36,6 +36,15 @@ public final class BigIntegerCraftingPlan implements WideCraftingPlan {
             BigCraftingPlan<AEKey> exactPlan,
             Map<IPatternDetails, BigInteger> exactPatternTimes,
             Ae2BigCraftingPlanFactory.PreparedBigRootPlan preparedRoot) {
+        this(finalOutput, exactPlan, exactPatternTimes, preparedRoot, false);
+    }
+
+    public BigIntegerCraftingPlan(
+            GenericStack finalOutput,
+            BigCraftingPlan<AEKey> exactPlan,
+            Map<IPatternDetails, BigInteger> exactPatternTimes,
+            Ae2BigCraftingPlanFactory.PreparedBigRootPlan preparedRoot,
+            boolean requiresBigIntegerExecution) {
         this.finalOutput = Objects.requireNonNull(finalOutput, "finalOutput");
         this.exactPlan = Objects.requireNonNull(exactPlan, "exactPlan");
         this.exactPatternTimes = immutablePositiveCounts(
@@ -48,10 +57,11 @@ public final class BigIntegerCraftingPlan implements WideCraftingPlan {
                 || !preparedRoot.reservedBytes().equals(preparedRoot.job().reservedCapacity())) {
             throw new IllegalArgumentException("BigInteger plan metadata is inconsistent");
         }
-        // この型は少なくとも一つの個別カウンタがlongを超える計画だけを運ぶ。
-        if (!containsWideCounter(exactPlan, this.exactPatternTimes)) {
+        // 個別値がlong超過、またはキー別合計がlong超過してAE2の乗算を使えない計画だけを運ぶ。
+        if (!requiresBigIntegerExecution
+                && !containsWideCounter(exactPlan, this.exactPatternTimes)) {
             throw new IllegalArgumentException(
-                    "BigInteger crafting plan requires at least one counter past signed long");
+                    "BigInteger crafting plan requires an exact-arithmetic reason");
         }
         this.usedItems = projectKeyCounter(exactPlan.usedInventory());
         this.emittedItems = projectKeyCounter(exactPlan.emitted());

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerCraftingPlan.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerCraftingPlan.java
@@ -57,7 +57,7 @@ public final class BigIntegerCraftingPlan implements WideCraftingPlan {
                 || !preparedRoot.reservedBytes().equals(preparedRoot.job().reservedCapacity())) {
             throw new IllegalArgumentException("BigInteger plan metadata is inconsistent");
         }
-        // 個別値がlong超過、またはキー別合計がlong超過してAE2の乗算を使えない計画だけを運ぶ。
+        // 個別値またはキー別合計がlong超過してAE2の乗算を使えない計画だけを運ぶ。
         if (!requiresBigIntegerExecution
                 && !containsWideCounter(exactPlan, this.exactPatternTimes)) {
             throw new IllegalArgumentException(

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigKeyCounterSidecars.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigKeyCounterSidecars.java
@@ -7,9 +7,11 @@ import java.lang.ref.WeakReference;
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * AE2のlong {@link KeyCounter}へ対応する、正確なBigInteger在庫Snapshot。
@@ -41,13 +43,24 @@ public final class BigKeyCounterSidecars {
             }
 
             Map<AEKey, BigInteger> merged = new LinkedHashMap<>(current.amounts());
+            Set<AEKey> exactKeys = new LinkedHashSet<>(current.exactKeys());
             // 同一キーをBigIntegerで加算し、long境界を越えても負数へ巻き戻さない。
             for (Map.Entry<AEKey, BigInteger> entry : contribution.amounts().entrySet()) {
                 merged.merge(entry.getKey(), entry.getValue(), BigInteger::add);
+                // 現在値と今回の寄与の両方が正確なキーだけ、合計値も正確と証明できる。
+                if (current.isExact(entry.getKey())
+                        && contribution.isExact(entry.getKey())) {
+                    exactKeys.add(entry.getKey());
+                } else {
+                    exactKeys.remove(entry.getKey());
+                }
             }
             SIDECARS.put(
                     new IdentityWeakReference(target, COLLECTED_COUNTERS),
-                    new Snapshot(merged, current.complete() && contribution.complete()));
+                    new Snapshot(
+                            merged,
+                            current.complete() && contribution.complete(),
+                            exactKeys));
         }
     }
 
@@ -69,7 +82,14 @@ public final class BigKeyCounterSidecars {
                 visible.put(entry.getKey(), entry.getValue());
             }
         }
-        put(target, new Snapshot(visible, sourceSnapshot.complete()));
+        Set<AEKey> exactVisible = new LinkedHashSet<>();
+        for (AEKey key : sourceSnapshot.exactKeys()) {
+            // 画面側Counterに存在しないキーを正確在庫として復活させない。
+            if (visible.containsKey(key)) {
+                exactVisible.add(key);
+            }
+        }
+        put(target, new Snapshot(visible, sourceSnapshot.complete(), exactVisible));
     }
 
     /** long FacadeとBigInteger Sidecarを一つの独立したKeyCounterへ複製する。 */
@@ -114,7 +134,7 @@ public final class BigKeyCounterSidecars {
                 amounts.put(entry.getKey(), BigInteger.valueOf(amount));
             }
         }
-        return new Snapshot(amounts, complete);
+        return new Snapshot(amounts, complete, amounts.keySet());
     }
 
     /** 単体テスト間でstatic Sidecarを共有しないためのreset。 */
@@ -146,9 +166,18 @@ public final class BigKeyCounterSidecars {
     }
 
     /** 一回の在庫集計に対応する不変BigInteger Map。 */
-    public record Snapshot(Map<AEKey, BigInteger> amounts, boolean complete) {
+    public record Snapshot(
+            Map<AEKey, BigInteger> amounts,
+            boolean complete,
+            Set<AEKey> exactKeys) {
+        /** 既存アダプター向けの簡略コンストラクター。false時はキー単位の証明も持たない。 */
+        public Snapshot(Map<AEKey, BigInteger> amounts, boolean complete) {
+            this(amounts, complete, complete ? amounts.keySet() : Set.of());
+        }
+
         public Snapshot {
             Objects.requireNonNull(amounts, "amounts");
+            Objects.requireNonNull(exactKeys, "exactKeys");
             Map<AEKey, BigInteger> checked = new LinkedHashMap<>();
             // 不正な負数やnullをSidecarへ入れず、計画時の在庫過大評価を防ぐ。
             for (Map.Entry<AEKey, BigInteger> entry : amounts.entrySet()) {
@@ -166,10 +195,27 @@ public final class BigKeyCounterSidecars {
                 }
             }
             amounts = Map.copyOf(checked);
+
+            Set<AEKey> checkedExactKeys = new LinkedHashSet<>();
+            for (AEKey key : exactKeys) {
+                Objects.requireNonNull(key, "exact inventory key");
+                // 0量はMapへ保持しないため、正確性集合にも登録しない。
+                if (checked.containsKey(key)) {
+                    checkedExactKeys.add(key);
+                }
+            }
+            exactKeys = Set.copyOf(checkedExactKeys);
         }
 
         public BigInteger amount(AEKey key) {
             return amounts.getOrDefault(Objects.requireNonNull(key, "key"), BigInteger.ZERO);
+        }
+
+        /** 指定キーの値が、ネットワーク内の不完全な別キーに影響されず確定しているか返す。 */
+        public boolean isExact(AEKey key) {
+            Objects.requireNonNull(key, "key");
+            // 完全Snapshotでは、Mapにないキーの0も正確に証明できる。
+            return complete || exactKeys.contains(key);
         }
 
         public boolean containsWideValue() {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOStartupReport.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOStartupReport.java
@@ -181,9 +181,10 @@ final class ACOStartupReport {
                 ACOConfig.coalesceAssemblerMatrixStatusUpdates());
         logDeepRewriteFlags();
         AE2CraftingOptimizer.LOGGER.info(
-                "ACO experimental crafting engine: {} (AQE profile {}, shadow {}, compiled graph {}, proof-qualified long plans {}, transaction V2 {}, GT native {}, Mekanism native {}, fair scheduler {}, persistent journal {})",
+                "ACO experimental crafting engine: {} (AQE profile {}, InsaneAE profile {}, shadow {}, compiled graph {}, proof-qualified long plans {}, transaction V2 {}, GT native {}, Mekanism native {}, fair scheduler {}, persistent journal {})",
                 ACOConfig.enableExperimentalCraftingEngine(),
                 ACOConfig.enableAqeBigCraftingProfile(),
+                ACOConfig.enableInsaneAeBigCraftingProfile(),
                 ACOConfig.enableCraftingEngineShadowMode(),
                 ACOConfig.enableCompiledCraftingGraph(),
                 ACOConfig.enableProofQualifiedLongPlans(),

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCpuClusterBigCapacityGuardMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCpuClusterBigCapacityGuardMixin.java
@@ -8,6 +8,7 @@ import appeng.api.networking.security.IActionSource;
 import appeng.crafting.execution.CraftingSubmitResult;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
 import com.syaru.ae2craftingoptimizer.access.BigCapacityPlanBoundaryAccess;
+import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -26,7 +27,11 @@ public abstract class CraftingCpuClusterBigCapacityGuardMixin
             ICraftingRequester requester,
             CallbackInfoReturnable<ICraftingSubmitResult> cir) {
         // Long.MAXは真の容量ではないため、対応Sidecarを持たない標準CPUでは実行しない。
-        if (Ae2CraftingPlanSidecars.isWide(plan)) {
+        boolean insaneAeExactPlan = ACOConfig.enableInsaneAeBigCraftingProfile()
+                && Ae2CraftingPlanSidecars.bigInteger(plan).isPresent();
+        // InsaneAE専用のExact受け渡しだけはInsaneAE側が同じPlanを所有するため通す。
+        // 容量だけをlongへ飽和したBigCapacity計画は標準CPUへ絶対に渡さない。
+        if (Ae2CraftingPlanSidecars.isWide(plan) && !insaneAeExactPlan) {
             cir.setReturnValue(CraftingSubmitResult.CPU_TOO_SMALL);
         }
     }

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/CompiledRootProgramTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/CompiledRootProgramTest.java
@@ -66,6 +66,26 @@ class CompiledRootProgramTest {
     }
 
     @Test
+    void promotesPatternInputWhenEightTimesTwoToTheSixtiethWouldOverflowLong() {
+        var program = compile(
+                List.of(pattern("output", "gas", 8L, "output", 1L)),
+                "output");
+        var inventory = program.captureLongInventory(ignored -> 0L);
+        BigInteger requested = BigInteger.ONE.shiftLeft(60);
+
+        var result = new OverflowPromotingCraftingPlanner<String>().plan(
+                program,
+                requested,
+                inventory,
+                PlanningGuard.none());
+
+        var big = assertInstanceOf(OverflowPromotingCraftingPlanner.BigResult.class, result);
+        assertEquals(
+                BigInteger.ONE.shiftLeft(63),
+                big.plan().missing().get("gas"));
+    }
+
+    @Test
     void keepsTwoLongMaximumChemicalInputsExactAfterPromotion() {
         var output = new CompiledPattern<>(
                 "pressurized-reaction",

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/BigIntegerStorageSnapshotBridgeTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/BigIntegerStorageSnapshotBridgeTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 class BigIntegerStorageSnapshotBridgeTest {
     private static final TestKey TEST_KEY = new TestKey();
+    private static final TestKey UNRELATED_KEY = new TestKey();
     private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
     /** tick番号自体に意味を持たせず、同一tick判定だけを検証する固定値。 */
     private static final long CACHE_TEST_TICK = 42L;
@@ -120,6 +121,29 @@ class BigIntegerStorageSnapshotBridgeTest {
         BigKeyCounterSidecars.Snapshot exact =
                 BigKeyCounterSidecars.snapshot(network).orElseThrow();
         assertFalse(exact.complete());
+    }
+
+    @Test
+    void keepsExactnessForAReferencedKeyWhenAnUnrelatedContributionIsIncomplete() {
+        KeyCounter network = new KeyCounter();
+
+        BigKeyCounterSidecars.merge(
+                network,
+                new BigKeyCounterSidecars.Snapshot(
+                        Map.of(TEST_KEY, BigInteger.TEN),
+                        true));
+        // 別キーのadapter失敗だけを再現し、TEST_KEYの正確値まで無効化しないことを確認する。
+        BigKeyCounterSidecars.merge(
+                network,
+                new BigKeyCounterSidecars.Snapshot(
+                        Map.of(UNRELATED_KEY, BigInteger.ONE),
+                        false));
+
+        BigKeyCounterSidecars.Snapshot snapshot =
+                BigKeyCounterSidecars.snapshot(network).orElseThrow();
+        assertFalse(snapshot.complete());
+        assertTrue(snapshot.isExact(TEST_KEY));
+        assertFalse(snapshot.isExact(UNRELATED_KEY));
     }
 
     @Test


### PR DESCRIPTION
## 概要

InsaneAE の Quantum CPU 実行経路が ACO の BigInteger 計画を AE2 標準の long 計画として再処理し、`CraftingTreeProcessCheckedMathMixin` の境界検査へ到達して `CountOverflowException` になる問題を修正します。

## 変更内容

- `BigIntegerCraftingPlanView` と calculation-profile API を公開
- InsaneAE が競合する計算バッチを重ねないための capability query を追加
- InsaneAE profile 有効時は ACO の BigInteger sidecar を標準計画に紐付ける
- InsaneAE が Exact Pattern 回数を読み取れるように immutable view を提供
- BigInteger 計画だけは容量ガードを InsaneAE の受理経路へ渡す
- 通常の AE2 計画、AQE、未対応アドオンの経路は変更しない
- Forge 1.20.1 の実行契約と mod discovery を確認

## 検証

- `gradlew.bat clean test build --no-daemon` 成功
- Forge 1.20.1 の clean build 成功
- 実環境の起動・クラフト試験は別途実施

Refs #42
Refs #46
