### PR TITLE
feat(api): BigInteger上限とAEKey台帳を公開する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- Added a versioned public capacity-limit query for BigInteger CPU add-ons.
+- Added AEKey amount-ledger factories so optional integrations do not need to
+  resolve ACO's internal codec type.
+
 ### Fixed
 
 - Added an optional InsaneAE calculation profile. When enabled, ACO owns the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,6 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
-### Added
-
-- Added a versioned public capacity-limit query for BigInteger CPU add-ons.
-- Added AEKey amount-ledger factories so optional integrations do not need to
-  resolve ACO's internal codec type.
-
-### Fixed
-
-- Added an optional InsaneAE calculation profile. When enabled, ACO owns the
-  strict compiled/BigInteger calculation boundary instead of allowing the
-  InsaneAE calculation batch to pass an overflowing `long` request into AE2.
-- Added a public calculation-profile capability query for optional CPU add-ons.
-
 ## [1.5.12] - 2026-08-11
 
 ### Added
@@ -25,11 +12,18 @@ All notable changes to this project are documented here.
   crafting CPU add-ons.
 - Added the public exact amount ledger and calculation-profile compatibility
   contracts for Forge 1.20.1.
+- Added a versioned public capacity-limit query and AEKey amount-ledger
+  factories for optional CPU add-ons.
+- Added an optional InsaneAE calculation profile and a public capability query.
 
 ### Fixed
 
 - Promoted aggregate long overflow to the BigInteger host instead of sending a
   wrapped or clamped value into AE2's checked long calculation.
+- Made ACO own the strict compiled/BigInteger calculation boundary when the
+  InsaneAE profile is enabled.
+- Returned pending BigInteger windows before optional hosts close during
+  shutdown.
 
 ## [1.5.11] - 2026-08-11
 

--- a/docs/EXPERIMENTAL_ENGINE.md
+++ b/docs/EXPERIMENTAL_ENGINE.md
@@ -267,6 +267,11 @@ return to AE2 before source ownership changes.
 It does not automatically patch standard AE2 or Advanced AE CPUs.
 
 - API version: `3`.
+- Amount-ledger API version: `2`. AE2 add-ons use
+  `createAeKeyAmountLedger()` and `loadAeKeyAmountLedger()` without resolving
+  ACO's internal codec types.
+- Capacity-limit API version: `1`. `maximumSupportedAmount()` returns the
+  exact configured BigInteger bound after applying ACO's hard safety limit.
 - One shared host reconciles external signed-long job reservations and native
   BigInteger jobs against the same physical capacity.
 - Runtime NBT schema: `2`, including a persistent runtime UUID.

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java
@@ -2,6 +2,7 @@ package com.syaru.ae2craftingoptimizer.api.big;
 
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.engine.BigCraftingKeyCodec;
+import com.syaru.ae2craftingoptimizer.engine.BigCountMath;
 import com.syaru.ae2craftingoptimizer.engine.OverflowPromotingCraftingPlanner;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
 import com.syaru.ae2craftingoptimizer.engine.BigIntegerCraftingPlan;
