### PR TITLE
fix: return BigInteger accounting before host shutdown on NeoForge 1.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,6 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
-### Fixed
-
-- Added an optional InsaneAE calculation profile for the NeoForge 1.21.1
-  build. When enabled, ACO owns the strict compiled/BigInteger calculation
-  boundary instead of allowing an InsaneAE calculation batch to pass an
-  overflowing `long` request into AE2.
-- Added a public calculation-profile capability query for optional CPU add-ons.
-
 ## [1.5.12] - 2026-08-11
 
 ### Added
@@ -20,11 +12,16 @@ All notable changes to this project are documented here.
   crafting CPU add-ons.
 - Added the public exact amount ledger and calculation-profile compatibility
   contracts for NeoForge 1.21.1.
+- Added an optional InsaneAE calculation profile and a public capability query.
 
 ### Fixed
 
 - Promoted aggregate long overflow to the BigInteger host instead of sending a
   wrapped or clamped value into AE2's checked long calculation.
+- Made ACO own the strict compiled/BigInteger calculation boundary when the
+  InsaneAE profile is enabled.
+- Returned pending BigInteger windows before optional hosts close during
+  shutdown.
 
 ## [1.5.10] - 2026-08-10
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOServerLifecycle.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOServerLifecycle.java
@@ -34,6 +34,7 @@ import net.neoforged.neoforge.event.server.ServerAboutToStartEvent;
 import net.neoforged.neoforge.event.server.ServerStartedEvent;
 import net.neoforged.neoforge.event.server.ServerStoppingEvent;
 import net.neoforged.neoforge.event.tick.ServerTickEvent;
+import net.neoforged.bus.api.EventPriority;
 
 /**
  * サーバーの開始・tick・データ再読込・停止に伴うACO状態を一元管理する。
@@ -55,6 +56,7 @@ public final class ACOServerLifecycle {
         NeoForge.EVENT_BUS.addListener(
                 ACOServerLifecycle::onDatapackSync);
         NeoForge.EVENT_BUS.addListener(
+                EventPriority.HIGHEST,
                 ACOServerLifecycle::onServerStopping);
     }
 


### PR DESCRIPTION
## 目的

NeoForge 1.21.1版ACO 1.5.12へ、Forge版と同じ停止時のBigInteger会計返却順序を適用します。

## 変更内容

- `ServerStoppingEvent` listenerを`EventPriority.HIGHEST`で登録
- pending Windowを任意Hostの解放前にrollback
- 既存の実行Manager、Host Registry解放順序は維持
- 1.5.12のCHANGELOGへ修正内容を収録

## 非変更範囲

- 通常tick
- クラフト計算
- BigInteger容量計算
- クラフト実行速度
- Advanced AE構造判定

## 検証

- `gradlew.bat clean build --no-daemon`: 成功
- 全JUnit成功、失敗0件
- NeoForge 1.21.1配布JAR生成を確認

Refs #53
