### PR TITLE
Fix wide BigInteger plans and Future ownership (NeoForge 1.21.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.13] - 2026-08-13
+
+### Added
+
+- Added exact BigInteger simulation plans for wide crafting requests with
+  missing ingredients.
+- Added configurable diagnostics and statistics for every reason the exact
+  BigInteger planner declines a request.
+
+### Fixed
+
+- Promoted wide requests made through `CraftingService.beginCraftingCalculation`
+  through the same exact BigInteger path as direct planner API calls.
+- Prevented wide plans from silently falling back to AE2's overflowing long
+  calculation path.
+- Fixed shared calculation Future ownership, subscriber cancellation, and
+  fast-completion handling.
+- Fixed cancellation ownership in the NeoForge calculation deduplicator so
+  one subscriber cannot cancel work still owned by another subscriber.
+- Invalidated deduplicated and completed plans when inventory generations
+  change, and excluded single-use wide execution plans from completed caches.
+- Preserved exact BigInteger shortage counts, pattern counts, and byte totals
+  without clamping their source values to long.
+
 ## [1.5.12] - 2026-08-11
 
 ### Added

--- a/docs/LUNA_BIGINT_GAMETEST.md
+++ b/docs/LUNA_BIGINT_GAMETEST.md
@@ -1,0 +1,27 @@
+# LUNA BigInteger 回帰試験
+
+この文書は、InsaneAE作者の診断GameTestをACO側の回帰条件へ対応付けたものです。
+GameTestの実行はこの作業では行わず、ユーザー側のMinecraft試験項目として残します。
+
+## 参照
+
+- 診断ブランチ: https://github.com/taikun24/InsaneAE/tree/diag/aco-bigint
+- 再現報告: https://github.com/taikun24/InsaneAE/issues/6#issuecomment-5264634773
+
+## 回帰条件
+
+1. 鉄ナゲット在庫 `8,600,000,000,000,000,000` と鉄ブロック要求
+   `106,000,000,000,000,000` で、正確な不足または成立判定を確認する。
+2. direct planner APIと`CraftingService.beginCraftingCalculation`経路で、同じSnapshotから
+   `BigInteger`の要求量、使用量、不足量、exact bytesが一致する。
+3. long超過かつ素材不足の計画が`ArithmeticException`にならず、simulationとして返る。
+4. wide計画がAE2標準long計算へ無言で戻らず、辞退理由を診断統計で確認できる。
+5. 同じ計算を二つの呼出し元から共有し、一方のキャンセルで他方の結果を壊さない。
+6. 全購読者がキャンセルした場合だけ下流Futureをキャンセルする。
+
+## 合格条件
+
+- BigInteger正本が`Long.MAX_VALUE`へ切り捨てられない。
+- simulation計画が実行Jobへ変換されない。
+- 通常long範囲の結果は変更前と一致する。
+- GameTest以外の自動確認は`clean build`とJUnitで実施する。

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ minecraft_version=1.21.1
 neo_version=21.1.247
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.12
+mod_version=1.5.13
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/access/CheckedCraftingArithmeticHookAccess.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/access/CheckedCraftingArithmeticHookAccess.java
@@ -1,0 +1,5 @@
+package com.syaru.ae2craftingoptimizer.access;
+
+/** AE2クラフト計算のlong境界検査Mixinが適用済みであることを示す印。 */
+public interface CheckedCraftingArithmeticHookAccess {
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/access/CraftingServiceCalculationHookAccess.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/access/CraftingServiceCalculationHookAccess.java
@@ -1,0 +1,5 @@
+package com.syaru.ae2craftingoptimizer.access;
+
+/** CraftingServiceの計算共有・事前判定Mixinが適用済みであることを示す印。 */
+public interface CraftingServiceCalculationHookAccess {
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/access/ExactBigIntegerInventoryHookAccess.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/access/ExactBigIntegerInventoryHookAccess.java
@@ -1,0 +1,5 @@
+package com.syaru.ae2craftingoptimizer.access;
+
+/** 正確なBigInteger在庫Snapshotの生成・伝播・失効Mixinが適用済みであることを示す印。 */
+public interface ExactBigIntegerInventoryHookAccess {
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
@@ -167,6 +167,7 @@ public final class ACOConfig {
     private static final ModConfigSpec.BooleanValue LOG_SLOW_CRAFT_CALCULATIONS;
     private static final ModConfigSpec.IntValue SLOW_CRAFT_CALCULATION_MILLIS;
     private static final ModConfigSpec.BooleanValue LOG_CACHE_STATISTICS;
+    private static final ModConfigSpec.BooleanValue LOG_BIG_INTEGER_PLAN_DECLINES;
     private static final ModConfigSpec.BooleanValue ENABLE_AQE_BIG_CRAFTING_PROFILE;
     private static final ModConfigSpec.BooleanValue ENABLE_INSANE_AE_BIG_CRAFTING_PROFILE;
     private static final ModConfigSpec.BooleanValue ENABLE_LONG_ROOT_CRAFT_AMOUNTS;
@@ -938,6 +939,11 @@ public final class ACOConfig {
         LOG_CACHE_STATISTICS = builder
                 .comment("Log preliminary missing preview cache hits, writes, and clears.")
                 .define("logCacheStatistics", false);
+        LOG_BIG_INTEGER_PLAN_DECLINES = builder
+                .comment(
+                        "Log the exact reason when an ACO BigInteger plan is declined or cannot be promoted.",
+                        "The /aco stats counters are kept even when this detailed log is disabled.")
+                .define("logBigIntegerPlanDeclines", false);
         builder.pop();
 
         SPEC = builder.build();
@@ -1580,6 +1586,10 @@ public final class ACOConfig {
 
     public static boolean logCacheStatistics() {
         return enableOptimizer() && LOG_CACHE_STATISTICS.get();
+    }
+
+    public static boolean logBigIntegerPlanDeclines() {
+        return enableOptimizer() && LOG_BIG_INTEGER_PLAN_DECLINES.get();
     }
 
     public static boolean enableExperimentalCraftingEngine() {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
@@ -433,7 +433,7 @@ public final class Ae2AuthoritativeCraftingPlanner {
         } catch (WidePlanUnavailableException unavailable) {
             // wide計画はAE2標準long経路へ戻さず、元の明示的な辞退理由を保持する。
             throw unavailable;
-        } catch (Throwable failure) {
+        } catch (RuntimeException failure) {
             CraftingFallbackDiagnostics.record(
                     output,
                     capture == null ? ProviderPatternGenerationTracker.generation() : capture.patternGeneration(),
@@ -482,18 +482,11 @@ public final class Ae2AuthoritativeCraftingPlanner {
             return null;
         }
 
-        Map<IPatternDetails, BigInteger> exactPatternTimes = new LinkedHashMap<>();
-        // fingerprint IDを同じ世代Snapshot内の実Patternへ一対一で戻す。
-        for (Map.Entry<String, BigInteger> entry : exactPlan.patternExecutions().entrySet()) {
-            IPatternDetails details = graphSnapshot.pattern(entry.getKey());
-            // 欠損Patternまたは0回以下は永続親Jobへ載せない。
-            if (details == null || entry.getValue().signum() <= 0) {
-                return null;
-            }
-            exactPatternTimes.merge(details, entry.getValue(), BigInteger::add);
-        }
-        // 画面同期と保存のPattern種類数を既存の設定上限内へ保つ。
-        if (exactPatternTimes.size() > ACOConfig.getCraftingEngineShadowMaximumPatterns()) {
+        Map<IPatternDetails, BigInteger> exactPatternTimes = resolveExactPatternTimes(
+                graphSnapshot,
+                exactPlan.patternExecutions());
+        // Pattern参照を同一世代へ戻せない計画は、永続親Jobとして採用しない。
+        if (exactPatternTimes == null) {
             return null;
         }
 
@@ -584,16 +577,11 @@ public final class Ae2AuthoritativeCraftingPlanner {
             AEKey output,
             BigInteger requestedAmount,
             BigCraftingPlan<AEKey> exactPlan) {
-        Map<IPatternDetails, BigInteger> exactPatternTimes = new LinkedHashMap<>();
-        // 不足simulationへ載せる全Pattern回数を、同一世代Snapshotの実Patternへ戻す。
-        for (Map.Entry<String, BigInteger> entry : exactPlan.patternExecutions().entrySet()) {
-            IPatternDetails details = graphSnapshot.pattern(entry.getKey());
-            if (details == null || entry.getValue().signum() <= 0) {
-                return null;
-            }
-            exactPatternTimes.merge(details, entry.getValue(), BigInteger::add);
-        }
-        if (exactPatternTimes.size() > ACOConfig.getCraftingEngineShadowMaximumPatterns()) {
+        Map<IPatternDetails, BigInteger> exactPatternTimes = resolveExactPatternTimes(
+                graphSnapshot,
+                exactPlan.patternExecutions());
+        // 不足simulationも実行計画と同じPattern参照条件を満たす必要がある。
+        if (exactPatternTimes == null) {
             return null;
         }
         BigInteger exactBytes = topology.calculateBigExactBytes(
@@ -607,6 +595,27 @@ public final class Ae2AuthoritativeCraftingPlanner {
                         exactPlan,
                         exactPatternTimes,
                         exactBytes));
+    }
+
+    @Nullable
+    private static Map<IPatternDetails, BigInteger> resolveExactPatternTimes(
+            Ae2CompiledCraftingGraphCache.Snapshot graphSnapshot,
+            Map<String, BigInteger> fingerprintCounts) {
+        Map<IPatternDetails, BigInteger> resolved = new LinkedHashMap<>();
+        // fingerprint IDを同じ世代Snapshot内の実Patternへ一対一で戻す。
+        for (Map.Entry<String, BigInteger> entry : fingerprintCounts.entrySet()) {
+            IPatternDetails details = graphSnapshot.pattern(entry.getKey());
+            // 欠損Patternまたは0回以下は表示にも永続Jobにも載せない。
+            if (details == null || entry.getValue().signum() <= 0) {
+                return null;
+            }
+            resolved.merge(details, entry.getValue(), BigInteger::add);
+        }
+        // 画面同期と保存のPattern種類数を既存の設定上限内へ保つ。
+        if (resolved.size() > ACOConfig.getCraftingEngineShadowMaximumPatterns()) {
+            return null;
+        }
+        return Map.copyOf(resolved);
     }
 
     private static ICraftingPlan declineOrThrow(

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
@@ -86,10 +86,25 @@ public final class Ae2AuthoritativeCraftingPlanner {
                     Thread.currentThread().isInterrupted()
                             ? FallbackReasonCode.CANCELLED
                             : FallbackReasonCode.UNSUPPORTED_PATTERN);
-                    return null;
+            BigIntegerPlanDiagnostics.record(
+                    requestedAmount <= 0L
+                            ? BigIntegerPlanDeclineReason.INVALID_REQUEST
+                            : BigIntegerPlanDeclineReason.DISABLED,
+                    output == null ? null : output.getId().toString(),
+                    BigInteger.valueOf(requestedAmount),
+                    capture == null ? -1L : capture.patternGeneration(),
+                    capture == null ? -1L : capture.recipeGeneration(),
+                    "invalid planner input");
+            return null;
         }
         // 割込みはAE2標準long計算へ戻す理由ではなく、明示的な再試行可能キャンセルとする。
         if (Thread.currentThread().isInterrupted()) {
+            recordDecline(
+                    capture,
+                    output,
+                    requestedAmount,
+                    BigIntegerPlanDeclineReason.CANCELLED,
+                    "planner thread was interrupted before planning");
             throw new PlanningCancelledException(0);
         }
 
@@ -103,6 +118,12 @@ public final class Ae2AuthoritativeCraftingPlanner {
             if (optionalProgram.isEmpty()) {
                 CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
                         FallbackReasonCode.AMBIGUOUS_PRODUCER);
+                recordDecline(
+                        capture,
+                        output,
+                        requestedAmount,
+                        BigIntegerPlanDeclineReason.NO_COMPILED_PROGRAM,
+                        "no compiled root program");
                 return null;
             }
             CompiledRootProgram<AEKey> program = optionalProgram.get();
@@ -116,6 +137,14 @@ public final class Ae2AuthoritativeCraftingPlanner {
                         capture.patternGeneration(),
                         capture.recipeGeneration(),
                         topology == null ? FallbackReasonCode.UNSUPPORTED_PATTERN : FallbackReasonCode.INVENTORY_CHANGED);
+                recordDecline(
+                        capture,
+                        output,
+                        requestedAmount,
+                        topology == null
+                                ? BigIntegerPlanDeclineReason.UNSUPPORTED_TOPOLOGY
+                                : BigIntegerPlanDeclineReason.INVENTORY_CHANGED,
+                        topology == null ? "strict topology was not proven" : "inventory was not accepted");
                 return null;
             }
             wideArithmeticRequired = topology.mightRequireWideArithmetic(

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
@@ -11,6 +11,8 @@ import appeng.api.stacks.KeyCounter;
 import appeng.crafting.CraftingPlan;
 import com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
+import com.syaru.ae2craftingoptimizer.optimization.BigIntegerPlanDeclineReason;
+import com.syaru.ae2craftingoptimizer.optimization.BigIntegerPlanDiagnostics;
 import com.syaru.ae2craftingoptimizer.optimization.ProviderPatternGenerationTracker;
 import com.syaru.ae2craftingoptimizer.optimization.CraftingFallbackDiagnostics;
 import com.syaru.ae2craftingoptimizer.optimization.FallbackReasonCode;
@@ -21,6 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
@@ -70,13 +73,12 @@ public final class Ae2AuthoritativeCraftingPlanner {
             AEKey output,
             long requestedAmount,
             CalculationStrategy strategy) {
-        // 無効設定、不正引数、キャンセル済み計算はAE2標準経路へ戻す。
+        // 無効設定、参照欠落、不正注文はACO計画を作らず呼出側へ戻す。
         if (!planningEnabled()
                 || capture == null
                 || output == null
                 || strategy == null
-                || requestedAmount <= 0L
-                || Thread.currentThread().isInterrupted()) {
+                || requestedAmount <= 0L) {
             CraftingFallbackDiagnostics.record(
                     output,
                     capture == null ? ProviderPatternGenerationTracker.generation() : capture.patternGeneration(),
@@ -84,9 +86,14 @@ public final class Ae2AuthoritativeCraftingPlanner {
                     Thread.currentThread().isInterrupted()
                             ? FallbackReasonCode.CANCELLED
                             : FallbackReasonCode.UNSUPPORTED_PATTERN);
-            return null;
+                    return null;
+        }
+        // 割込みはAE2標準long計算へ戻す理由ではなく、明示的な再試行可能キャンセルとする。
+        if (Thread.currentThread().isInterrupted()) {
+            throw new PlanningCancelledException(0);
         }
 
+        boolean wideArithmeticRequired = false;
         try {
             capture.requireCurrentGenerations();
             Ae2CompiledCraftingGraphCache.Snapshot graphSnapshot =
@@ -111,7 +118,7 @@ public final class Ae2AuthoritativeCraftingPlanner {
                         topology == null ? FallbackReasonCode.UNSUPPORTED_PATTERN : FallbackReasonCode.INVENTORY_CHANGED);
                 return null;
             }
-            boolean wideArithmeticRequired = topology.mightRequireWideArithmetic(
+            wideArithmeticRequired = topology.mightRequireWideArithmetic(
                     output,
                     BigInteger.valueOf(requestedAmount),
                     ACOConfig.getBigIntegerMaximumBits());
@@ -129,7 +136,13 @@ public final class Ae2AuthoritativeCraftingPlanner {
                     ACOConfig.requireAqeBigPlanShadowQualification())) {
                 CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
                         FallbackReasonCode.SHADOW_NOT_QUALIFIED);
-                return null;
+                return declineOrThrow(
+                        capture,
+                        output,
+                        requestedAmount,
+                        wideArithmeticRequired,
+                        BigIntegerPlanDeclineReason.SHADOW_NOT_QUALIFIED,
+                        "shadow qualification is below the configured threshold");
             }
             // 通常注文の置換を両方の設定で無効化した場合は、wide互換経路だけを残す。
             if (!normalLongReplacementEnabled() && !wideArithmeticRequired) {
@@ -144,7 +157,13 @@ public final class Ae2AuthoritativeCraftingPlanner {
             if (inventoryMetadata != null && !inventoryMetadata.complete()) {
                 CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
                         FallbackReasonCode.INVENTORY_CHANGED);
-                return null;
+                return declineOrThrow(
+                        capture,
+                        output,
+                        requestedAmount,
+                        wideArithmeticRequired,
+                        BigIntegerPlanDeclineReason.INCOMPLETE_INVENTORY,
+                        "BigInteger inventory sidecar is incomplete");
             }
             CompiledRootProgram.BigInventorySnapshot<AEKey> exactPlanningInventory =
                     Ae2ReferencedInventory.captureExactNetworkSnapshot(
@@ -172,6 +191,8 @@ public final class Ae2AuthoritativeCraftingPlanner {
             OverflowPromotingCraftingPlanner<AEKey> planner =
                     new OverflowPromotingCraftingPlanner<>(
                             ACOConfig.getBigIntegerMaximumBits());
+            final CompiledRootProgram.BigInventorySnapshot<AEKey> exactInventorySnapshot = exactPlanningInventory;
+            final CompiledRootProgram.InventorySnapshot<AEKey> longInventorySnapshot = planningInventory;
             var promoted = exactPlanningInventory != null
                     ? planner.plan(
                             program,
@@ -187,45 +208,124 @@ public final class Ae2AuthoritativeCraftingPlanner {
             if (!promoted.provenEquivalent()) {
                 CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
                         FallbackReasonCode.TAG_SELECTION_UNPROVEN);
-                return null;
+                return declineOrThrow(
+                        capture,
+                        output,
+                        requestedAmount,
+                        wideArithmeticRequired || promoted.usesBigInteger(),
+                        BigIntegerPlanDeclineReason.PLAN_NOT_PROVEN,
+                        "compiled plan was not proven equivalent");
             }
             NormalizedPlan symbolic = normalize(promoted);
             ICraftingPlan result;
-            // 個別値またはキー別合計がlongを超える場合、通常AE2 Jobへ戻さずBig親Jobを作る。
-            boolean bigIntegerExecutionRequired = symbolic == null
-                    || symbolic.hasAggregatePastLong();
-            if (bigIntegerExecutionRequired) {
-                result = createBigIntegerParentPlan(
-                        capture,
-                        graphSnapshot,
-                        program,
-                        topology,
-                        output,
-                        requestedAmount,
-                        strategy,
-                        promoted,
-                        true);
-                // 厳格な親Jobへ変換できない経路は、値を近似せずAE2本来の計算へ戻す。
+            BigCraftingPlan<AEKey> exactPlan = exactPlan(promoted);
+            boolean widePlan = wideArithmeticRequired
+                    || promoted.usesBigInteger()
+                    || symbolic == null;
+            // wide不足はAE2のlong計算へ戻さず、正確なsimulationまたは部分探索へ進める。
+            if (!exactPlan.craftable() && widePlan) {
+                if (strategy == CalculationStrategy.CRAFT_LESS) {
+                    BigInteger partialAmount = largestCraftableAmount(
+                            BigInteger.valueOf(requestedAmount),
+                            candidate -> exactPlanAt(
+                                    planner,
+                                    program,
+                                    candidate,
+                                    exactInventorySnapshot,
+                                    longInventorySnapshot,
+                                    guard));
+                    if (partialAmount.signum() <= 0) {
+                        result = createBigIntegerSimulationPlan(
+                                graphSnapshot,
+                                topology,
+                                output,
+                                BigInteger.valueOf(requestedAmount),
+                                exactPlan);
+                    } else {
+                        OverflowPromotingCraftingPlanner.Result<AEKey> partial = exactPlanAt(
+                                planner,
+                                program,
+                                partialAmount,
+                                exactInventorySnapshot,
+                                longInventorySnapshot,
+                                guard);
+                        result = createBigIntegerParentPlan(
+                                capture,
+                                graphSnapshot,
+                                program,
+                                topology,
+                                output,
+                                partialAmount,
+                                strategy,
+                                partial,
+                                true);
+                    }
+                } else {
+                    result = createBigIntegerSimulationPlan(
+                            graphSnapshot,
+                            topology,
+                            output,
+                            BigInteger.valueOf(requestedAmount),
+                            exactPlan);
+                }
                 if (result == null) {
-                    CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
-                            FallbackReasonCode.UNSUPPORTED_PATTERN);
-                    return null;
+                    return declineOrThrow(
+                            capture,
+                            output,
+                            requestedAmount,
+                            true,
+                            BigIntegerPlanDeclineReason.MISSING_SIMULATION,
+                            "exact wide missing simulation could not be represented");
                 }
             } else {
-                result = createLongFacadePlan(
-                        capture,
-                        graphSnapshot,
-                        topology,
-                        output,
-                        requestedAmount,
-                        strategy,
-                        symbolic,
-                        wideArithmeticRequired);
-                // AtomicまたはAuthoritative設定で採用できない通常計画はAE2へ戻す。
-                if (result == null) {
-                    CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
-                            FallbackReasonCode.UNSUPPORTED_PATTERN);
-                    return null;
+                // 個別値またはキー別合計がlongを超える場合、通常AE2 Jobへ戻さずBig親Jobを作る。
+                boolean bigIntegerExecutionRequired = symbolic == null
+                        || symbolic.hasAggregatePastLong();
+                if (bigIntegerExecutionRequired) {
+                    result = createBigIntegerParentPlan(
+                            capture,
+                            graphSnapshot,
+                            program,
+                            topology,
+                            output,
+                            BigInteger.valueOf(requestedAmount),
+                            strategy,
+                            promoted,
+                            true);
+                    // 厳格な親Jobへ変換できない経路は、値を近似せずAE2本来の計算へ戻す。
+                    if (result == null) {
+                        CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
+                                FallbackReasonCode.UNSUPPORTED_PATTERN);
+                        return declineOrThrow(
+                                capture,
+                                output,
+                                requestedAmount,
+                                widePlan,
+                                BigIntegerPlanDeclineReason.EXECUTION_WINDOW_UNAVAILABLE,
+                                "exact execution plan could not be prepared");
+                    }
+                } else {
+                    result = createLongFacadePlan(
+                            capture,
+                            graphSnapshot,
+                            topology,
+                            output,
+                            requestedAmount,
+                            strategy,
+                            symbolic,
+                            wideArithmeticRequired);
+                    // AtomicまたはAuthoritative設定で採用できない通常計画はAE2へ戻す。
+                    if (result == null) {
+                        CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
+                                FallbackReasonCode.UNSUPPORTED_PATTERN);
+                        return declineOrThrow(
+                                capture,
+                                output,
+                                requestedAmount,
+                                widePlan,
+                                BigIntegerPlanDeclineReason.UNSUPPORTED_TOPOLOGY,
+                                "long facade could not be built");
+                    }
                 }
             }
 
@@ -247,34 +347,78 @@ public final class Ae2AuthoritativeCraftingPlanner {
             if (!inventoryStillMatches) {
                 CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
                         FallbackReasonCode.INVENTORY_CHANGED);
-                return null;
+                return declineOrThrow(
+                        capture,
+                        output,
+                        requestedAmount,
+                        widePlan,
+                        BigIntegerPlanDeclineReason.INVENTORY_CHANGED,
+                        "referenced inventory changed during planning");
             }
             // Emitterまたはファジー候補が変わった場合も、AE2と選択結果がずれるため破棄する。
             if (!topology.remainsValid(capture.grid())) {
                 CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
                         FallbackReasonCode.GENERATION_CHANGED);
-                return null;
+                return declineOrThrow(
+                        capture,
+                        output,
+                        requestedAmount,
+                        widePlan,
+                        BigIntegerPlanDeclineReason.TOPOLOGY_CHANGED,
+                        "strict topology changed during planning");
             }
             return result;
-        } catch (PlanningCancelledException
-                | StalePlanningSnapshotException
-                | ArithmeticException ignored) {
+        } catch (PlanningCancelledException | StalePlanningSnapshotException retryable) {
             CraftingFallbackDiagnostics.record(
                     output,
                     capture == null ? ProviderPatternGenerationTracker.generation() : capture.patternGeneration(),
                     capture == null ? RecipeGenerationTracker.generation() : capture.recipeGeneration(),
-                    ignored instanceof PlanningCancelledException
+                    retryable instanceof PlanningCancelledException
                             ? FallbackReasonCode.CANCELLED
-                            : ignored instanceof ArithmeticException
-                                    ? FallbackReasonCode.COUNT_OVERFLOW
-                                    : FallbackReasonCode.GENERATION_CHANGED);
+                            : FallbackReasonCode.GENERATION_CHANGED);
+            recordDecline(
+                    capture,
+                    output,
+                    requestedAmount,
+                    retryable instanceof PlanningCancelledException
+                            ? BigIntegerPlanDeclineReason.CANCELLED
+                            : BigIntegerPlanDeclineReason.GENERATION_CHANGED,
+                    retryable.getMessage());
+            throw retryable;
+        } catch (ArithmeticException arithmeticFailure) {
+            CraftingFallbackDiagnostics.record(
+                    output,
+                    capture == null ? ProviderPatternGenerationTracker.generation() : capture.patternGeneration(),
+                    capture == null ? RecipeGenerationTracker.generation() : capture.recipeGeneration(),
+                    FallbackReasonCode.COUNT_OVERFLOW);
+            recordDecline(
+                    capture,
+                    output,
+                    requestedAmount,
+                    BigIntegerPlanDeclineReason.ARITHMETIC_FAILURE,
+                    arithmeticFailure.getMessage());
+            if (wideArithmeticRequired) {
+                throw new WidePlanUnavailableException(output, "exact arithmetic failed", arithmeticFailure);
+            }
             return null;
+        } catch (WidePlanUnavailableException unavailable) {
+            // wide計画はAE2標準long経路へ戻さず、元の明示的な辞退理由を保持する。
+            throw unavailable;
         } catch (Throwable failure) {
             CraftingFallbackDiagnostics.record(
                     output,
                     capture == null ? ProviderPatternGenerationTracker.generation() : capture.patternGeneration(),
                     capture == null ? RecipeGenerationTracker.generation() : capture.recipeGeneration(),
                     classifyFallback(failure));
+            recordDecline(
+                    capture,
+                    output,
+                    requestedAmount,
+                    BigIntegerPlanDeclineReason.INTERNAL_FAILURE,
+                    failure.getClass().getName());
+            if (wideArithmeticRequired) {
+                throw new WidePlanUnavailableException(output, "wide plan failed", failure);
+            }
             logFallbackOnce(output, failure);
             return null;
         }
@@ -287,7 +431,7 @@ public final class Ae2AuthoritativeCraftingPlanner {
             CompiledRootProgram<AEKey> program,
             Ae2StrictCraftingTopology topology,
             AEKey output,
-            long requestedAmount,
+            BigInteger requestedAmount,
             CalculationStrategy strategy,
             OverflowPromotingCraftingPlanner.Result<AEKey> promoted,
             boolean requiresBigIntegerExecution) {
@@ -324,7 +468,7 @@ public final class Ae2AuthoritativeCraftingPlanner {
             return null;
         }
 
-        BigInteger requested = BigInteger.valueOf(requestedAmount);
+        BigInteger requested = requestedAmount;
         BigInteger exactBytes = topology.calculateBigExactBytes(
                 output,
                 requested,
@@ -345,13 +489,124 @@ public final class Ae2AuthoritativeCraftingPlanner {
             return null;
         }
         BigIntegerCraftingPlan metadata = new BigIntegerCraftingPlan(
-                new GenericStack(output, requestedAmount),
+                new GenericStack(output, requested.longValueExact()),
                 exactPlan,
                 exactPatternTimes,
                 prepared,
                 requiresBigIntegerExecution);
         // AE2と周辺アドオンへは必ず最終実装CraftingPlanを返し、BigInteger真値はSidecarへ置く。
         return Ae2CraftingPlanSidecars.expose(metadata);
+    }
+
+    private static BigCraftingPlan<AEKey> exactPlan(
+            OverflowPromotingCraftingPlanner.Result<AEKey> promoted) {
+        if (promoted instanceof OverflowPromotingCraftingPlanner.BigResult<AEKey> bigResult) {
+            return bigResult.plan();
+        }
+        if (promoted instanceof OverflowPromotingCraftingPlanner.LongResult<AEKey> longResult) {
+            return widenLongPlan(longResult.plan());
+        }
+        throw new IllegalArgumentException("Unsupported promoted crafting result");
+    }
+
+    private static OverflowPromotingCraftingPlanner.Result<AEKey> exactPlanAt(
+            OverflowPromotingCraftingPlanner<AEKey> planner,
+            CompiledRootProgram<AEKey> program,
+            BigInteger amount,
+            CompiledRootProgram.BigInventorySnapshot<AEKey> exactInventory,
+            CompiledRootProgram.InventorySnapshot<AEKey> longInventory,
+            PlanningGuard guard) {
+        // 同じ不変在庫Snapshotで候補量だけを変えてBigInteger計画を再計算する。
+        if (exactInventory != null) {
+            return planner.plan(program, amount, exactInventory, guard);
+        }
+        return planner.plan(program, amount, longInventory, guard);
+    }
+
+    private static BigInteger largestCraftableAmount(
+            BigInteger requestedAmount,
+            Function<BigInteger, OverflowPromotingCraftingPlanner.Result<AEKey>> planner) {
+        OverflowPromotingCraftingPlanner.Result<AEKey> full = planner.apply(requestedAmount);
+        // 要求全量が成立する場合は二分探索を省略する。
+        if (full.craftable()) {
+            return requestedAmount;
+        }
+
+        BigInteger lower = BigInteger.ZERO;
+        BigInteger upper = requestedAmount;
+        // 成立量と不成立量の境界をBigIntegerの二分探索で求める。
+        while (lower.add(BigInteger.ONE).compareTo(upper) < 0) {
+            BigInteger middle = lower.add(upper).shiftRight(1);
+            OverflowPromotingCraftingPlanner.Result<AEKey> candidate = planner.apply(middle);
+            // 候補量が成立するかを判定し、探索区間を半分へ狭める。
+            if (candidate.craftable()) {
+                lower = middle;
+                continue;
+            }
+            upper = middle;
+        }
+        // lowerはBigInteger上で証明できた最大作成量である。
+        return lower;
+    }
+
+    private static ICraftingPlan createBigIntegerSimulationPlan(
+            Ae2CompiledCraftingGraphCache.Snapshot graphSnapshot,
+            Ae2StrictCraftingTopology topology,
+            AEKey output,
+            BigInteger requestedAmount,
+            BigCraftingPlan<AEKey> exactPlan) {
+        Map<IPatternDetails, BigInteger> exactPatternTimes = new LinkedHashMap<>();
+        // 不足simulationへ載せる全Pattern回数を、同一世代Snapshotの実Patternへ戻す。
+        for (Map.Entry<String, BigInteger> entry : exactPlan.patternExecutions().entrySet()) {
+            IPatternDetails details = graphSnapshot.pattern(entry.getKey());
+            if (details == null || entry.getValue().signum() <= 0) {
+                return null;
+            }
+            exactPatternTimes.merge(details, entry.getValue(), BigInteger::add);
+        }
+        if (exactPatternTimes.size() > ACOConfig.getCraftingEngineShadowMaximumPatterns()) {
+            return null;
+        }
+        BigInteger exactBytes = topology.calculateBigExactBytes(
+                output,
+                requestedAmount,
+                exactPlan.patternExecutions(),
+                ACOConfig.getBigIntegerMaximumBits());
+        return Ae2CraftingPlanSidecars.expose(
+                new BigIntegerSimulationPlan(
+                        new GenericStack(output, requestedAmount.longValueExact()),
+                        exactPlan,
+                        exactPatternTimes,
+                        exactBytes));
+    }
+
+    private static ICraftingPlan declineOrThrow(
+            Capture capture,
+            AEKey output,
+            long requestedAmount,
+            boolean wide,
+            BigIntegerPlanDeclineReason reason,
+            String detail) {
+        recordDecline(capture, output, requestedAmount, reason, detail);
+        if (wide) {
+            throw new WidePlanUnavailableException(output, detail);
+        }
+        return null;
+    }
+
+    private static void recordDecline(
+            @Nullable Capture capture,
+            @Nullable AEKey output,
+            long requestedAmount,
+            BigIntegerPlanDeclineReason reason,
+            String detail) {
+        BigIntegerPlanDiagnostics.record(
+                reason,
+                output == null ? null : output.getId().toString(),
+                BigInteger.valueOf(requestedAmount),
+                capture == null ? -1L : capture.patternGeneration(),
+                capture == null ? -1L : capture.recipeGeneration(),
+                detail);
     }
 
     private static BigCraftingPlan<AEKey> widenLongPlan(LongCraftingPlan<AEKey> source) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2BigCraftingPlanFactory.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2BigCraftingPlanFactory.java
@@ -46,9 +46,13 @@ public final class Ae2BigCraftingPlanFactory {
         Objects.requireNonNull(output, "output");
         int maximumBits = ACOConfig.getBigIntegerMaximumBits();
         BigCountMath.requireMaximumBits(requestedAmount, "BigInteger root request", maximumBits);
-        // 0以下の注文またはキャンセル済みスレッドからBig jobを作らない。
-        if (requestedAmount.signum() <= 0 || Thread.currentThread().isInterrupted()) {
+        // 0以下の注文はBig jobにしない。
+        if (requestedAmount.signum() <= 0) {
             return null;
+        }
+        // 割込みはAE2 long経路へ戻す理由ではなく、呼出側が再試行できる明示的な中断とする。
+        if (Thread.currentThread().isInterrupted()) {
+            throw new PlanningCancelledException(0);
         }
 
         long patternGeneration = ProviderPatternGenerationTracker.generation();

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2CraftingPlanSidecars.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2CraftingPlanSidecars.java
@@ -71,6 +71,13 @@ public final class Ae2CraftingPlanSidecars {
                 .map(BigIntegerCraftingPlan.class::cast);
     }
 
+    /** 素材不足のBigInteger simulationだけを取得する。実行親Jobとは分離する。 */
+    public static Optional<BigIntegerSimulationPlan> bigIntegerSimulation(ICraftingPlan plan) {
+        return metadata(plan)
+                .filter(BigIntegerSimulationPlan.class::isInstance)
+                .map(BigIntegerSimulationPlan.class::cast);
+    }
+
     /** 個別カウンタはlong内で、CPU容量合計だけがlongを超えた計画を取得する。 */
     public static Optional<BigCapacityCraftingPlan> bigCapacity(ICraftingPlan plan) {
         return metadata(plan)

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2CraftingShadowValidator.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2CraftingShadowValidator.java
@@ -184,7 +184,7 @@ public final class Ae2CraftingShadowValidator {
             }
         } catch (CountOverflowException overflow) {
             OptimizationMetrics.recordCraftingEngineShadowOverflow();
-        } catch (Throwable throwable) {
+        } catch (RuntimeException | LinkageError throwable) {
             OptimizationMetrics.recordCraftingEngineShadowSkipped();
             String key = throwable.getClass().getName() + ':' + output.getId();
             // 同じ出力と例外型のShadow skip理由は一度だけdebugへ残す。

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2StrictCraftingTopology.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2StrictCraftingTopology.java
@@ -51,9 +51,9 @@ final class Ae2StrictCraftingTopology {
         List<InputProof> proofs = new ArrayList<>();
         // 配列Programの全ノードを一度だけ検証し、再帰や共有中間素材の二重訪問を避ける。
         for (int node = 0; node < program.nodeCount(); node++) {
-            // 計算キャンセル時は検証を継続せず、AE2呼出側へFallbackする。
+            // 64ノード単位の検証対象を反復し、割込みをAE2 long経路へ黙って戻さない。
             if (Thread.currentThread().isInterrupted()) {
-                return null;
+                throw new PlanningCancelledException(node);
             }
             AEKey key = program.keyAt(node);
             boolean currentlyEmittable = service.canEmitFor(key);

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigCraftingPlanSummary.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigCraftingPlanSummary.java
@@ -82,6 +82,27 @@ public final class BigCraftingPlanSummary {
             mergeLongCounter(stats, plan.missingItems(), CounterTarget.MISSING, maximumBits);
             mergeLongCounter(stats, plan.emittedItems(), CounterTarget.EMITTED, maximumBits);
             mergeLongPatternOutputs(stats, plan.patternTimes(), maximumBits);
+        } else if (plan instanceof BigIntegerSimulationPlan simulationPlan) {
+            exactBytes = simulationPlan.exactBytes();
+            mergeCounts(
+                    stats,
+                    simulationPlan.exactPlan().usedInventory(),
+                    CounterTarget.STORED,
+                    maximumBits);
+            mergeCounts(
+                    stats,
+                    simulationPlan.exactPlan().missing(),
+                    CounterTarget.MISSING,
+                    maximumBits);
+            mergeCounts(
+                    stats,
+                    simulationPlan.exactPlan().emitted(),
+                    CounterTarget.EMITTED,
+                    maximumBits);
+            mergePatternOutputs(
+                    stats,
+                    simulationPlan.exactPatternTimes(),
+                    maximumBits);
         } else {
             throw new IllegalArgumentException(
                     "Big crafting confirmation requires an ACO wide plan");

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigCraftingPlanSummary.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigCraftingPlanSummary.java
@@ -22,8 +22,6 @@ import java.util.Objects;
  * 互換Summaryを作り、Clientにはlongを越える行だけをACO packetで追加同期する。</p>
  */
 public final class BigCraftingPlanSummary {
-    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
-
     private final BigInteger usedBytes;
     private final boolean simulation;
     private final Map<AEKey, Entry> entries;
@@ -149,12 +147,12 @@ public final class BigCraftingPlanSummary {
         ArrayList<CraftingPlanSummaryEntry> projected = new ArrayList<>(entries.size());
         entries.forEach((key, entry) -> projected.add(new CraftingPlanSummaryEntry(
                 key,
-                saturatedLong(entry.missing()),
-                saturatedLong(entry.stored()),
-                saturatedLong(entry.craft()))));
+                BigIntegerPlanProjection.saturatedLong(entry.missing()),
+                BigIntegerPlanProjection.saturatedLong(entry.stored()),
+                BigIntegerPlanProjection.saturatedLong(entry.craft()))));
         Collections.sort(projected);
         return new CraftingPlanSummary(
-                saturatedLong(usedBytes),
+                BigIntegerPlanProjection.saturatedLong(usedBytes),
                 simulation,
                 List.copyOf(projected));
     }
@@ -214,10 +212,6 @@ public final class BigCraftingPlanSummary {
         });
     }
 
-    private static long saturatedLong(BigInteger value) {
-        return value.compareTo(LONG_MAX) > 0 ? Long.MAX_VALUE : value.longValueExact();
-    }
-
     public record Entry(
             BigInteger stored,
             BigInteger missing,
@@ -236,10 +230,10 @@ public final class BigCraftingPlanSummary {
 
         public boolean requiresExactDisplay() {
             BigInteger requested = stored.add(missing);
-            return stored.compareTo(LONG_MAX) > 0
-                    || missing.compareTo(LONG_MAX) > 0
-                    || craft.compareTo(LONG_MAX) > 0
-                    || requested.compareTo(LONG_MAX) > 0;
+            return BigIntegerPlanProjection.exceedsLong(stored)
+                    || BigIntegerPlanProjection.exceedsLong(missing)
+                    || BigIntegerPlanProjection.exceedsLong(craft)
+                    || BigIntegerPlanProjection.exceedsLong(requested);
         }
     }
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerCraftingPlan.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerCraftingPlan.java
@@ -6,7 +6,6 @@ import appeng.api.stacks.GenericStack;
 import appeng.api.stacks.KeyCounter;
 import com.syaru.ae2craftingoptimizer.optimization.ProviderPatternGenerationTracker;
 import java.math.BigInteger;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -19,8 +18,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * waitingFor、remainingOutput、容量を同じ実Jobへ設置する。通常AE2 CPUは専用Mixinで拒否する。</p>
  */
 public final class BigIntegerCraftingPlan implements WideCraftingPlan {
-    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
-
     private final GenericStack finalOutput;
     private final BigCraftingPlan<AEKey> exactPlan;
     private final Map<IPatternDetails, BigInteger> exactPatternTimes;
@@ -47,7 +44,7 @@ public final class BigIntegerCraftingPlan implements WideCraftingPlan {
             boolean requiresBigIntegerExecution) {
         this.finalOutput = Objects.requireNonNull(finalOutput, "finalOutput");
         this.exactPlan = Objects.requireNonNull(exactPlan, "exactPlan");
-        this.exactPatternTimes = immutablePositiveCounts(
+        this.exactPatternTimes = BigIntegerPlanProjection.immutablePositiveCounts(
                 exactPatternTimes, "exactPatternTimes");
         this.preparedRoot = Objects.requireNonNull(preparedRoot, "preparedRoot");
         // 表示対象とBig親Jobが別注文を指す状態は、提出前に構築エラーとして止める。
@@ -63,10 +60,10 @@ public final class BigIntegerCraftingPlan implements WideCraftingPlan {
             throw new IllegalArgumentException(
                     "BigInteger crafting plan requires an exact-arithmetic reason");
         }
-        this.usedItems = projectKeyCounter(exactPlan.usedInventory());
-        this.emittedItems = projectKeyCounter(exactPlan.emitted());
-        this.missingItems = projectKeyCounter(exactPlan.missing());
-        this.patternTimes = projectPatternCounter(this.exactPatternTimes);
+        this.usedItems = BigIntegerPlanProjection.projectKeyCounter(exactPlan.usedInventory());
+        this.emittedItems = BigIntegerPlanProjection.projectKeyCounter(exactPlan.emitted());
+        this.missingItems = BigIntegerPlanProjection.projectKeyCounter(exactPlan.missing());
+        this.patternTimes = BigIntegerPlanProjection.projectPatternCounter(this.exactPatternTimes);
     }
 
     @Override
@@ -142,26 +139,6 @@ public final class BigIntegerCraftingPlan implements WideCraftingPlan {
                 && preparedRoot.recipeGeneration() == RecipeGenerationTracker.generation();
     }
 
-    private static KeyCounter projectKeyCounter(Map<AEKey, BigInteger> exact) {
-        KeyCounter projected = new KeyCounter();
-        // 画面同期用Facadeだけを作り、BigInteger正本Mapは変更しない。
-        exact.forEach((key, amount) -> projected.add(key, saturatedLong(amount)));
-        return projected;
-    }
-
-    private static Map<IPatternDetails, Long> projectPatternCounter(
-            Map<IPatternDetails, BigInteger> exact) {
-        Map<IPatternDetails, Long> projected = new LinkedHashMap<>();
-        // AE2の画面が要求するMap値だけを飽和し、実行回数はpreparedRoot内へ保持する。
-        exact.forEach((pattern, amount) -> projected.put(pattern, saturatedLong(amount)));
-        return Map.copyOf(projected);
-    }
-
-    private static long saturatedLong(BigInteger amount) {
-        // Long.MAX_VALUE以下だけをexact変換し、超過値を負数へwrapさせない。
-        return amount.compareTo(LONG_MAX) > 0 ? Long.MAX_VALUE : amount.longValueExact();
-    }
-
     private static boolean containsWideCounter(
             BigCraftingPlan<AEKey> plan,
             Map<IPatternDetails, BigInteger> exactPatternTimes) {
@@ -175,26 +152,11 @@ public final class BigIntegerCraftingPlan implements WideCraftingPlan {
         // 各値を個別に調べ、Map全体の合計だけが大きいBigCapacity計画とは区別する。
         for (BigInteger amount : counts.values()) {
             // 個別値がlongを超えた時点で専用親計画が必要になる。
-            if (amount.compareTo(LONG_MAX) > 0) {
+            if (BigIntegerPlanProjection.exceedsLong(amount)) {
                 return true;
             }
         }
         return false;
     }
 
-    private static <K> Map<K, BigInteger> immutablePositiveCounts(
-            Map<K, BigInteger> counts,
-            String name) {
-        Map<K, BigInteger> copy = new LinkedHashMap<>();
-        Objects.requireNonNull(counts, name).forEach((key, amount) -> {
-            Objects.requireNonNull(key, name + " key");
-            BigCountMath.requireNonNegative(amount, name);
-            // Pattern回数0は実行計画へ含めず、負数は上の共通検査で拒否する。
-            if (amount.signum() <= 0) {
-                throw new IllegalArgumentException(name + " values must be positive");
-            }
-            copy.put(key, amount);
-        });
-        return Map.copyOf(copy);
-    }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerPlanProjection.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerPlanProjection.java
@@ -1,0 +1,62 @@
+package com.syaru.ae2craftingoptimizer.engine;
+
+import appeng.api.crafting.IPatternDetails;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.KeyCounter;
+import java.math.BigInteger;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** BigInteger正本を変更せず、AE2のlong固定表示境界へ投影する共通処理。 */
+final class BigIntegerPlanProjection {
+    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
+
+    private BigIntegerPlanProjection() {
+    }
+
+    static KeyCounter projectKeyCounter(Map<AEKey, BigInteger> exact) {
+        KeyCounter projected = new KeyCounter();
+        // AE2の表示用Counterだけを作り、BigInteger Mapを正本として保持する。
+        exact.forEach((key, amount) -> projected.add(key, saturatedLong(amount)));
+        return projected;
+    }
+
+    static Map<IPatternDetails, Long> projectPatternCounter(
+            Map<IPatternDetails, BigInteger> exact) {
+        Map<IPatternDetails, Long> projected = new LinkedHashMap<>();
+        // 画面互換のPattern回数だけを飽和し、正確な回数はSidecarへ残す。
+        exact.forEach((pattern, amount) -> projected.put(pattern, saturatedLong(amount)));
+        return Map.copyOf(projected);
+    }
+
+    static long saturatedLong(BigInteger amount) {
+        Objects.requireNonNull(amount, "amount");
+        // long範囲を超える値を負数へwrapさせず、画面互換の上限へ飽和する。
+        if (exceedsLong(amount)) {
+            return Long.MAX_VALUE;
+        }
+        return amount.longValueExact();
+    }
+
+    static boolean exceedsLong(BigInteger amount) {
+        Objects.requireNonNull(amount, "amount");
+        return amount.compareTo(LONG_MAX) > 0;
+    }
+
+    static <K> Map<K, BigInteger> immutablePositiveCounts(
+            Map<K, BigInteger> counts,
+            String name) {
+        Map<K, BigInteger> copy = new LinkedHashMap<>();
+        Objects.requireNonNull(counts, name).forEach((key, amount) -> {
+            Objects.requireNonNull(key, name + " key");
+            BigCountMath.requireNonNegative(amount, name);
+            // 0以下の値は実行・表示会計へ含められないため拒否する。
+            if (amount.signum() <= 0) {
+                throw new IllegalArgumentException(name + " values must be positive");
+            }
+            copy.put(key, amount);
+        });
+        return Map.copyOf(copy);
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerSimulationPlan.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerSimulationPlan.java
@@ -1,0 +1,160 @@
+package com.syaru.ae2craftingoptimizer.engine;
+
+import appeng.api.crafting.IPatternDetails;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.GenericStack;
+import appeng.api.stacks.KeyCounter;
+import java.math.BigInteger;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * long計算へ戻さずに返す、BigInteger正本の不足simulation計画。
+ *
+ * <p>実行用の{@link BigIntegerCraftingPlan}とは意図的に別型にする。
+ * 素材不足の計画をAQEやInsaneAEの実行境界へ渡さず、AE2の確認画面だけへ返すためである。</p>
+ */
+public final class BigIntegerSimulationPlan implements WideCraftingPlan {
+    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
+
+    private final GenericStack finalOutput;
+    private final BigCraftingPlan<AEKey> exactPlan;
+    private final Map<IPatternDetails, BigInteger> exactPatternTimes;
+    private final KeyCounter usedItems;
+    private final KeyCounter emittedItems;
+    private final KeyCounter missingItems;
+    private final Map<IPatternDetails, Long> patternTimes;
+    private final BigInteger exactBytes;
+
+    public BigIntegerSimulationPlan(
+            GenericStack finalOutput,
+            BigCraftingPlan<AEKey> exactPlan,
+            Map<IPatternDetails, BigInteger> exactPatternTimes,
+            BigInteger exactBytes) {
+        this(
+                finalOutput,
+                exactPlan,
+                exactPatternTimes,
+                exactBytes,
+                com.syaru.ae2craftingoptimizer.config.ACOConfig.getBigIntegerMaximumBits());
+    }
+
+    BigIntegerSimulationPlan(
+            GenericStack finalOutput,
+            BigCraftingPlan<AEKey> exactPlan,
+            Map<IPatternDetails, BigInteger> exactPatternTimes,
+            BigInteger exactBytes,
+            int maximumBits) {
+        this.finalOutput = Objects.requireNonNull(finalOutput, "finalOutput");
+        this.exactPlan = Objects.requireNonNull(exactPlan, "exactPlan");
+        // simulationは不足計画だけを表し、実行可能計画を誤って提出境界へ流さない。
+        if (exactPlan.craftable()) {
+            throw new IllegalArgumentException("BigInteger simulation plan must be missing");
+        }
+        this.exactPatternTimes = immutablePositiveCounts(
+                exactPatternTimes, "exactPatternTimes");
+        this.exactBytes = BigCountMath.requireMaximumBits(
+                Objects.requireNonNull(exactBytes, "exactBytes"),
+                "simulation/exactBytes",
+                maximumBits);
+        // 表示する注文とBigInteger正本が異なる計画を外へ出さない。
+        if (!finalOutput.what().equals(exactPlan.requestedKey())
+                || !BigInteger.valueOf(finalOutput.amount()).equals(exactPlan.requestedAmount())) {
+            throw new IllegalArgumentException("BigInteger simulation metadata is inconsistent");
+        }
+        this.usedItems = projectKeyCounter(exactPlan.usedInventory());
+        this.emittedItems = projectKeyCounter(exactPlan.emitted());
+        this.missingItems = projectKeyCounter(exactPlan.missing());
+        this.patternTimes = projectPatternCounter(this.exactPatternTimes);
+    }
+
+    @Override
+    public GenericStack finalOutput() {
+        return finalOutput;
+    }
+
+    /** AE2互換境界では負数へwrapさせず、long範囲内は正確値、超過だけを飽和する。 */
+    @Override
+    public long bytes() {
+        return saturatedLong(exactBytes);
+    }
+
+    @Override
+    public boolean simulation() {
+        return true;
+    }
+
+    @Override
+    public boolean multiplePaths() {
+        return false;
+    }
+
+    @Override
+    public KeyCounter usedItems() {
+        return usedItems;
+    }
+
+    @Override
+    public KeyCounter emittedItems() {
+        return emittedItems;
+    }
+
+    @Override
+    public KeyCounter missingItems() {
+        return missingItems;
+    }
+
+    @Override
+    public Map<IPatternDetails, Long> patternTimes() {
+        return patternTimes;
+    }
+
+    public BigInteger exactBytes() {
+        return exactBytes;
+    }
+
+    public BigCraftingPlan<AEKey> exactPlan() {
+        return exactPlan;
+    }
+
+    public Map<IPatternDetails, BigInteger> exactPatternTimes() {
+        return exactPatternTimes;
+    }
+
+    private static KeyCounter projectKeyCounter(Map<AEKey, BigInteger> exact) {
+        KeyCounter projected = new KeyCounter();
+        // AE2の表示用Counterだけを作り、BigInteger Mapを正本として保持する。
+        exact.forEach((key, amount) -> projected.add(key, saturatedLong(amount)));
+        return projected;
+    }
+
+    private static Map<IPatternDetails, Long> projectPatternCounter(
+            Map<IPatternDetails, BigInteger> exact) {
+        Map<IPatternDetails, Long> projected = new LinkedHashMap<>();
+        // 画面互換のPattern回数だけを飽和し、正確な回数はSidecarへ残す。
+        exact.forEach((pattern, amount) -> projected.put(pattern, saturatedLong(amount)));
+        return Map.copyOf(projected);
+    }
+
+    private static long saturatedLong(BigInteger amount) {
+        // long範囲を超える値を負数へwrapさせず、画面互換の上限へ飽和する。
+        return amount.compareTo(LONG_MAX) > 0 ? Long.MAX_VALUE : amount.longValueExact();
+    }
+
+    private static Map<IPatternDetails, BigInteger> immutablePositiveCounts(
+            Map<IPatternDetails, BigInteger> counts,
+            String name) {
+        Map<IPatternDetails, BigInteger> copy = new LinkedHashMap<>();
+        Objects.requireNonNull(counts, name).forEach((pattern, amount) -> {
+            Objects.requireNonNull(pattern, name + " key");
+            BigCountMath.requireNonNegative(amount, name);
+            // 実行回数0のPatternは表示・会計へ含めない。
+            if (amount.signum() <= 0) {
+                throw new IllegalArgumentException(name + " values must be positive");
+            }
+            copy.put(pattern, amount);
+        });
+        return Map.copyOf(copy);
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerSimulationPlan.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerSimulationPlan.java
@@ -5,7 +5,6 @@ import appeng.api.stacks.AEKey;
 import appeng.api.stacks.GenericStack;
 import appeng.api.stacks.KeyCounter;
 import java.math.BigInteger;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -16,8 +15,6 @@ import java.util.Objects;
  * 素材不足の計画をAQEやInsaneAEの実行境界へ渡さず、AE2の確認画面だけへ返すためである。</p>
  */
 public final class BigIntegerSimulationPlan implements WideCraftingPlan {
-    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
-
     private final GenericStack finalOutput;
     private final BigCraftingPlan<AEKey> exactPlan;
     private final Map<IPatternDetails, BigInteger> exactPatternTimes;
@@ -52,7 +49,7 @@ public final class BigIntegerSimulationPlan implements WideCraftingPlan {
         if (exactPlan.craftable()) {
             throw new IllegalArgumentException("BigInteger simulation plan must be missing");
         }
-        this.exactPatternTimes = immutablePositiveCounts(
+        this.exactPatternTimes = BigIntegerPlanProjection.immutablePositiveCounts(
                 exactPatternTimes, "exactPatternTimes");
         this.exactBytes = BigCountMath.requireMaximumBits(
                 Objects.requireNonNull(exactBytes, "exactBytes"),
@@ -63,10 +60,10 @@ public final class BigIntegerSimulationPlan implements WideCraftingPlan {
                 || !BigInteger.valueOf(finalOutput.amount()).equals(exactPlan.requestedAmount())) {
             throw new IllegalArgumentException("BigInteger simulation metadata is inconsistent");
         }
-        this.usedItems = projectKeyCounter(exactPlan.usedInventory());
-        this.emittedItems = projectKeyCounter(exactPlan.emitted());
-        this.missingItems = projectKeyCounter(exactPlan.missing());
-        this.patternTimes = projectPatternCounter(this.exactPatternTimes);
+        this.usedItems = BigIntegerPlanProjection.projectKeyCounter(exactPlan.usedInventory());
+        this.emittedItems = BigIntegerPlanProjection.projectKeyCounter(exactPlan.emitted());
+        this.missingItems = BigIntegerPlanProjection.projectKeyCounter(exactPlan.missing());
+        this.patternTimes = BigIntegerPlanProjection.projectPatternCounter(this.exactPatternTimes);
     }
 
     @Override
@@ -77,7 +74,7 @@ public final class BigIntegerSimulationPlan implements WideCraftingPlan {
     /** AE2互換境界では負数へwrapさせず、long範囲内は正確値、超過だけを飽和する。 */
     @Override
     public long bytes() {
-        return saturatedLong(exactBytes);
+        return BigIntegerPlanProjection.saturatedLong(exactBytes);
     }
 
     @Override
@@ -122,39 +119,4 @@ public final class BigIntegerSimulationPlan implements WideCraftingPlan {
         return exactPatternTimes;
     }
 
-    private static KeyCounter projectKeyCounter(Map<AEKey, BigInteger> exact) {
-        KeyCounter projected = new KeyCounter();
-        // AE2の表示用Counterだけを作り、BigInteger Mapを正本として保持する。
-        exact.forEach((key, amount) -> projected.add(key, saturatedLong(amount)));
-        return projected;
-    }
-
-    private static Map<IPatternDetails, Long> projectPatternCounter(
-            Map<IPatternDetails, BigInteger> exact) {
-        Map<IPatternDetails, Long> projected = new LinkedHashMap<>();
-        // 画面互換のPattern回数だけを飽和し、正確な回数はSidecarへ残す。
-        exact.forEach((pattern, amount) -> projected.put(pattern, saturatedLong(amount)));
-        return Map.copyOf(projected);
-    }
-
-    private static long saturatedLong(BigInteger amount) {
-        // long範囲を超える値を負数へwrapさせず、画面互換の上限へ飽和する。
-        return amount.compareTo(LONG_MAX) > 0 ? Long.MAX_VALUE : amount.longValueExact();
-    }
-
-    private static Map<IPatternDetails, BigInteger> immutablePositiveCounts(
-            Map<IPatternDetails, BigInteger> counts,
-            String name) {
-        Map<IPatternDetails, BigInteger> copy = new LinkedHashMap<>();
-        Objects.requireNonNull(counts, name).forEach((pattern, amount) -> {
-            Objects.requireNonNull(pattern, name + " key");
-            BigCountMath.requireNonNegative(amount, name);
-            // 実行回数0のPatternは表示・会計へ含めない。
-            if (amount.signum() <= 0) {
-                throw new IllegalArgumentException(name + " values must be positive");
-            }
-            copy.put(pattern, amount);
-        });
-        return Map.copyOf(copy);
-    }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/WidePlanUnavailableException.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/WidePlanUnavailableException.java
@@ -1,0 +1,25 @@
+package com.syaru.ae2craftingoptimizer.engine;
+
+import appeng.api.stacks.AEKey;
+
+/**
+ * wide計画を正確に作れず、AE2のoverflowするlong計算へ戻してはいけないことを示す例外。
+ * 呼出側は通常のlong計画として再実行せず、診断または再試行可能な失敗として扱う。
+ */
+public final class WidePlanUnavailableException extends RuntimeException {
+    private final AEKey output;
+
+    public WidePlanUnavailableException(AEKey output, String message) {
+        super(message);
+        this.output = output;
+    }
+
+    public WidePlanUnavailableException(AEKey output, String message, Throwable cause) {
+        super(message, cause);
+        this.output = output;
+    }
+
+    public AEKey output() {
+        return output;
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/gtceu/GTCEuRecipeIntentFastPath.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/gtceu/GTCEuRecipeIntentFastPath.java
@@ -93,7 +93,7 @@ public final class GTCEuRecipeIntentFastPath {
                         context.machinePos());
             }
             return new IntentFirstIterator(candidates, original);
-        } catch (Throwable throwable) {
+        } catch (ReflectiveOperationException | RuntimeException | LinkageError throwable) {
             logReflectionFailure("wrap", throwable);
             return original;
         }
@@ -417,7 +417,7 @@ public final class GTCEuRecipeIntentFastPath {
                     }
                 }
                 return ids;
-            } catch (Throwable throwable) {
+            } catch (ReflectiveOperationException | RuntimeException | LinkageError throwable) {
                 logReflectionFailure(fieldName + "Ids", throwable);
                 return List.of();
             }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExperimentalCompatibilityValidator.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExperimentalCompatibilityValidator.java
@@ -2,13 +2,16 @@ package com.syaru.ae2craftingoptimizer.integration;
 
 import com.syaru.ae2craftingoptimizer.access.AdvancedAeExactCraftingJobAccess;
 import com.syaru.ae2craftingoptimizer.access.AdvancedAeExactCraftingLogicAccess;
+import com.syaru.ae2craftingoptimizer.access.BigCapacityPlanBoundaryAccess;
+import com.syaru.ae2craftingoptimizer.access.CheckedCraftingArithmeticHookAccess;
 import com.syaru.ae2craftingoptimizer.access.CraftingClusterHostTransactionAccess;
 import com.syaru.ae2craftingoptimizer.access.CraftingClusterRecoveryAccess;
 import com.syaru.ae2craftingoptimizer.access.CraftingJobTransactionAccess;
 import com.syaru.ae2craftingoptimizer.access.CraftingLogicTransactionAccess;
 import com.syaru.ae2craftingoptimizer.access.CraftingOwnerTransactionAccess;
+import com.syaru.ae2craftingoptimizer.access.CraftingServiceCalculationHookAccess;
 import com.syaru.ae2craftingoptimizer.access.CraftingTaskProgressAccess;
-import com.syaru.ae2craftingoptimizer.access.BigCapacityPlanBoundaryAccess;
+import com.syaru.ae2craftingoptimizer.access.ExactBigIntegerInventoryHookAccess;
 import com.syaru.ae2craftingoptimizer.access.ExactCraftingInventoryAccess;
 import com.syaru.ae2craftingoptimizer.access.MekanismCachedRecipeAccess;
 import com.syaru.ae2craftingoptimizer.access.PatternProviderTransactionAccess;
@@ -33,13 +36,45 @@ public final class ExperimentalCompatibilityValidator {
     }
 
     public static void validateEnabledFeatures() {
-        // Experimental全体またはAQE専用経路のどちらも無効なら、深いMixin契約の監査は不要。
-        if (!ACOConfig.enableExperimentalCraftingEngine()
-                && !ACOConfig.enableAqeBigCraftingProfile()) {
-            return;
-        }
         List<String> failures = new ArrayList<>();
-        requireExactVersion(failures, "ae2", SUPPORTED_AE2_VERSION);
+        /*
+         * InsaneAE単独プロファイルもBigInteger計算を使用する。
+         * AQEだけを見て早期returnすると、同じ必須Mixinの欠落を見逃すため共通判定を使う。
+         */
+        boolean strictCraftingProfile = ACOConfig.enableExperimentalCraftingEngine()
+                || ACOConfig.enableBigCraftingProfile();
+        if (strictCraftingProfile) {
+            requireExactVersion(failures, "ae2", SUPPORTED_AE2_VERSION);
+        }
+        // 計算共有・完了Cache・事前不足判定は同じCraftingService Mixinを使用する。
+        if (ACOConfig.deduplicateActiveCraftingCalculations()
+                || ACOConfig.cacheCompletedCraftingPlans()
+                || ACOConfig.fastFailMissingCrafts()) {
+            require(failures, "appeng.me.service.CraftingService",
+                    CraftingServiceCalculationHookAccess.class);
+        }
+        // long境界検査は四つのAE2計算段階がそろった場合だけ安全に有効化できる。
+        if (ACOConfig.enableCheckedAe2CraftingArithmetic()) {
+            require(failures, "appeng.crafting.CraftingCalculation",
+                    CheckedCraftingArithmeticHookAccess.class);
+            require(failures, "appeng.crafting.CraftingTreeNode",
+                    CheckedCraftingArithmeticHookAccess.class);
+            require(failures, "appeng.crafting.CraftingTreeProcess",
+                    CheckedCraftingArithmeticHookAccess.class);
+            require(failures, "appeng.crafting.inv.CraftingSimulationState",
+                    CheckedCraftingArithmeticHookAccess.class);
+        }
+        // BigInteger在庫は集計・複製・Sidecar破棄・Cache失効の四境界を一組として監査する。
+        if (ACOConfig.enableExactBigIntegerInventorySnapshots()) {
+            require(failures, "appeng.me.storage.NetworkStorage",
+                    ExactBigIntegerInventoryHookAccess.class);
+            require(failures, "appeng.crafting.inv.NetworkCraftingSimulationState",
+                    ExactBigIntegerInventoryHookAccess.class);
+            require(failures, "appeng.api.stacks.KeyCounter",
+                    ExactBigIntegerInventoryHookAccess.class);
+            require(failures, "appeng.me.service.StorageService",
+                    ExactBigIntegerInventoryHookAccess.class);
+        }
         if ((ACOConfig.enableTransactionalBatchingV2()
                         || ACOConfig.enableFairCraftingJobScheduler()
                         || ACOConfig.enableAtomicBigCapacityPlans()

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mekanism/MekanismRecipeIntentFastPath.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mekanism/MekanismRecipeIntentFastPath.java
@@ -118,7 +118,7 @@ public final class MekanismRecipeIntentFastPath {
                         pos.toShortString());
             }
             return null;
-        } catch (Throwable throwable) {
+        } catch (ReflectiveOperationException | RuntimeException | LinkageError throwable) {
             logReflectionFailure("findRecipe:" + tile.getClass().getName(), throwable);
             return null;
         }
@@ -530,7 +530,7 @@ public final class MekanismRecipeIntentFastPath {
         try {
             Object id = invoke(recipe, "m_6423_");
             return String.valueOf(id);
-        } catch (Throwable ignored) {
+        } catch (ReflectiveOperationException | RuntimeException | LinkageError ignored) {
             return recipe.getClass().getName();
         }
     }
@@ -597,7 +597,7 @@ public final class MekanismRecipeIntentFastPath {
                 if (recipes instanceof List<?> list) {
                     return list;
                 }
-            } catch (Throwable throwable) {
+            } catch (ReflectiveOperationException | RuntimeException | LinkageError throwable) {
                 logReflectionFailure("mekanismRecipesFor:" + recipeType.getClass().getName(), throwable);
             }
             return List.of();
@@ -612,7 +612,7 @@ public final class MekanismRecipeIntentFastPath {
                 try {
                     method.setAccessible(true);
                     collectStackIds(method.invoke(recipe), ids, 0);
-                } catch (Throwable throwable) {
+                } catch (ReflectiveOperationException | RuntimeException | LinkageError throwable) {
                     logReflectionFailure("mekanismOutputIds:" + recipe.getClass().getName() + "#" + method.getName(), throwable);
                 }
             }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAePatternProviderLogicNativeBatchReceiptMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAePatternProviderLogicNativeBatchReceiptMixin.java
@@ -217,7 +217,7 @@ public abstract class AdvancedAePatternProviderLogicNativeBatchReceiptMixin
             saveChanges();
             mainNode.ifPresent((grid, node) -> grid.getTickManager().alertDevice(node));
             return ownershipProof(accepted);
-        } catch (Throwable failure) {
+        } catch (RuntimeException | LinkageError failure) {
             if (!ownershipRecorded) {
                 sendList.clear();
                 sendDirection = null;

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCalculationCheckedMathMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCalculationCheckedMathMixin.java
@@ -3,6 +3,7 @@ package com.syaru.ae2craftingoptimizer.mixin;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.KeyCounter;
 import appeng.crafting.CraftingCalculation;
+import com.syaru.ae2craftingoptimizer.access.CheckedCraftingArithmeticHookAccess;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -12,11 +13,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /** 不足数のKeyCounterがlong境界で負数へ巻き戻る前に計算をAE2エラーとして止める。 */
 @Mixin(value = CraftingCalculation.class, remap = false)
-public abstract class CraftingCalculationCheckedMathMixin {
+public abstract class CraftingCalculationCheckedMathMixin
+        implements CheckedCraftingArithmeticHookAccess {
     @Shadow
     private KeyCounter missing;
 
-    @Inject(method = "addMissing", at = @At("HEAD"))
+    @Inject(method = "addMissing", at = @At("HEAD"), require = 1)
     private void aco$validateMissingAdd(AEKey key, long amount, CallbackInfo ci) {
         if (!ACOConfig.enableCheckedAe2CraftingArithmetic()) {
             return;

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCpuLogicExecutionBudgetMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCpuLogicExecutionBudgetMixin.java
@@ -23,7 +23,7 @@ public abstract class CraftingCpuLogicExecutionBudgetMixin {
             at = @At(
                     value = "INVOKE",
                     target = "Lappeng/me/cluster/implementations/CraftingCPUCluster;getCoProcessors()I"),
-            require = 0)
+            require = 1)
     private int aco$limitAe2CraftingExecution(CraftingCPUCluster cluster) {
         return CraftingExecutionBudget.limitCoProcessors(this, cluster, cluster.getCoProcessors());
     }
@@ -33,7 +33,7 @@ public abstract class CraftingCpuLogicExecutionBudgetMixin {
             at = @At(
                     value = "INVOKE",
                     target = "Lappeng/crafting/execution/CraftingCpuLogic;executeCrafting(ILappeng/me/service/CraftingService;Lappeng/api/networking/energy/IEnergyService;Lnet/minecraft/world/level/Level;)I"),
-            require = 0)
+            require = 1)
     private int aco$recordAe2CraftingExecution(
             CraftingCpuLogic logic,
             int maxOperations,

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingServiceCalculationDeduplicationMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingServiceCalculationDeduplicationMixin.java
@@ -6,6 +6,7 @@ import appeng.api.networking.crafting.ICraftingSimulationRequester;
 import appeng.api.networking.IGrid;
 import appeng.api.stacks.AEKey;
 import appeng.me.service.CraftingService;
+import com.syaru.ae2craftingoptimizer.access.CraftingServiceCalculationHookAccess;
 import com.syaru.ae2craftingoptimizer.optimization.CraftingCalculationDeduplicator;
 import com.syaru.ae2craftingoptimizer.optimization.DeterministicCraftingPreflight;
 import java.util.concurrent.Future;
@@ -18,12 +19,17 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = CraftingService.class, remap = false)
-public abstract class CraftingServiceCalculationDeduplicationMixin {
+public abstract class CraftingServiceCalculationDeduplicationMixin
+        implements CraftingServiceCalculationHookAccess {
     @Shadow
     @Final
     private IGrid grid;
 
-    @Inject(method = "beginCraftingCalculation", at = @At("HEAD"), cancellable = true)
+    @Inject(
+            method = "beginCraftingCalculation",
+            at = @At("HEAD"),
+            cancellable = true,
+            require = 1)
     private void aco$reuseActiveCraftingCalculation(
             Level level,
             ICraftingSimulationRequester requester,
@@ -57,7 +63,11 @@ public abstract class CraftingServiceCalculationDeduplicationMixin {
     }
 
     // 戻り値を変換するための代替実装としてcancellableを明示し、非cancellable RETURN注入のCancellationExceptionを防ぐ。
-    @Inject(method = "beginCraftingCalculation", at = @At("RETURN"), cancellable = true)
+    @Inject(
+            method = "beginCraftingCalculation",
+            at = @At("RETURN"),
+            cancellable = true,
+            require = 1)
     private void aco$rememberActiveCraftingCalculation(
             Level level,
             ICraftingSimulationRequester requester,

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingServiceCalculationDeduplicationMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingServiceCalculationDeduplicationMixin.java
@@ -56,7 +56,8 @@ public abstract class CraftingServiceCalculationDeduplicationMixin {
         }
     }
 
-    @Inject(method = "beginCraftingCalculation", at = @At("RETURN"))
+    // 戻り値を変換するための代替実装としてcancellableを明示し、非cancellable RETURN注入のCancellationExceptionを防ぐ。
+    @Inject(method = "beginCraftingCalculation", at = @At("RETURN"), cancellable = true)
     private void aco$rememberActiveCraftingCalculation(
             Level level,
             ICraftingSimulationRequester requester,

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingSimulationStateCheckedMathMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingSimulationStateCheckedMathMixin.java
@@ -5,6 +5,7 @@ import appeng.api.config.Actionable;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.KeyCounter;
 import appeng.crafting.inv.CraftingSimulationState;
+import com.syaru.ae2craftingoptimizer.access.CheckedCraftingArithmeticHookAccess;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import java.util.Map;
 import org.spongepowered.asm.mixin.Mixin;
@@ -15,7 +16,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /** Craft回数のMap加算とdouble bytes蓄積をAE2へ渡す前に検査する。 */
 @Mixin(value = CraftingSimulationState.class, remap = false)
-public abstract class CraftingSimulationStateCheckedMathMixin {
+public abstract class CraftingSimulationStateCheckedMathMixin
+        implements CheckedCraftingArithmeticHookAccess {
     @Shadow
     private double bytes;
 
@@ -28,7 +30,7 @@ public abstract class CraftingSimulationStateCheckedMathMixin {
     @Shadow
     private KeyCounter emittedItems;
 
-    @Inject(method = "insert", at = @At("HEAD"))
+    @Inject(method = "insert", at = @At("HEAD"), require = 1)
     private void aco$validateInventoryInsert(
             AEKey key,
             long amount,
@@ -45,7 +47,7 @@ public abstract class CraftingSimulationStateCheckedMathMixin {
         }
     }
 
-    @Inject(method = "emitItems", at = @At("HEAD"))
+    @Inject(method = "emitItems", at = @At("HEAD"), require = 1)
     private void aco$validateEmittedItems(AEKey key, long amount, CallbackInfo ci) {
         if (!ACOConfig.enableCheckedAe2CraftingArithmetic()) {
             return;
@@ -56,17 +58,18 @@ public abstract class CraftingSimulationStateCheckedMathMixin {
         Math.addExact(emittedItems.get(key), amount);
     }
 
-    @Inject(method = "addCrafting", at = @At("HEAD"))
+    @Inject(method = "addCrafting", at = @At("HEAD"), require = 1)
     private void aco$validateCraftCount(IPatternDetails details, long count, CallbackInfo ci) {
-        if (ACOConfig.enableCheckedAe2CraftingArithmetic()) {
-            if (count < 0L) {
-                throw new ArithmeticException("negative AE2 crafting count");
-            }
-            Math.addExact(crafts.getOrDefault(details, 0L), count);
+        if (!ACOConfig.enableCheckedAe2CraftingArithmetic()) {
+            return;
         }
+        if (count < 0L) {
+            throw new ArithmeticException("negative AE2 crafting count");
+        }
+        Math.addExact(crafts.getOrDefault(details, 0L), count);
     }
 
-    @Inject(method = "addBytes", at = @At("HEAD"))
+    @Inject(method = "addBytes", at = @At("HEAD"), require = 1)
     private void aco$validateBytes(double amount, CallbackInfo ci) {
         if (!ACOConfig.enableCheckedAe2CraftingArithmetic()) {
             return;

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingTreeCalculationMemoMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingTreeCalculationMemoMixin.java
@@ -26,7 +26,7 @@ public abstract class CraftingTreeCalculationMemoMixin {
     @Redirect(
             method = {"<init>", "findCraftedStack"},
             at = @At(value = "INVOKE", target = "Lappeng/api/networking/crafting/ICraftingService;canEmitFor(Lappeng/api/stacks/AEKey;)Z"),
-            require = 0)
+            require = 2)
     private boolean aco$memoizeCanEmit(ICraftingService service, AEKey key) {
         return CraftingCalculationMemo.canEmit(job, service, key);
     }
@@ -34,7 +34,7 @@ public abstract class CraftingTreeCalculationMemoMixin {
     @Redirect(
             method = "findCraftedStack",
             at = @At(value = "INVOKE", target = "Lappeng/api/networking/crafting/ICraftingService;getCraftingFor(Lappeng/api/stacks/AEKey;)Ljava/util/Collection;"),
-            require = 0)
+            require = 1)
     private java.util.Collection<IPatternDetails> aco$memoizePatternLookup(ICraftingService service, AEKey key) {
         return CraftingCalculationMemo.patterns(job, service, key);
     }
@@ -42,7 +42,7 @@ public abstract class CraftingTreeCalculationMemoMixin {
     @Redirect(
             method = "findCraftedStack",
             at = @At(value = "INVOKE", target = "Lappeng/api/networking/crafting/ICraftingService;getFuzzyCraftable(Lappeng/api/stacks/AEKey;Lappeng/api/storage/AEKeyFilter;)Lappeng/api/stacks/AEKey;"),
-            require = 0)
+            require = 1)
     private AEKey aco$memoizeFuzzyCraftable(
             ICraftingService service, AEKey key, appeng.api.storage.AEKeyFilter filter) {
         return CraftingCalculationMemo.fuzzyCraftable(
@@ -52,7 +52,7 @@ public abstract class CraftingTreeCalculationMemoMixin {
     @Redirect(
             method = "addContainerItems",
             at = @At(value = "INVOKE", target = "Lappeng/api/crafting/IPatternDetails$IInput;getRemainingKey(Lappeng/api/stacks/AEKey;)Lappeng/api/stacks/AEKey;"),
-            require = 0)
+            require = 1)
     private AEKey aco$memoizeRemainingKey(IPatternDetails.IInput input, AEKey template) {
         return CraftingCalculationMemo.remainingKey(job, input, template);
     }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingTreeCandidatePruningMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingTreeCandidatePruningMixin.java
@@ -29,7 +29,7 @@ public abstract class CraftingTreeCandidatePruningMixin {
             at = @At(
                     value = "INVOKE",
                     target = "Lappeng/api/networking/crafting/ICraftingService;getCraftingFor(Lappeng/api/stacks/AEKey;)Ljava/util/Collection;"),
-            require = 0)
+            require = 1)
     private Collection<IPatternDetails> aco$pruneInvalidCandidates(ICraftingService craftingService, AEKey output) {
         return PatternCandidatePruner.prune(
                 CraftingCalculationMemo.patterns(job, craftingService, output), what);

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingTreeNodeCheckedMathMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingTreeNodeCheckedMathMixin.java
@@ -4,6 +4,7 @@ import appeng.api.stacks.AEKey;
 import appeng.api.stacks.KeyCounter;
 import appeng.crafting.CraftingTreeNode;
 import appeng.crafting.inv.CraftingSimulationState;
+import com.syaru.ae2craftingoptimizer.access.CheckedCraftingArithmeticHookAccess;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.engine.CheckedLongMath;
 import org.spongepowered.asm.mixin.Final;
@@ -15,7 +16,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /** CraftingTreeNode内のunchecked LMULが負数へ巻き戻る前に停止する。 */
 @Mixin(value = CraftingTreeNode.class, remap = false)
-public abstract class CraftingTreeNodeCheckedMathMixin {
+public abstract class CraftingTreeNodeCheckedMathMixin
+        implements CheckedCraftingArithmeticHookAccess {
     @Shadow
     @Final
     private AEKey what;
@@ -24,7 +26,7 @@ public abstract class CraftingTreeNodeCheckedMathMixin {
     @Final
     private long amount;
 
-    @Inject(method = "request", at = @At("HEAD"))
+    @Inject(method = "request", at = @At("HEAD"), require = 1)
     private void aco$validateNodeRequest(
             CraftingSimulationState inventory,
             long requestedAmount,

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingTreeProcessCheckedMathMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingTreeProcessCheckedMathMixin.java
@@ -4,6 +4,7 @@ import appeng.api.crafting.IPatternDetails;
 import appeng.crafting.CraftingTreeNode;
 import appeng.crafting.CraftingTreeProcess;
 import appeng.crafting.inv.CraftingSimulationState;
+import com.syaru.ae2craftingoptimizer.access.CheckedCraftingArithmeticHookAccess;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.engine.CheckedLongMath;
 import java.util.Map;
@@ -16,7 +17,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /** Pattern入力Multiplierと出力数量のunchecked LMULを検査する。 */
 @Mixin(value = CraftingTreeProcess.class, remap = false)
-public abstract class CraftingTreeProcessCheckedMathMixin {
+public abstract class CraftingTreeProcessCheckedMathMixin
+        implements CheckedCraftingArithmeticHookAccess {
     @Shadow
     @Final
     private IPatternDetails details;
@@ -25,7 +27,7 @@ public abstract class CraftingTreeProcessCheckedMathMixin {
     @Final
     private Map<CraftingTreeNode, Long> nodes;
 
-    @Inject(method = "request", at = @At("HEAD"))
+    @Inject(method = "request", at = @At("HEAD"), require = 1)
     private void aco$validateProcessRequest(
             CraftingSimulationState inventory,
             long times,

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/KeyCounterBigIntegerSidecarLifecycleMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/KeyCounterBigIntegerSidecarLifecycleMixin.java
@@ -1,6 +1,7 @@
 package com.syaru.ae2craftingoptimizer.mixin;
 
 import appeng.api.stacks.KeyCounter;
+import com.syaru.ae2craftingoptimizer.access.ExactBigIntegerInventoryHookAccess;
 import com.syaru.ae2craftingoptimizer.engine.BigKeyCounterSidecars;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -9,8 +10,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /** AE2がKeyCounterを再利用する時、前回集計のBigInteger Sidecarも同時に破棄する。 */
 @Mixin(value = KeyCounter.class, remap = false)
-public abstract class KeyCounterBigIntegerSidecarLifecycleMixin {
-    @Inject(method = {"clear", "reset"}, at = @At("HEAD"))
+public abstract class KeyCounterBigIntegerSidecarLifecycleMixin
+        implements ExactBigIntegerInventoryHookAccess {
+    @Inject(method = {"clear", "reset"}, at = @At("HEAD"), require = 2)
     private void aco$clearExactInventorySidecar(CallbackInfo ci) {
         BigKeyCounterSidecars.clear((KeyCounter) (Object) this);
     }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/NetworkCraftingSimulationStateBigIntegerSnapshotMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/NetworkCraftingSimulationStateBigIntegerSnapshotMixin.java
@@ -4,6 +4,7 @@ import appeng.api.networking.security.IActionSource;
 import appeng.api.networking.storage.IStorageService;
 import appeng.api.stacks.KeyCounter;
 import appeng.crafting.inv.NetworkCraftingSimulationState;
+import com.syaru.ae2craftingoptimizer.access.ExactBigIntegerInventoryHookAccess;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.engine.BigKeyCounterSidecars;
 import org.spongepowered.asm.mixin.Final;
@@ -15,12 +16,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /** AE2がクラフト計算用に複製したKeyCounterへ、正確なBigInteger Snapshotも伝播する。 */
 @Mixin(value = NetworkCraftingSimulationState.class, remap = false)
-public abstract class NetworkCraftingSimulationStateBigIntegerSnapshotMixin {
+public abstract class NetworkCraftingSimulationStateBigIntegerSnapshotMixin
+        implements ExactBigIntegerInventoryHookAccess {
     @Shadow
     @Final
     private KeyCounter list;
 
-    @Inject(method = "<init>", at = @At("RETURN"))
+    @Inject(method = "<init>", at = @At("RETURN"), require = 1)
     private void aco$copyExactNetworkInventory(
             IStorageService storageService,
             IActionSource actionSource,

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/NetworkStorageBigIntegerSnapshotMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/NetworkStorageBigIntegerSnapshotMixin.java
@@ -6,6 +6,7 @@ import appeng.api.stacks.AEKey;
 import appeng.api.stacks.KeyCounter;
 import appeng.api.storage.MEStorage;
 import appeng.me.storage.NetworkStorage;
+import com.syaru.ae2craftingoptimizer.access.ExactBigIntegerInventoryHookAccess;
 import com.syaru.ae2craftingoptimizer.integration.BigIntegerStorageSnapshotBridge;
 import com.syaru.ae2craftingoptimizer.integration.ExactNetworkStorageSnapshotCache;
 import org.spongepowered.asm.mixin.Mixin;
@@ -17,11 +18,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /** mounted storageごとの正確値を集計し、同一世代の重複Network走査を抑える。 */
 @Mixin(value = NetworkStorage.class, priority = 900, remap = false)
-public abstract class NetworkStorageBigIntegerSnapshotMixin {
+public abstract class NetworkStorageBigIntegerSnapshotMixin
+        implements ExactBigIntegerInventoryHookAccess {
     @Inject(
             method = "getAvailableStacks",
             at = @At("HEAD"),
-            cancellable = true)
+            cancellable = true,
+            require = 1)
     private void aco$reuseExactNetworkSnapshot(
             KeyCounter networkCounter,
             CallbackInfo ci) {
@@ -50,7 +53,8 @@ public abstract class NetworkStorageBigIntegerSnapshotMixin {
 
     @Inject(
             method = "getAvailableStacks",
-            at = @At("RETURN"))
+            at = @At("RETURN"),
+            require = 1)
     private void aco$rememberExactNetworkSnapshot(
             KeyCounter networkCounter,
             CallbackInfo ci) {
@@ -61,7 +65,8 @@ public abstract class NetworkStorageBigIntegerSnapshotMixin {
 
     @Inject(
             method = {"mount", "unmount"},
-            at = @At("HEAD"))
+            at = @At("HEAD"),
+            require = 2)
     private void aco$invalidateExactSnapshotAfterMountChange(
             CallbackInfo ci) {
         // mount優先順または構成が変わる前に、依存する全Network Snapshotを失効させる。
@@ -70,7 +75,8 @@ public abstract class NetworkStorageBigIntegerSnapshotMixin {
 
     @Inject(
             method = "insert",
-            at = @At("RETURN"))
+            at = @At("RETURN"),
+            require = 1)
     private void aco$invalidateExactSnapshotAfterInsert(
             AEKey key,
             long amount,
@@ -85,7 +91,8 @@ public abstract class NetworkStorageBigIntegerSnapshotMixin {
 
     @Inject(
             method = "extract",
-            at = @At("RETURN"))
+            at = @At("RETURN"),
+            require = 1)
     private void aco$invalidateExactSnapshotAfterExtract(
             AEKey key,
             long amount,

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/PatternProviderLogicNativeBatchReceiptMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/PatternProviderLogicNativeBatchReceiptMixin.java
@@ -209,7 +209,7 @@ public abstract class PatternProviderLogicNativeBatchReceiptMixin
             ((PatternProviderLogic) (Object) this).saveChanges();
             mainNode.ifPresent((grid, node) -> grid.getTickManager().alertDevice(node));
             return ownershipProof(accepted);
-        } catch (Throwable failure) {
+        } catch (RuntimeException | LinkageError failure) {
             if (!ownershipRecorded) {
                 sendList.clear();
                 sendDirection = null;

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/StorageServiceDeepCoalescingMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/StorageServiceDeepCoalescingMixin.java
@@ -28,7 +28,7 @@ public abstract class StorageServiceDeepCoalescingMixin {
             at = @At(
                     value = "INVOKE",
                     target = "Lappeng/me/service/StorageService;updateCachedStacks()V"),
-            require = 0)
+            require = 1)
     private void aco$coalesceAggregateRefresh(StorageService service) {
         long currentTick = TickHandler.instance().getCurrentTick();
         if (ACOConfig.deepNetworkForceUpdateCoalescing()
@@ -41,17 +41,17 @@ public abstract class StorageServiceDeepCoalescingMixin {
         aco$lastAggregateRefreshTick = currentTick;
     }
 
-    @Inject(method = "addNode", at = @At("HEAD"))
+    @Inject(method = "addNode", at = @At("HEAD"), require = 1)
     private void aco$refreshAfterNodeAdd(IGridNode node, CompoundTag savedData, CallbackInfo ci) {
         aco$lastAggregateRefreshTick = Long.MIN_VALUE;
     }
 
-    @Inject(method = "removeNode", at = @At("HEAD"))
+    @Inject(method = "removeNode", at = @At("HEAD"), require = 1)
     private void aco$refreshAfterNodeRemove(IGridNode node, CallbackInfo ci) {
         aco$lastAggregateRefreshTick = Long.MIN_VALUE;
     }
 
-    @Inject(method = "invalidateCache", at = @At("HEAD"))
+    @Inject(method = "invalidateCache", at = @At("HEAD"), require = 1)
     private void aco$refreshAfterExplicitInvalidation(CallbackInfo ci) {
         aco$lastAggregateRefreshTick = Long.MIN_VALUE;
     }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/StorageServiceExactSnapshotInvalidationMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/StorageServiceExactSnapshotInvalidationMixin.java
@@ -1,6 +1,7 @@
 package com.syaru.ae2craftingoptimizer.mixin;
 
 import appeng.me.service.StorageService;
+import com.syaru.ae2craftingoptimizer.access.ExactBigIntegerInventoryHookAccess;
 import com.syaru.ae2craftingoptimizer.integration.ExactNetworkStorageSnapshotCache;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -9,7 +10,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /** AE2が集約在庫をdirtyにした時、ACOの同一tick Snapshotも同時に失効させる。 */
 @Mixin(value = StorageService.class, remap = false)
-public abstract class StorageServiceExactSnapshotInvalidationMixin {
+public abstract class StorageServiceExactSnapshotInvalidationMixin
+        implements ExactBigIntegerInventoryHookAccess {
     @Inject(
             method = "invalidateCache",
             at = @At("HEAD"),

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/StorageServiceWatcherThrottleMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/StorageServiceWatcherThrottleMixin.java
@@ -15,6 +15,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = StorageService.class, remap = false)
 public abstract class StorageServiceWatcherThrottleMixin {
+    @Inject(method = "postWatcherUpdate", at = @At("HEAD"))
+    private void aco$advanceStorageGeneration(AEKey key, long amount, CallbackInfo ci) {
+        CraftingCalculationDeduplicator.onStorageChange();
+    }
+
     @Redirect(
             method = "postWatcherUpdate",
             at = @At(

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/StorageServiceWatcherThrottleMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/StorageServiceWatcherThrottleMixin.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = StorageService.class, remap = false)
 public abstract class StorageServiceWatcherThrottleMixin {
-    @Inject(method = "postWatcherUpdate", at = @At("HEAD"))
+    @Inject(method = "postWatcherUpdate", at = @At("HEAD"), require = 1)
     private void aco$advanceStorageGeneration(AEKey key, long amount, CallbackInfo ci) {
         CraftingCalculationDeduplicator.onStorageChange();
     }
@@ -25,29 +25,29 @@ public abstract class StorageServiceWatcherThrottleMixin {
             at = @At(
                     value = "INVOKE",
                     target = "Lappeng/api/networking/storage/IStorageWatcherNode;onStackChange(Lappeng/api/stacks/AEKey;J)V"),
-            require = 0)
+            require = 2)
     private void aco$bufferStorageWatcherUpdate(IStorageWatcherNode watcher, AEKey key, long amount) {
         StorageWatcherUpdateBuffer.onStackChange(watcher, key, amount);
     }
 
-    @Inject(method = "onServerEndTick", at = @At("TAIL"))
+    @Inject(method = "onServerEndTick", at = @At("TAIL"), require = 1)
     private void aco$flushStorageWatcherUpdatesOnTick(CallbackInfo ci) {
         StorageWatcherUpdateBuffer.tick();
     }
 
-    @Inject(method = "addNode", at = @At("HEAD"))
+    @Inject(method = "addNode", at = @At("HEAD"), require = 1)
     private void aco$flushBeforeStorageNodeAdd(IGridNode node, CompoundTag savedData, CallbackInfo ci) {
         StorageWatcherUpdateBuffer.flush();
         CraftingCalculationDeduplicator.clearCompleted("storage node added");
     }
 
-    @Inject(method = "removeNode", at = @At("HEAD"))
+    @Inject(method = "removeNode", at = @At("HEAD"), require = 1)
     private void aco$flushBeforeStorageNodeRemove(IGridNode node, CallbackInfo ci) {
         StorageWatcherUpdateBuffer.flush();
         CraftingCalculationDeduplicator.clearCompleted("storage node removed");
     }
 
-    @Inject(method = "invalidateCache", at = @At("HEAD"))
+    @Inject(method = "invalidateCache", at = @At("HEAD"), require = 1)
     private void aco$flushBeforeStorageCacheInvalidation(CallbackInfo ci) {
         StorageWatcherUpdateBuffer.flush();
         CraftingCalculationDeduplicator.clearCompleted("storage cache invalidated");

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/BatchedCraftingExecutor.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/BatchedCraftingExecutor.java
@@ -210,7 +210,7 @@ public final class BatchedCraftingExecutor {
             return transactionCount >= maximumTransactions || !hasTimeRemaining(deadlineNanos)
                     ? 0
                     : NOT_HANDLED;
-        } catch (Throwable throwable) {
+        } catch (RuntimeException | LinkageError throwable) {
             if (pendingExtraction != null && pendingInventory != null && !commitStarted) {
                 CraftingCpuHelper.reinjectPatternInputs(
                         pendingInventory,
@@ -340,7 +340,7 @@ public final class BatchedCraftingExecutor {
                 }
             }
             return new BatchExtraction(extracted);
-        } catch (Throwable throwable) {
+        } catch (RuntimeException | LinkageError throwable) {
             CraftingCpuHelper.reinjectPatternInputs(inventory, extracted);
             throw throwable;
         }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/BigIntegerPlanDeclineReason.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/BigIntegerPlanDeclineReason.java
@@ -1,0 +1,21 @@
+package com.syaru.ae2craftingoptimizer.optimization;
+
+/** BigInteger計画を採用できなかった理由を、ログと統計で安定して識別するコード。 */
+public enum BigIntegerPlanDeclineReason {
+    DISABLED,
+    INVALID_REQUEST,
+    NO_COMPILED_PROGRAM,
+    UNSUPPORTED_TOPOLOGY,
+    INCOMPLETE_INVENTORY,
+    SHADOW_NOT_QUALIFIED,
+    GENERATION_CHANGED,
+    INVENTORY_CHANGED,
+    TOPOLOGY_CHANGED,
+    MISSING_SIMULATION,
+    EXECUTION_WINDOW_UNAVAILABLE,
+    EXECUTION_DISABLED,
+    PLAN_NOT_PROVEN,
+    CANCELLED,
+    ARITHMETIC_FAILURE,
+    INTERNAL_FAILURE
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/BigIntegerPlanDiagnostics.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/BigIntegerPlanDiagnostics.java
@@ -1,0 +1,79 @@
+package com.syaru.ae2craftingoptimizer.optimization;
+
+import com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer;
+import com.syaru.ae2craftingoptimizer.config.ACOConfig;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+import org.jetbrains.annotations.Nullable;
+
+/** BigInteger経路の採用・辞退理由を、計算結果と分離して記録する。 */
+public final class BigIntegerPlanDiagnostics {
+    private static final Map<BigIntegerPlanDeclineReason, LongAdder> COUNTERS =
+            new ConcurrentHashMap<>();
+
+    private BigIntegerPlanDiagnostics() {
+    }
+
+    public static void record(
+            BigIntegerPlanDeclineReason reason,
+            @Nullable String outputId,
+            String detail) {
+        record(reason, outputId, null, -1L, -1L, detail);
+    }
+
+    public static void record(
+            BigIntegerPlanDeclineReason reason,
+            @Nullable String outputId,
+            @Nullable BigInteger requestedAmount,
+            long patternGeneration,
+            long recipeGeneration,
+            String detail) {
+        COUNTERS.computeIfAbsent(reason, ignored -> new LongAdder()).increment();
+        // 詳細ログは設定時だけ出し、通常時のログ汚染を避ける。
+        // ユニット試験や早期初期化ではConfig未ロードでも統計記録を継続する。
+        if (!detailedLoggingEnabled()) {
+            return;
+        }
+        AE2CraftingOptimizer.LOGGER.debug(
+                "ACO BigInteger plan declined: reason={}, output={}, requested={}, "
+                        + "patternGeneration={}, recipeGeneration={}, thread={}, detail={}",
+                reason,
+                outputId == null ? "<unknown>" : outputId,
+                requestedAmount == null ? "<unknown>" : requestedAmount,
+                patternGeneration < 0L ? "<unknown>" : patternGeneration,
+                recipeGeneration < 0L ? "<unknown>" : recipeGeneration,
+                Thread.currentThread().getName(),
+                detail);
+    }
+
+    private static boolean detailedLoggingEnabled() {
+        try {
+            return ACOConfig.logBigIntegerPlanDeclines();
+        } catch (IllegalStateException configNotLoaded) {
+            return false;
+        }
+    }
+
+    public static List<String> summaryLines() {
+        List<String> lines = new ArrayList<>();
+        // enum順で出力し、同じ環境の/aco statsを比較可能にする。
+        for (BigIntegerPlanDeclineReason reason : BigIntegerPlanDeclineReason.values()) {
+            LongAdder counter = COUNTERS.get(reason);
+            // 未発生の理由は統計表示を短くするため省略する。
+            if (counter == null || counter.sum() == 0L) {
+                continue;
+            }
+            lines.add("BigInteger plan " + reason + ": " + counter.sum());
+        }
+        return List.copyOf(lines);
+    }
+
+    public static void reset() {
+        // 現在の理由カウンタだけをリセットし、参照中のMapを差し替えない。
+        COUNTERS.values().forEach(LongAdder::reset);
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/CraftingCalculationDeduplicator.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/CraftingCalculationDeduplicator.java
@@ -60,7 +60,11 @@ public final class CraftingCalculationDeduplicator {
                         strategy);
             }
             OptimizationMetrics.recordCraftingCalculationDeduplication(true);
-            return entry.future.acquire();
+            Future<ICraftingPlan> subscriber = entry.future.acquire();
+            // 最後の購読者がキャンセルした直後は、古い共有Futureを再利用しない。
+            return subscriber != null
+                    ? subscriber
+                    : findCompletedLocked(craftingService, requestKey, now);
         }
     }
 
@@ -85,7 +89,13 @@ public final class CraftingCalculationDeduplicator {
             Entry existing = serviceEntries.get(requestKey);
             if (existing != null && existing.isReusable(now)) {
                 OptimizationMetrics.recordCraftingCalculationDeduplication(true);
-                return existing.future.acquire();
+                Future<ICraftingPlan> subscriber = existing.future.acquire();
+                // 共有Futureが閉じた競合窓では、今回のAE2 Futureを新しい所有者にする。
+                if (subscriber != null) {
+                    // 既存計算を返す場合、新しく生成された重複Futureだけを停止する。
+                    future.cancel(false);
+                    return subscriber;
+                }
             }
             SharedCalculationFuture<ICraftingPlan> shared = new SharedCalculationFuture<>(future);
             serviceEntries.put(requestKey, new Entry(shared, now));

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/CraftingCalculationDeduplicator.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/CraftingCalculationDeduplicator.java
@@ -7,6 +7,7 @@ import appeng.api.stacks.AEKey;
 import appeng.me.service.CraftingService;
 import com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
+import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
 import com.syaru.ae2craftingoptimizer.integration.AppliedECompatibility;
 import com.syaru.ae2craftingoptimizer.engine.RecipeGenerationTracker;
 import com.syaru.ae2craftingoptimizer.optimization.ProviderPatternGenerationTracker;
@@ -15,6 +16,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicLong;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
 
@@ -22,6 +24,7 @@ public final class CraftingCalculationDeduplicator {
     private static final Map<CraftingService, Map<RequestKey, Entry>> ACTIVE_CALCULATIONS = new WeakHashMap<>();
     private static final Map<CraftingService, Map<RequestKey, CompletedEntry>> COMPLETED_PLANS = new WeakHashMap<>();
     private static final long NANOS_PER_TICK = 50_000_000L;
+    private static final AtomicLong STORAGE_GENERATION = new AtomicLong();
 
     private CraftingCalculationDeduplicator() {
     }
@@ -76,7 +79,11 @@ public final class CraftingCalculationDeduplicator {
             long amount,
             CalculationStrategy strategy,
             Future<ICraftingPlan> future) {
-        if (!ACOConfig.deduplicateActiveCraftingCalculations() || future == null || future.isDone() || future.isCancelled()) {
+        // 重複排除OFFまたは再利用不能な戻り値は、所有権を変更せずそのまま返す。
+        if (!ACOConfig.deduplicateActiveCraftingCalculations()
+                || future == null
+                || future.isDone()
+                || future.isCancelled()) {
             return future;
         }
 
@@ -88,6 +95,10 @@ public final class CraftingCalculationDeduplicator {
             cleanupActive(craftingService, serviceEntries, now);
             Entry existing = serviceEntries.get(requestKey);
             if (existing != null && existing.isReusable(now)) {
+                // HEAD注入ですでに取得した購読者は、RETURN注入で再取得・cancelしない。
+                if (existing.future.owns(future)) {
+                    return future;
+                }
                 OptimizationMetrics.recordCraftingCalculationDeduplication(true);
                 Future<ICraftingPlan> subscriber = existing.future.acquire();
                 // 共有Futureが閉じた競合窓では、今回のAE2 Futureを新しい所有者にする。
@@ -99,7 +110,7 @@ public final class CraftingCalculationDeduplicator {
             }
             SharedCalculationFuture<ICraftingPlan> shared = new SharedCalculationFuture<>(future);
             serviceEntries.put(requestKey, new Entry(shared, now));
-            return shared.acquire();
+            return shared.acquireOrDelegate();
         }
     }
 
@@ -113,16 +124,6 @@ public final class CraftingCalculationDeduplicator {
         }
     }
 
-    /** Invalidate only in-flight work when storage content changes. */
-    public static void clearActive(String reason) {
-        synchronized (ACTIVE_CALCULATIONS) {
-            ACTIVE_CALCULATIONS.clear();
-        }
-        if (ACOConfig.logCraftingCalculationDeduplication()) {
-            AE2CraftingOptimizer.LOGGER.debug("Cleared active AE2 crafting calculations: {}", reason);
-        }
-    }
-
     public static void clearCompleted(String reason) {
         synchronized (ACTIVE_CALCULATIONS) {
             COMPLETED_PLANS.clear();
@@ -130,6 +131,11 @@ public final class CraftingCalculationDeduplicator {
         if (ACOConfig.logCraftingCalculationDeduplication()) {
             AE2CraftingOptimizer.LOGGER.debug("Cleared completed AE2 crafting plan cache: {}", reason);
         }
+    }
+
+    public static void onStorageChange() {
+        // 内容世代を進め、変更前のactive計算とcompleted計画を新規要求から分離する。
+        STORAGE_GENERATION.incrementAndGet();
     }
 
     private static Future<ICraftingPlan> findCompletedLocked(CraftingService craftingService, RequestKey requestKey, long now) {
@@ -206,6 +212,11 @@ public final class CraftingCalculationDeduplicator {
             return false;
         }
 
+        // Wide実行計画は提出Claimと親Jobを一度だけ所有するため、成功計画キャッシュへ入れない。
+        if (Ae2CraftingPlanSidecars.isWide(plan) && !plan.simulation()) {
+            return false;
+        }
+
         if (AppliedECompatibility.requiresFreshCalculation(plan)) {
             // 一時Patternを再利用するとKnowledgeServiceへの追加処理を通らないため保持しない。
             OptimizationMetrics.recordAppliedECompletedPlanCacheBypass();
@@ -243,7 +254,8 @@ public final class CraftingCalculationDeduplicator {
             long amount,
             CalculationStrategy strategy,
             long patternGeneration,
-            long recipeGeneration) {
+            long recipeGeneration,
+            long storageGeneration) {
         private static RequestKey of(
                 Level level,
                 ICraftingSimulationRequester requester,
@@ -257,7 +269,8 @@ public final class CraftingCalculationDeduplicator {
                     amount,
                     strategy,
                     ProviderPatternGenerationTracker.generation(),
-                    RecipeGenerationTracker.generation());
+                    RecipeGenerationTracker.generation(),
+                    STORAGE_GENERATION.get());
         }
     }
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationMetrics.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationMetrics.java
@@ -1,6 +1,7 @@
 package com.syaru.ae2craftingoptimizer.optimization;
 
 import com.syaru.ae2craftingoptimizer.api.vector.VectorResourceMode;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.LongAccumulator;
 import java.util.concurrent.atomic.LongAdder;
@@ -311,7 +312,7 @@ public final class OptimizationMetrics {
         long reflectionMisses = REFLECTION_LOOKUP_MISSES.sum();
         long upgradeHits = AE2_OVERCLOCK_UPGRADE_COUNT_HITS.sum();
         long upgradeMisses = AE2_OVERCLOCK_UPGRADE_COUNT_MISSES.sum();
-        return List.of(
+        List<String> lines = new ArrayList<>(List.of(
                 "Shared CPU budget: " + SHARED_BUDGET_LIMITS.sum()
                         + " limit(s), " + SHARED_DEFERRED_OPERATIONS.sum() + " operation(s) deferred",
                 "GTCEu intent candidate cache: " + gtHits + " hit(s), " + gtMisses
@@ -384,7 +385,9 @@ public final class OptimizationMetrics {
                 "ExtendedAE Assembly Matrix: " + ASSEMBLER_MATRIX_THREAD_COUNT_HITS.sum()
                         + " thread-count hit(s), " + ASSEMBLER_MATRIX_BUSY_COUNT_HITS.sum()
                         + " busy-count hit(s), " + ASSEMBLER_MATRIX_STATUS_UPDATES_COALESCED.sum()
-                        + " status update(s) coalesced");
+                         + " status update(s) coalesced"));
+        lines.addAll(BigIntegerPlanDiagnostics.summaryLines());
+        return List.copyOf(lines);
     }
 
     public static void reset() {
@@ -443,6 +446,7 @@ public final class OptimizationMetrics {
         EXACT_VECTOR_RECEIPT_FREE_ROLLBACKS.reset();
         EXACT_VECTOR_FINGERPRINT_REVALIDATIONS.reset();
         EXACT_VECTOR_MAX_ACTIVE_TICK_NANOS.reset();
+        BigIntegerPlanDiagnostics.reset();
         EXACT_VECTOR_STEPS_SCANNED.reset();
         EXACT_VECTOR_ACTIVE_STEPS_PROCESSED.reset();
         EXACT_VECTOR_ACCOUNTING_REBUILDS.reset();

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/PatternProviderBatchEligibility.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/PatternProviderBatchEligibility.java
@@ -119,7 +119,7 @@ public final class PatternProviderBatchEligibility {
                     selectedSide.getOpposite(),
                     selectedTarget,
                     targets.size() == 1);
-        } catch (Throwable ignored) {
+        } catch (RuntimeException | LinkageError ignored) {
             return null;
         }
     }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/SharedCalculationFuture.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/SharedCalculationFuture.java
@@ -3,23 +3,29 @@ package com.syaru.ae2craftingoptimizer.optimization;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
 /**
  * Shares one AE2 calculation without allowing one requester's cancellation to
  * cancel the calculation still used by other requesters.
  */
 final class SharedCalculationFuture<T> {
     private final Future<T> delegate;
-    private final AtomicInteger subscribers = new AtomicInteger();
+    private final Object lock = new Object();
+    private int subscribers;
+    private boolean cancellationRequested;
 
     SharedCalculationFuture(Future<T> delegate) {
         this.delegate = delegate;
     }
 
     Future<T> acquire() {
-        subscribers.incrementAndGet();
-        return new Subscriber();
+        synchronized (lock) {
+            // 完了済み計算は新しい所有権を持たせず、そのまま読み取り専用で共有する。
+            if (delegate.isDone() || cancellationRequested) {
+                return null;
+            }
+            subscribers++;
+            return new Subscriber(true);
+        }
     }
 
     Future<T> delegate() {
@@ -34,27 +40,46 @@ final class SharedCalculationFuture<T> {
         return delegate.isCancelled();
     }
 
-    private void release(boolean mayInterruptIfRunning) {
-        int remaining = subscribers.decrementAndGet();
-        if (remaining == 0 && !delegate.isDone()) {
+    private void release(boolean mayInterruptIfRunning, boolean tracked) {
+        if (!tracked) {
+            return;
+        }
+        boolean cancelDelegate = false;
+        synchronized (lock) {
+            // 同じSubscriberからの二重cancelを下流Futureへ二重伝播させない。
+            subscribers--;
+            // 最後の所有者が離れた時だけ、AE2の計算本体をキャンセルする。
+            if (subscribers == 0 && !delegate.isDone() && !cancellationRequested) {
+                cancellationRequested = true;
+                cancelDelegate = true;
+            }
+        }
+        // delegate.cancelは外部実装の処理を含むため、共有ロックの外で呼び出す。
+        if (cancelDelegate) {
             delegate.cancel(mayInterruptIfRunning);
         }
     }
 
     private final class Subscriber implements Future<T> {
+        private final boolean tracked;
         private volatile boolean cancelled;
         private boolean released;
+
+        private Subscriber(boolean tracked) {
+            this.tracked = tracked;
+        }
 
         @Override
         public boolean cancel(boolean mayInterruptIfRunning) {
             synchronized (this) {
+                // 同一呼出し元の二重cancelは所有者数を減らさない。
                 if (cancelled || released || isDone()) {
                     return false;
                 }
                 cancelled = true;
                 released = true;
             }
-            release(mayInterruptIfRunning);
+            release(mayInterruptIfRunning, tracked);
             return true;
         }
 
@@ -83,6 +108,7 @@ final class SharedCalculationFuture<T> {
         }
 
         private void ensureNotCancelled() {
+            // 自分だけがキャンセルした場合は、他の購読者の結果を隠す。
             if (cancelled) {
                 throw new CancellationException();
             }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/SharedCalculationFuture.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/SharedCalculationFuture.java
@@ -28,6 +28,12 @@ final class SharedCalculationFuture<T> {
         }
     }
 
+    Future<T> acquireOrDelegate() {
+        Future<T> subscriber = acquire();
+        // 包装中に完了した計算はnullへ置換せず、読み取り可能な元Futureを返す。
+        return subscriber != null ? subscriber : delegate;
+    }
+
     Future<T> delegate() {
         return delegate;
     }
@@ -38,6 +44,14 @@ final class SharedCalculationFuture<T> {
 
     boolean isCancelled() {
         return delegate.isCancelled();
+    }
+
+    boolean owns(Future<?> candidate) {
+        // RETURN注入で同じ購読者を再登録しないため、作成元の共有Futureを照合する。
+        if (!(candidate instanceof SubscriberHandle handle)) {
+            return false;
+        }
+        return handle.owner() == this;
     }
 
     private void release(boolean mayInterruptIfRunning, boolean tracked) {
@@ -60,13 +74,22 @@ final class SharedCalculationFuture<T> {
         }
     }
 
-    private final class Subscriber implements Future<T> {
+    private interface SubscriberHandle {
+        SharedCalculationFuture<?> owner();
+    }
+
+    private final class Subscriber implements Future<T>, SubscriberHandle {
         private final boolean tracked;
         private volatile boolean cancelled;
         private boolean released;
 
         private Subscriber(boolean tracked) {
             this.tracked = tracked;
+        }
+
+        @Override
+        public SharedCalculationFuture<?> owner() {
+            return SharedCalculationFuture.this;
         }
 
         @Override
@@ -96,7 +119,10 @@ final class SharedCalculationFuture<T> {
         @Override
         public T get() throws InterruptedException, java.util.concurrent.ExecutionException {
             ensureNotCancelled();
-            return delegate.get();
+            T result = delegate.get();
+            // 待機中にこの購読者だけがキャンセルされた場合も、共有結果を返さない。
+            ensureNotCancelled();
+            return result;
         }
 
         @Override
@@ -104,7 +130,10 @@ final class SharedCalculationFuture<T> {
                 throws InterruptedException, java.util.concurrent.ExecutionException,
                 java.util.concurrent.TimeoutException {
             ensureNotCancelled();
-            return delegate.get(timeout, unit);
+            T result = delegate.get(timeout, unit);
+            // timed getの待機中にキャンセルされた場合も、通常getと同じ契約を守る。
+            ensureNotCancelled();
+            return result;
         }
 
         private void ensureNotCancelled() {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/StorageWatcherUpdateBuffer.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/StorageWatcherUpdateBuffer.java
@@ -16,9 +16,6 @@ public final class StorageWatcherUpdateBuffer {
     }
 
     public static void onStackChange(IStorageWatcherNode watcher, AEKey key, long amount) {
-        // Any in-flight plan may have used the previous amount. Do not reuse it
-        // across an inventory generation boundary.
-        CraftingCalculationDeduplicator.clearActive("storage watcher update");
         if (!ACOConfig.throttleStorageWatcherUpdates()) {
             watcher.onStackChange(key, amount);
             return;

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/TransactionalCraftingExecutorV2.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/TransactionalCraftingExecutorV2.java
@@ -389,7 +389,7 @@ public final class TransactionalCraftingExecutorV2 {
                     return accountingMode == BatchCpuAccountingMode.SINGLE_PHYSICAL_OPERATION
                             ? 1
                             : Math.toIntExact(accepted);
-                } catch (Throwable failure) {
+                } catch (RuntimeException | LinkageError failure) {
                     if (!targetAccepted && !commitStarted) {
                         try {
                             selection.adapter().rollback(selection.context(), prepared);
@@ -405,7 +405,7 @@ public final class TransactionalCraftingExecutorV2 {
                                     level.getGameTime(),
                                     NOT_HANDLED,
                                     "source rollback will be retried after " + failure);
-                        } catch (Throwable rollbackFailure) {
+                        } catch (RuntimeException | LinkageError rollbackFailure) {
                             safeQuarantine(
                                     transaction,
                                     level.getGameTime(),
@@ -425,7 +425,7 @@ public final class TransactionalCraftingExecutorV2 {
                 }
             }
             return NOT_HANDLED;
-        } catch (Throwable failure) {
+        } catch (RuntimeException | LinkageError failure) {
             logFailure(logic.getClass(), failure);
             return NOT_HANDLED;
         }
@@ -688,7 +688,7 @@ public final class TransactionalCraftingExecutorV2 {
             String detail) {
         try {
             transaction.reconciliationRequired(gameTick, detail);
-        } catch (Throwable journalFailure) {
+        } catch (RuntimeException | LinkageError journalFailure) {
             AE2CraftingOptimizer.LOGGER.error(
                     "ACO could not persist V2 reconciliation state: {}",
                     journalFailure.toString());
@@ -701,7 +701,7 @@ public final class TransactionalCraftingExecutorV2 {
             String detail) {
         try {
             transaction.quarantine(gameTick, detail);
-        } catch (Throwable journalFailure) {
+        } catch (RuntimeException | LinkageError journalFailure) {
             AE2CraftingOptimizer.LOGGER.error(
                     "ACO could not persist V2 quarantine state: {}",
                     journalFailure.toString());
@@ -742,14 +742,14 @@ public final class TransactionalCraftingExecutorV2 {
             BatchTransactionRecord record) {
         try {
             Ae2BatchSourceReconciler.INSTANCE.forgetResolvedSource(level, record);
-        } catch (Throwable cleanupFailure) {
+        } catch (RuntimeException | LinkageError cleanupFailure) {
             AE2CraftingOptimizer.LOGGER.warn(
                     "ACO retained a terminal source receipt after journal completion {}: {}",
                     record.id(), cleanupFailure.toString());
         }
         try {
             adapter.forgetResolvedTarget(context, record.id());
-        } catch (Throwable cleanupFailure) {
+        } catch (RuntimeException | LinkageError cleanupFailure) {
             AE2CraftingOptimizer.LOGGER.warn(
                     "ACO retained a terminal target receipt after journal completion {}: {}",
                     record.id(), cleanupFailure.toString());

--- a/src/main/java/com/syaru/ae2craftingoptimizer/transaction/BatchTransactionRecovery.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/transaction/BatchTransactionRecovery.java
@@ -64,7 +64,7 @@ public final class BatchTransactionRecovery {
                 case ACCEPTED -> reconcileAccepted(
                         journal, record, gameTick, adapter, source, level, target);
             }
-        } catch (Throwable throwable) {
+        } catch (RuntimeException | LinkageError throwable) {
             logOnce(record, "recovery threw " + throwable);
         }
     }
@@ -170,14 +170,14 @@ public final class BatchTransactionRecovery {
             BatchTransactionRecord record) {
         try {
             source.forgetResolvedSource(level, record);
-        } catch (Throwable cleanupFailure) {
+        } catch (RuntimeException | LinkageError cleanupFailure) {
             AE2CraftingOptimizer.LOGGER.warn(
                     "ACO retained a recovered terminal source receipt {}: {}",
                     record.id(), cleanupFailure.toString());
         }
         try {
             adapter.forgetResolvedTarget(level, record);
-        } catch (Throwable cleanupFailure) {
+        } catch (RuntimeException | LinkageError cleanupFailure) {
             AE2CraftingOptimizer.LOGGER.warn(
                     "ACO retained a recovered terminal target receipt {}: {}",
                     record.id(), cleanupFailure.toString());

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/Ae2CraftingPlanSidecarsTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/Ae2CraftingPlanSidecarsTest.java
@@ -3,6 +3,7 @@ package com.syaru.ae2craftingoptimizer.engine;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import appeng.api.crafting.IPatternDetails;
 import appeng.api.stacks.AEKey;
@@ -10,6 +11,7 @@ import appeng.api.stacks.AEKeyType;
 import appeng.api.stacks.GenericStack;
 import appeng.api.stacks.KeyCounter;
 import appeng.crafting.CraftingPlan;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
 import net.minecraft.core.BlockPos;
@@ -70,6 +72,36 @@ class Ae2CraftingPlanSidecarsTest {
         assertSame(
                 secondMetadata,
                 Ae2CraftingPlanSidecars.metadata(secondFacade).orElseThrow());
+    }
+
+    @Test
+    void preservesExactMissingSimulationBehindAe2Facade() {
+        BigInteger exactMissing = BigInteger.TEN.pow(30);
+        BigCraftingPlan<AEKey> exactPlan = new BigCraftingPlan<>(
+                TEST_KEY,
+                BigInteger.ONE,
+                Map.of(),
+                Map.of(),
+                Map.of(),
+                Map.of(TEST_KEY, exactMissing),
+                0);
+        BigIntegerSimulationPlan simulation = new BigIntegerSimulationPlan(
+                FINAL_OUTPUT,
+                exactPlan,
+                Map.of(),
+                exactMissing,
+                4096);
+
+        CraftingPlan exposed = Ae2CraftingPlanSidecars.expose(simulation);
+
+        assertTrue(exposed.simulation());
+        assertEquals(Long.MAX_VALUE, exposed.missingItems().get(TEST_KEY));
+        assertEquals(exactMissing, Ae2CraftingPlanSidecars.bigIntegerSimulation(exposed)
+                .orElseThrow()
+                .exactPlan()
+                .missing()
+                .get(TEST_KEY));
+        assertEquals(Long.MAX_VALUE, exposed.bytes());
     }
 
     private record FakeWidePlan(String id) implements WideCraftingPlan {

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerPlanProjectionTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerPlanProjectionTest.java
@@ -1,0 +1,40 @@
+package com.syaru.ae2craftingoptimizer.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigInteger;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class BigIntegerPlanProjectionTest {
+    @Test
+    void longBoundaryIsExactAndOnlyOverflowIsSaturated() {
+        BigInteger maximum = BigInteger.valueOf(Long.MAX_VALUE);
+
+        assertEquals(Long.MAX_VALUE, BigIntegerPlanProjection.saturatedLong(maximum));
+        assertEquals(
+                Long.MAX_VALUE,
+                BigIntegerPlanProjection.saturatedLong(maximum.add(BigInteger.ONE)));
+        assertEquals(42L, BigIntegerPlanProjection.saturatedLong(BigInteger.valueOf(42L)));
+    }
+
+    @Test
+    void positiveCountCopyRejectsZeroAndNegativeValues() {
+        assertEquals(
+                Map.of("pattern", BigInteger.ONE),
+                BigIntegerPlanProjection.immutablePositiveCounts(
+                        Map.of("pattern", BigInteger.ONE),
+                        "patterns"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> BigIntegerPlanProjection.immutablePositiveCounts(
+                        Map.of("pattern", BigInteger.ZERO),
+                        "patterns"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> BigIntegerPlanProjection.immutablePositiveCounts(
+                        Map.of("pattern", BigInteger.valueOf(-1L)),
+                        "patterns"));
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/CriticalMixinContractSourceTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/CriticalMixinContractSourceTest.java
@@ -1,0 +1,117 @@
+package com.syaru.ae2craftingoptimizer.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/** BigInteger正本を支える必須Mixinが、将来の編集で静かに任意化されることを防ぐ。 */
+class CriticalMixinContractSourceTest {
+    private static final Path PRODUCTION_ROOT = Path.of("src", "main", "java");
+    private static final Path MIXIN_ROOT = PRODUCTION_ROOT.resolve(
+            Path.of("com", "syaru", "ae2craftingoptimizer", "mixin"));
+    private static final Path VALIDATOR = PRODUCTION_ROOT.resolve(
+            Path.of("com", "syaru", "ae2craftingoptimizer", "integration",
+                    "ExperimentalCompatibilityValidator.java"));
+
+    @Test
+    void criticalMixinsDeclareFailClosedInjectionCountsAndAuditMarkers() {
+        Map<String, Contract> contracts = Map.of(
+                "CraftingServiceCalculationDeduplicationMixin.java",
+                new Contract("CraftingServiceCalculationHookAccess", 2L),
+                "CraftingCalculationCheckedMathMixin.java",
+                new Contract("CheckedCraftingArithmeticHookAccess", 1L),
+                "CraftingTreeNodeCheckedMathMixin.java",
+                new Contract("CheckedCraftingArithmeticHookAccess", 1L),
+                "CraftingTreeProcessCheckedMathMixin.java",
+                new Contract("CheckedCraftingArithmeticHookAccess", 1L),
+                "CraftingSimulationStateCheckedMathMixin.java",
+                new Contract("CheckedCraftingArithmeticHookAccess", 4L),
+                "NetworkCraftingSimulationStateBigIntegerSnapshotMixin.java",
+                new Contract("ExactBigIntegerInventoryHookAccess", 1L),
+                "NetworkStorageBigIntegerSnapshotMixin.java",
+                new Contract("ExactBigIntegerInventoryHookAccess", 6L),
+                "KeyCounterBigIntegerSidecarLifecycleMixin.java",
+                new Contract("ExactBigIntegerInventoryHookAccess", 1L),
+                "StorageServiceExactSnapshotInvalidationMixin.java",
+                new Contract("ExactBigIntegerInventoryHookAccess", 1L));
+
+        contracts.forEach((fileName, contract) -> {
+            String source = read(MIXIN_ROOT.resolve(fileName));
+            assertTrue(
+                    source.contains("implements " + contract.marker()),
+                    fileName + " must expose its runtime audit marker");
+            assertEquals(
+                    contract.requiredInjectionCount(),
+                    source.lines().filter(line -> line.contains("require =")).count(),
+                    fileName + " must fail closed at every verified injection point");
+        });
+    }
+
+    @Test
+    void compatibilityAuditCoversBothBigIntegerProfilesAndCriticalSurfaces() {
+        String source = read(VALIDATOR);
+        assertTrue(source.contains("enableBigCraftingProfile()"));
+        assertTrue(source.contains("CraftingServiceCalculationHookAccess.class"));
+        assertTrue(source.contains("CheckedCraftingArithmeticHookAccess.class"));
+        assertTrue(source.contains("ExactBigIntegerInventoryHookAccess.class"));
+    }
+
+    @Test
+    void verifiedAe2CoreOptimizationsDoNotSilentlyDisableTheirInjectionPoints() {
+        Map<String, Long> requiredInjectionLines = Map.of(
+                "CraftingCpuLogicExecutionBudgetMixin.java", 2L,
+                "CraftingCpuLogicTransactionalBatchV2Mixin.java", 1L,
+                "CraftingTreeCalculationMemoMixin.java", 4L,
+                "CraftingTreeCandidatePruningMixin.java", 1L,
+                "StorageServiceDeepCoalescingMixin.java", 4L,
+                "StorageServiceWatcherThrottleMixin.java", 6L);
+
+        requiredInjectionLines.forEach((fileName, requiredLines) -> {
+            String source = read(MIXIN_ROOT.resolve(fileName));
+            assertEquals(
+                    requiredLines,
+                    source.lines().filter(line -> line.contains("require =")).count(),
+                    fileName + " must declare every verified injection count");
+            assertFalse(
+                    source.contains("require = 0"),
+                    fileName + " must not silently disable an AE2 core hook");
+        });
+    }
+
+    @Test
+    void broadThrowableCatchIsLimitedToTheMethodHandleInvocationBoundary() throws IOException {
+        List<String> offenders;
+        try (Stream<Path> files = Files.walk(PRODUCTION_ROOT)) {
+            offenders = files
+                    .filter(path -> path.toString().endsWith(".java"))
+                    .filter(path -> read(path).contains("catch (Throwable"))
+                    .map(PRODUCTION_ROOT::relativize)
+                    .map(path -> path.toString().replace('\\', '/'))
+                    .sorted()
+                    .toList();
+        }
+        assertEquals(
+                List.of("com/syaru/ae2craftingoptimizer/optimization/MethodHandleInvocationCache.java"),
+                offenders);
+    }
+
+    private static String read(Path path) {
+        try {
+            return Files.readString(path);
+        } catch (IOException exception) {
+            throw new UncheckedIOException(path.toString(), exception);
+        }
+    }
+
+    private record Contract(String marker, long requiredInjectionCount) {
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/optimization/BigIntegerPlanDiagnosticsTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/optimization/BigIntegerPlanDiagnosticsTest.java
@@ -1,0 +1,28 @@
+package com.syaru.ae2craftingoptimizer.optimization;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class BigIntegerPlanDiagnosticsTest {
+    @AfterEach
+    void resetDiagnostics() {
+        BigIntegerPlanDiagnostics.reset();
+    }
+
+    @Test
+    void recordsExactDeclineReasonForStats() {
+        BigIntegerPlanDiagnostics.record(
+                BigIntegerPlanDeclineReason.ARITHMETIC_FAILURE,
+                "minecraft:iron",
+                BigInteger.TEN.pow(30),
+                12L,
+                13L,
+                "overflow in exact planner");
+
+        assertTrue(BigIntegerPlanDiagnostics.summaryLines().stream()
+                .anyMatch(line -> line.contains("ARITHMETIC_FAILURE") && line.endsWith(": 1")));
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/optimization/SharedCalculationFutureTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/optimization/SharedCalculationFutureTest.java
@@ -2,10 +2,15 @@ package com.syaru.ae2craftingoptimizer.optimization;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.Test;
 
 class SharedCalculationFutureTest {
@@ -43,5 +48,119 @@ class SharedCalculationFutureTest {
         SharedCalculationFuture<String> shared = new SharedCalculationFuture<>(delegate);
 
         assertTrue(shared.acquire() == null);
+        assertSame(delegate, shared.acquireOrDelegate());
+    }
+
+    @Test
+    void subscriberOwnershipIsScopedToItsSharedCalculation() {
+        SharedCalculationFuture<String> first = new SharedCalculationFuture<>(new CompletableFuture<>());
+        SharedCalculationFuture<String> second = new SharedCalculationFuture<>(new CompletableFuture<>());
+        Future<String> subscriber = first.acquire();
+
+        assertTrue(first.owns(subscriber));
+        assertFalse(second.owns(subscriber));
+        assertFalse(first.owns(CompletableFuture.completedFuture("plan")));
+    }
+
+    @Test
+    void cancellationWhileGetIsWaitingDoesNotLeakSharedResult() throws Exception {
+        assertCancellationWhileWaiting(false);
+    }
+
+    @Test
+    void cancellationWhileTimedGetIsWaitingDoesNotLeakSharedResult() throws Exception {
+        assertCancellationWhileWaiting(true);
+    }
+
+    private static void assertCancellationWhileWaiting(boolean timedGet) throws Exception {
+        BlockingFuture<String> delegate = new BlockingFuture<>();
+        SharedCalculationFuture<String> shared = new SharedCalculationFuture<>(delegate);
+        Future<String> cancelledSubscriber = shared.acquire();
+        Future<String> survivingSubscriber = shared.acquire();
+
+        CompletableFuture<Throwable> observed = CompletableFuture.supplyAsync(() -> {
+            try {
+                // timed getと通常getの双方で、待機開始後キャンセルの競合を再現する。
+                if (timedGet) {
+                    cancelledSubscriber.get(5L, TimeUnit.SECONDS);
+                } else {
+                    cancelledSubscriber.get();
+                }
+                return null;
+            } catch (Exception failure) {
+                return failure;
+            }
+        });
+
+        assertTrue(delegate.awaitGetCall(5L, TimeUnit.SECONDS));
+        assertTrue(cancelledSubscriber.cancel(false));
+        assertFalse(delegate.isCancelled());
+        delegate.complete("plan");
+
+        Throwable failure = observed.get(5L, TimeUnit.SECONDS);
+        assertTrue(failure instanceof CancellationException);
+        assertEquals("plan", survivingSubscriber.get(5L, TimeUnit.SECONDS));
+    }
+
+    private static final class BlockingFuture<T> implements Future<T> {
+        private final CountDownLatch getCalled = new CountDownLatch(1);
+        private final CountDownLatch completed = new CountDownLatch(1);
+        private volatile boolean cancelled;
+        private T value;
+
+        boolean awaitGetCall(long timeout, TimeUnit unit) throws InterruptedException {
+            return getCalled.await(timeout, unit);
+        }
+
+        void complete(T completedValue) {
+            value = completedValue;
+            completed.countDown();
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            // 完了済みFutureは通常のFuture契約どおりキャンセルしない。
+            if (isDone()) {
+                return false;
+            }
+            cancelled = true;
+            completed.countDown();
+            return true;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled;
+        }
+
+        @Override
+        public boolean isDone() {
+            return cancelled || completed.getCount() == 0L;
+        }
+
+        @Override
+        public T get() throws InterruptedException {
+            getCalled.countDown();
+            completed.await();
+            return completedValue();
+        }
+
+        @Override
+        public T get(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException {
+            getCalled.countDown();
+            // 指定時間内にテスト用Futureが完了しない場合は、競合試験を明示的に失敗させる。
+            if (!completed.await(timeout, unit)) {
+                throw new TimeoutException("blocking test future timed out");
+            }
+            return completedValue();
+        }
+
+        private T completedValue() {
+            // 下流Future自体がキャンセルされた場合だけCancellationExceptionを返す。
+            if (cancelled) {
+                throw new CancellationException();
+            }
+            return value;
+        }
     }
 }

--- a/src/test/java/com/syaru/ae2craftingoptimizer/optimization/SharedCalculationFutureTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/optimization/SharedCalculationFutureTest.java
@@ -36,4 +36,12 @@ class SharedCalculationFutureTest {
         assertTrue(second.cancel(true));
         assertTrue(delegate.isCancelled());
     }
+
+    @Test
+    void completedDelegateDoesNotCreateAStaleSubscriber() {
+        CompletableFuture<String> delegate = CompletableFuture.completedFuture("plan");
+        SharedCalculationFuture<String> shared = new SharedCalculationFuture<>(delegate);
+
+        assertTrue(shared.acquire() == null);
+    }
 }


### PR DESCRIPTION
## 概要

NeoForge 1.21.1向けに、long超過のBigInteger計画と重複排除Futureのキャンセル所有権を修正します。

## 原因

long超過かつ素材不足の計画が、正確なBigInteger不足計画へ昇格する前にAE2標準long経路へ戻っていました。加えて、`CraftingService.beginCraftingCalculation`の非cancellableなRETURN注入で共有Futureへ戻り値を差し替えたため、重複排除時に`CancellationException`が発生していました。

レビューでは、共有Futureに次の競合も確認しました。

- `get()`待機中にその購読者だけをキャンセルしても、別購読者が計算を継続すると結果を受け取れてしまう
- Futureを共有表へ登録した直後に計算が完了すると、呼出元へ`null Future`を返せる
- 在庫変更後も、変更前のcompleted planを短時間再利用できる
- 一回限りの提出Claimを持つWide実行計画を、成功計画キャッシュへ再登録できる

## 変更内容

- `BigIntegerSimulationPlan`を追加し、正確な不足量、Pattern回数、bytesをSidecarへ保持
- `CraftingCalculation.computePlan`実経路でwide計画をBigIntegerへ昇格
- `CRAFT_LESS`ではBigInteger二分探索で成立量を求め、近似値を返さない
- wide計画の未証明、世代変更、在庫変更、算術失敗をlongへ黙って戻さず、明示的な辞退理由として扱う
- requested amount、Pattern/Recipe世代、出力ID、スレッドを診断ログへ含める
- RETURN注入をcancellableにし、共有Futureを購読者単位でキャンセルする
- 待機前後で購読者キャンセルを検査し、共有計算の結果漏れを防止
- 高速完了時は元Futureを返し、`null Future`を防止
- 在庫世代を重複排除キーへ加え、変更前のactive/completed計画と新規要求を分離
- Wide実行計画をcompleted plan cacheから除外
- BigInteger正本からAE2表示用longへ投影する処理を共通化
- fingerprintから実Patternへ戻す処理を実行計画と不足simulationで共通化
- 回復不能な`Error`を通常フォールバックとして捕捉しない
- GameTestの回帰条件を`docs/LUNA_BIGINT_GAMETEST.md`へ記録

ACOはBigInteger計画と公開APIだけを担当します。InsaneAEのCPU実行ロジック、Task Fusion、構造、GUI、モデル、テクスチャ、レシピには介入しません。

## 検証

- `gradlew.bat clean build --no-daemon -PacoLocalModsDir=<dependency-dir>`: 成功
- JUnit: 327件成功、失敗0、エラー0、スキップ0
- 静的検査: `git diff --check`が成功
- 待機中キャンセル、timed get、高速完了、購読者所有権、long境界投影の回帰試験を追加
- Minecraftクライアント、専用サーバー、GameTest実行: 未実施。指示書に従いユーザー側確認とする

## 参照

- 再現報告: https://github.com/taikun24/InsaneAE/issues/6#issuecomment-5264634773
- 診断ブランチ: https://github.com/taikun24/InsaneAE/tree/diag/aco-bigint
