### PR TITLE
Fix BigInteger reservations and InsaneAE Mixin compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- Synchronized Advanced AE CPU reservations before exact BigInteger promotion.
+- Kept ACO's transaction receipt state API applied when InsaneAE is installed,
+  while continuing to delegate overlapping execution hooks to InsaneAE.
+- Added regression coverage for fully qualified Mixin names so the compatibility
+  audit cannot fail from the same over-broad exclusion again.
+
 ## [1.5.15] - 2026-08-13
 
 ### Added

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AcoMixinPlugin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AcoMixinPlugin.java
@@ -27,12 +27,12 @@ public final class AcoMixinPlugin implements IMixinConfigPlugin {
         return !Ae2UelmCompatibility.ownsAe2SurfaceMixin(mixinClassName);
     }
 
-    private static boolean isInsaneAeOwnedExecutionMixin(String mixinClassName) {
+    static boolean isInsaneAeOwnedExecutionMixin(String mixinClassName) {
         String simpleName = simpleMixinName(mixinClassName);
         return switch (simpleName) {
-            // AE2 CraftingCpuLogicの予算計算はInsaneAE側のlong実装へ委譲する。
+            // 実行予算と実行入口だけをInsaneAEへ委譲する。
+            // BatchSourceReceiptMixinは実行を変更せず、V2会計に必要な状態APIを付与するため残す。
             case "CraftingCpuLogicExecutionBudgetMixin",
-                    "CraftingCpuLogicBatchSourceReceiptMixin",
                     "CraftingCpuLogicTransactionalBatchV2Mixin",
                     // Advanced AEの通常executeCraftingもInsaneAE側の互換Mixinを優先する。
                     "AdvancedAeCraftingCpuLogicExecutionBudgetMixin",

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AcoMixinPlugin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AcoMixinPlugin.java
@@ -28,7 +28,8 @@ public final class AcoMixinPlugin implements IMixinConfigPlugin {
     }
 
     private static boolean isInsaneAeOwnedExecutionMixin(String mixinClassName) {
-        return switch (mixinClassName) {
+        String simpleName = simpleMixinName(mixinClassName);
+        return switch (simpleName) {
             // AE2 CraftingCpuLogicの予算計算はInsaneAE側のlong実装へ委譲する。
             case "CraftingCpuLogicExecutionBudgetMixin",
                     "CraftingCpuLogicBatchSourceReceiptMixin",
@@ -38,6 +39,15 @@ public final class AcoMixinPlugin implements IMixinConfigPlugin {
                     "AdvancedAeCraftingCpuLogicTransactionalBatchV2Mixin" -> true;
             default -> false;
         };
+    }
+
+    /**
+     * Mixinが渡す完全修飾名から、登録名との比較に使う単純名を取り出す。
+     * 実行時の値はパッケージ付きになるため、単純名へ正規化しないと競合除外が働かない。
+     */
+    private static String simpleMixinName(String mixinClassName) {
+        int separator = mixinClassName.lastIndexOf('.');
+        return separator >= 0 ? mixinClassName.substring(separator + 1) : mixinClassName;
     }
 
     private static boolean isInsaneAeLoadedDuringBootstrap() {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AcoMixinPlugin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AcoMixinPlugin.java
@@ -15,10 +15,38 @@ import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 public final class AcoMixinPlugin implements IMixinConfigPlugin {
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        // InsaneAEが同じAE2実行入口を所有する場合は、ACOの予算・通常Batch入口を重ねない。
+        // BigInteger会計とAQE専用のAdvanced AE連携Mixinはこの除外対象に含めない。
+        if (isInsaneAeLoadedDuringBootstrap()
+                && isInsaneAeOwnedExecutionMixin(mixinClassName)) {
+            return false;
+        }
         if (!isUelmLoadedDuringBootstrap()) {
             return true;
         }
         return !Ae2UelmCompatibility.ownsAe2SurfaceMixin(mixinClassName);
+    }
+
+    private static boolean isInsaneAeOwnedExecutionMixin(String mixinClassName) {
+        return switch (mixinClassName) {
+            // AE2 CraftingCpuLogicの予算計算はInsaneAE側のlong実装へ委譲する。
+            case "CraftingCpuLogicExecutionBudgetMixin",
+                    "CraftingCpuLogicBatchSourceReceiptMixin",
+                    "CraftingCpuLogicTransactionalBatchV2Mixin",
+                    // Advanced AEの通常executeCraftingもInsaneAE側の互換Mixinを優先する。
+                    "AdvancedAeCraftingCpuLogicExecutionBudgetMixin",
+                    "AdvancedAeCraftingCpuLogicTransactionalBatchV2Mixin" -> true;
+            default -> false;
+        };
+    }
+
+    private static boolean isInsaneAeLoadedDuringBootstrap() {
+        try {
+            return FMLLoader.getLoadingModList().getModFileById("insaneae") != null;
+        } catch (RuntimeException | LinkageError ignored) {
+            // 起動初期に判定できない場合は、既存のACO経路を維持する。
+            return false;
+        }
     }
 
     private static boolean isUelmLoadedDuringBootstrap() {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeBigCapacityPlanSubmissionMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeBigCapacityPlanSubmissionMixin.java
@@ -250,7 +250,16 @@ public abstract class AdvancedAeBigCapacityPlanSubmissionMixin
         BigInteger exactBytes = bigIntegerPlan != null
                 ? bigIntegerPlan.exactBytes()
                 : bigPlan.exactBytes();
-        boolean promoted = host != null
+        /*
+         * Advanced AE inserts the new CPU into activeCpus before this RETURN
+         * callback, while AQE's normal reconciliation is deferred until the
+         * next storage read. Synchronize that just-created facade reservation
+         * before promotion, otherwise previous == null is reported even when
+         * the host has sufficient exact BigInteger capacity.
+         */
+        boolean reservationsSynchronized = host != null
+                && aco$synchronizeActiveCpuReservations(host);
+        boolean promoted = reservationsSynchronized
                 && host.promoteExternalReservation(cpuId, exactBytes);
         // Sidecar昇格に失敗したJobを互換値Long.MAXのまま動かさず、Advanced AEの取消処理へ戻す。
         if (!promoted) {
@@ -294,6 +303,30 @@ public abstract class AdvancedAeBigCapacityPlanSubmissionMixin
         AdvCraftingCPUCluster cluster = (AdvCraftingCPUCluster) (Object) this;
         cluster.recalculateRemainingStorage();
         cluster.markDirty();
+    }
+
+    /** ACO側の外部予約を、提出直後のAdvanced AE CPU一覧へ追いつける。 */
+    @Unique
+    private boolean aco$synchronizeActiveCpuReservations(
+            com.syaru.ae2craftingoptimizer.api.big.BigCraftingHostRuntime<?> host) {
+        Map<UUID, BigInteger> reservations = new LinkedHashMap<>();
+        // Advanced AEが現在所有している全CPUを一度だけ走査し、互換long予約を再構築する。
+        for (var entry : activeCpus.entrySet()) {
+            AdvCraftingCPU cpu = entry.getValue();
+            // null/ゼロ容量の削除済みCPUはACOの外部予約へ戻さない。
+            if (cpu != null && cpu.getAvailableStorage() > 0L) {
+                reservations.put(entry.getKey(), BigInteger.valueOf(cpu.getAvailableStorage()));
+            }
+        }
+        try {
+            host.replaceExternalReservations(reservations);
+            return true;
+        } catch (RuntimeException | LinkageError failure) {
+            AE2CraftingOptimizer.LOGGER.error(
+                    "ACO could not synchronize Advanced AE CPU reservations before exact promotion",
+                    failure);
+            return false;
+        }
     }
 
     @Unique

--- a/src/test/java/com/syaru/ae2craftingoptimizer/mixin/AcoMixinPluginTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/mixin/AcoMixinPluginTest.java
@@ -1,0 +1,28 @@
+package com.syaru.ae2craftingoptimizer.mixin;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class AcoMixinPluginTest {
+    @Test
+    void keepsTransactionStateApiWhenInsaneAeIsInstalled() {
+        assertFalse(AcoMixinPlugin.isInsaneAeOwnedExecutionMixin(
+                "com.syaru.ae2craftingoptimizer.mixin.CraftingCpuLogicBatchSourceReceiptMixin"));
+        assertFalse(AcoMixinPlugin.isInsaneAeOwnedExecutionMixin(
+                "com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingCpuLogicBatchSourceReceiptMixin"));
+    }
+
+    @Test
+    void delegatesOnlyExecutionHooksToInsaneAe() {
+        assertTrue(AcoMixinPlugin.isInsaneAeOwnedExecutionMixin(
+                "com.syaru.ae2craftingoptimizer.mixin.CraftingCpuLogicExecutionBudgetMixin"));
+        assertTrue(AcoMixinPlugin.isInsaneAeOwnedExecutionMixin(
+                "com.syaru.ae2craftingoptimizer.mixin.CraftingCpuLogicTransactionalBatchV2Mixin"));
+        assertTrue(AcoMixinPlugin.isInsaneAeOwnedExecutionMixin(
+                "com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingCpuLogicExecutionBudgetMixin"));
+        assertTrue(AcoMixinPlugin.isInsaneAeOwnedExecutionMixin(
+                "com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingCpuLogicTransactionalBatchV2Mixin"));
+    }
+}


### PR DESCRIPTION
## 目的

Forge 1.20.1で、Advanced AEのBigInteger Quantum CPU予約昇格と、InsaneAE併用時のACO Mixin境界を修正します。

Closes #51

## Advanced AE予約

- BigInteger昇格直前に現在のCPU一覧を外部予約へ同期
- 既存BigInteger予約を`Long.MAX_VALUE`互換値で上書きしない
- 正確な容量比較と予約昇格を維持

## InsaneAE境界

- InsaneAEと重なる実行予算・実行入口Mixinだけを除外
- V2会計状態を提供する`CraftingCpuLogicBatchSourceReceiptMixin`は維持
- 完全修飾Mixin名を使う回帰テストで除外範囲を固定
- InsaneAEのQuantum CPU実行ロジックには介入しない

## 現行ベースへの再検証

- `mc/1.20.1`（ACO 1.5.15）へrebase済み
- `gradlew.bat clean build --no-daemon`: 成功
- `git diff --check`: 成功

Minecraftクライアント、専用サーバー、GameTestの起動は実施していません。