@@ -19,15 +20,43 @@ public final class BigCraftingEngineApi {
     /** Existing AQE host API contract. Keep this stable when adding optional API surfaces. */
     public static final int API_VERSION = 3;
     /** Version of the exact amount-ledger surface added for crafting add-ons. */
-    public static final int AMOUNT_LEDGER_API_VERSION = 1;
+    public static final int AMOUNT_LEDGER_API_VERSION = 2;
     /** Version of the optional AE2 calculation-profile query used by CPU add-ons. */
     public static final int CALCULATION_PROFILE_API_VERSION = 1;
+    /** アドオンがACOの正確なBigInteger上限を照会するAPIの契約番号。 */
+    public static final int CAPACITY_LIMIT_API_VERSION = 1;
 
     private BigCraftingEngineApi() {
     }
 
     public static boolean isEnabled() {
         return ACOConfig.enableBigIntegerCraftingBackend();
+    }
+
+    /**
+     * 現在のACO設定で計画・会計・NBTへ保存できる正確な最大値を返す。
+     *
+     * <p>アドオンはこの値をCPU容量の上限や表示に利用できる。BigIntegerは不変なので、
+     * 呼び出し側へ同じ値を返してもACO内部状態は変更されない。</p>
+     */
+    public static BigInteger maximumSupportedAmount() {
+        return maximumSupportedAmount(ACOConfig.getBigIntegerMaximumBits());
+    }
+
+    static BigInteger maximumSupportedAmount(int configuredMaximumBits) {
+        // ACOの設定境界外の値を、公開API経由で有効な上限として扱わせない。
+        if (configuredMaximumBits < 1
+                || configuredMaximumBits > BigCountMath.HARD_MAXIMUM_BITS) {
+            throw new IllegalArgumentException(
+                    "configuredMaximumBits must be between 1 and "
+                            + BigCountMath.HARD_MAXIMUM_BITS);
+        }
+
+        BigInteger binaryLimit = BigInteger.ONE
+                .shiftLeft(configuredMaximumBits)
+                .subtract(BigInteger.ONE);
+        // bit上限の端が16,385桁へ届く場合は、ACOの10進16,384桁上限を正本にする。
+        return binaryLimit.min(BigCountMath.hardMaximumValue());
     }
 
     /**
@@ -125,11 +154,28 @@ public final class BigCraftingEngineApi {
                 ACOConfig.getBigIntegerMaximumBits());
     }
 
+    /**
+     * AE2のitem、fluid、chemicalキーを扱うアドオン向け台帳を作成する。
+     *
+     * <p>アドオンがACO内部の{@code BigCraftingKeyCodec}型を解決しなくて済むよう、
+     * 公開APIだけで完結する固定型ファクトリとして提供する。</p>
+     */
+    public static BigIntegerAmountLedger<AEKey> createAeKeyAmountLedger() {
+        return createAmountLedger(AeKeyBigCraftingCodec.INSTANCE);
+    }
+
     /** Restores an add-on amount ledger using the current server-side bit limit. */
     public static <K> BigIntegerAmountLedger<K> loadAmountLedger(
             CompoundTag saved,
             BigCraftingKeyCodec<K> keyCodec) {
         BigIntegerAmountLedger<K> ledger = createAmountLedger(keyCodec);
+        ledger.load(Objects.requireNonNull(saved, "saved"));
+        return ledger;
+    }
+
+    /** AEKey用の保存済み台帳を、ACO内部型を公開せず復元する。 */
+    public static BigIntegerAmountLedger<AEKey> loadAeKeyAmountLedger(CompoundTag saved) {
+        BigIntegerAmountLedger<AEKey> ledger = createAeKeyAmountLedger();
         ledger.load(Objects.requireNonNull(saved, "saved"));
         return ledger;
     }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOServerLifecycle.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOServerLifecycle.java
@@ -33,6 +33,7 @@ import net.minecraftforge.event.OnDatapackSyncEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.server.ServerStartedEvent;
 import net.minecraftforge.event.server.ServerStoppingEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
 
 /**
  * サーバーの開始・tick・データ再読込・停止に伴うACO状態を一元管理する。
@@ -50,6 +51,7 @@ public final class ACOServerLifecycle {
         MinecraftForge.EVENT_BUS.addListener(
                 ACOServerLifecycle::onDatapackSync);
         MinecraftForge.EVENT_BUS.addListener(
+                EventPriority.HIGHEST,
                 ACOServerLifecycle::onServerStopping);
     }
 

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApiCapacityTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApiCapacityTest.java
@@ -1,0 +1,50 @@
+package com.syaru.ae2craftingoptimizer.api.big;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import appeng.api.stacks.AEKey;
+import com.syaru.ae2craftingoptimizer.engine.BigCountMath;
+import java.lang.reflect.Method;
+import java.math.BigInteger;
+import org.junit.jupiter.api.Test;
+
+class BigCraftingEngineApiCapacityTest {
+    @Test
+    void returnsExactConfiguredBinaryLimit() {
+        assertEquals(
+                BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE),
+                BigCraftingEngineApi.maximumSupportedAmount(64));
+    }
+
+    @Test
+    void clampsMaximumBitsToDecimalImplementationLimit() {
+        assertEquals(
+                BigCountMath.hardMaximumValue(),
+                BigCraftingEngineApi.maximumSupportedAmount(
+                        BigCountMath.HARD_MAXIMUM_BITS));
+    }
+
+    @Test
+    void rejectsBitsOutsideAcoBoundary() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> BigCraftingEngineApi.maximumSupportedAmount(0));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> BigCraftingEngineApi.maximumSupportedAmount(
+                        BigCountMath.HARD_MAXIMUM_BITS + 1));
+    }
+
+    @Test
+    void exposesAeKeyLedgerFactoryWithoutInternalCodecParameter() throws Exception {
+        Method factory = BigCraftingEngineApi.class.getMethod("createAeKeyAmountLedger");
+
+        assertEquals(BigIntegerAmountLedger.class, factory.getReturnType());
+        assertEquals(0, factory.getParameterCount());
+        assertTrue(BigCraftingEngineApi.AMOUNT_LEDGER_API_VERSION >= 2);
+        // ジェネリック戻り値にもAEKeyが残り、アドオン側の型契約を文書化できる。
+        assertTrue(factory.getGenericReturnType().getTypeName().contains(AEKey.class.getName()));
+    }
+}


### PR DESCRIPTION
## 目的

Forge 1.20.1版ACO 1.5.12で、任意CPUアドオンが内部実装へ依存せず公開BigInteger APIを利用できるようにし、停止時の会計返却順序も修正します。

## 変更内容

- BigInteger容量上限APIを追加
- AEKey対応Amount Ledger APIを追加
- InsaneAE向け計算プロファイルと能力照会APIを追加
- aggregate long overflowをBigInteger Hostへ昇格
- 停止時の会計返却を`EventPriority.HIGHEST`へ移動
- API形状、境界値、NBT台帳、停止時読取契約のJUnitを追加

## 互換性

- 既存Host API v3を維持
- 通常AE2、AQE、InsaneAEの実行処理をACO側から置換しない
- 任意連携が利用できない場合は各アドオンの従来経路へ戻れる
- 停止時以外のクラフト計算、容量会計、実行速度は変更しない

## 検証

- `gradlew.bat clean build --no-daemon`: 成功
- 全JUnit成功、失敗0件
- Forge 1.20.1配布JAR生成を確認

Refs #46
Refs #53
