### PR TITLE
[1.21.1] Native Batchの最小実行数契約を追加

### DIFF
--- a/docs/BATCH_API.md
+++ b/docs/BATCH_API.md
@@ -56,6 +56,10 @@ remove terminal source and target receipts
 
 An adapter must obey these rules:
 
+- `minimumExecutions` is evaluated after task progress, waiting-output,
+  source-energy, and source-inventory limits. When the final available count is
+  smaller, ACO moves no input and leaves that execution call to AE2's normal
+  path. The default is `1`, preserving existing adapters.
 - The transaction UUID, pattern fingerprint, offered count, exact aggregate
   inputs, and expected outputs must remain unchanged through recovery.
 - `commit` returns either zero or the complete offered count. Partial native

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/TransactionalPatternBatchAdapter.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/TransactionalPatternBatchAdapter.java
@@ -34,6 +34,15 @@ public interface TransactionalPatternBatchAdapter {
 
     boolean supports(PatternBatchContext context);
 
+    /**
+     * 在庫、waitingFor、電力を適用した後で一括経路を使う最小実行回数。
+     *
+     * <p>ACOはこの数まで入力が同時に揃わない場合、入力を抽出せず通常AE2経路へ戻す。</p>
+     */
+    default long minimumExecutions(PatternBatchContext context) {
+        return 1L;
+    }
+
     default long limitExecutions(PatternBatchContext context, long offeredExecutions) {
         return offeredExecutions;
     }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/BatchMinimumExecutionPolicy.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/BatchMinimumExecutionPolicy.java
@@ -1,0 +1,22 @@
+package com.syaru.ae2craftingoptimizer.optimization;
+
+/** Native Batchを開始する最小実行回数の共通検証。 */
+final class BatchMinimumExecutionPolicy {
+    private BatchMinimumExecutionPolicy() {
+    }
+
+    static boolean isEligible(
+            long finalExecutions,
+            long minimumExecutions) {
+        // Adapterの不正な契約値を通常経路への無言Fallbackとして隠さない。
+        if (minimumExecutions <= 0L) {
+            throw new IllegalArgumentException(
+                    "minimum batch executions must be positive");
+        }
+        // 0は現在利用できる入力がない状態であり、Batchを開始しない。
+        if (finalExecutions <= 0L) {
+            return false;
+        }
+        return finalExecutions >= minimumExecutions;
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationMetrics.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationMetrics.java
@@ -38,6 +38,7 @@ public final class OptimizationMetrics {
     private static final Map<FallbackReasonCode, LongAdder> CRAFTING_FALLBACK_REASONS = new ConcurrentHashMap<>();
     private static final LongAdder NATIVE_BATCH_TRANSACTIONS = new LongAdder();
     private static final Map<String, LongAdder> NATIVE_BATCH_EXECUTIONS = new ConcurrentHashMap<>();
+    private static final Map<String, LongAdder> NATIVE_BATCH_MINIMUM_DECLINES = new ConcurrentHashMap<>();
     private static final LongAdder INSTANT_DISPATCH_CALLS = new LongAdder();
     private static final LongAdder INSTANT_DISPATCH_MULTI_TRANSACTION_CALLS = new LongAdder();
     private static final LongAdder INSTANT_DISPATCH_TRANSACTIONS = new LongAdder();
@@ -181,6 +182,14 @@ public final class OptimizationMetrics {
     public static void recordNativePatternBatch(String adapterId, long executions) {
         NATIVE_BATCH_TRANSACTIONS.increment();
         NATIVE_BATCH_EXECUTIONS.computeIfAbsent(adapterId, ignored -> new LongAdder()).add(executions);
+    }
+
+    public static void recordNativeBatchMinimumDecline(String adapterId) {
+        NATIVE_BATCH_MINIMUM_DECLINES
+                .computeIfAbsent(
+                        adapterId,
+                        ignored -> new LongAdder())
+                .increment();
     }
 
     /** Instantが一回のCPU呼び出しで実際に何取引を配送したかを記録する。 */
@@ -336,7 +345,8 @@ public final class OptimizationMetrics {
                         + " completed-plan hit(s)",
                 "AE2 fallback reasons: " + CRAFTING_FALLBACK_REASONS,
                 "Experimental native batch: " + NATIVE_BATCH_TRANSACTIONS.sum()
-                        + " transaction(s), executions by adapter " + NATIVE_BATCH_EXECUTIONS,
+                        + " transaction(s), executions by adapter " + NATIVE_BATCH_EXECUTIONS
+                        + ", below-minimum fallback(s) by adapter " + NATIVE_BATCH_MINIMUM_DECLINES,
                 "Sequential Instant: " + SEQUENTIAL_INSTANT_WAVES.sum()
                         + " wave(s), " + SEQUENTIAL_INSTANT_COMPLETED.sum()
                         + "/" + SEQUENTIAL_INSTANT_REQUESTED.sum() + " operation(s), "

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/TransactionalCraftingExecutorV2.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/TransactionalCraftingExecutorV2.java
@@ -233,7 +233,23 @@ public final class TransactionalCraftingExecutorV2 {
                             energyService);
                 }
                 requested = limitByInventory(plan.inputsPerExecution(), requested, inventory);
-                if (requested < 1L) {
+                long minimumExecutions = selection.adapter()
+                        .minimumExecutions(
+                                selection.context());
+                /*
+                 * 予定Task数ではなく、waitingFor・電力・現在在庫で縮小した最終数を判定する。
+                 * 素材が一個ずつ届く巨大Jobを、一回ずつ重いTransactionへ入れない。
+                 */
+                if (!BatchMinimumExecutionPolicy.isEligible(
+                        requested,
+                        minimumExecutions)) {
+                    // 正数の小口辞退だけを統計化し、単なる在庫0とは区別する。
+                    if (requested > 0L) {
+                        OptimizationMetrics.recordNativeBatchMinimumDecline(
+                                selection.adapter()
+                                        .id()
+                                        .toString());
+                    }
                     continue;
                 }
 

--- a/src/test/java/com/syaru/ae2craftingoptimizer/optimization/BatchMinimumExecutionPolicyTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/optimization/BatchMinimumExecutionPolicyTest.java
@@ -1,0 +1,54 @@
+package com.syaru.ae2craftingoptimizer.optimization;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class BatchMinimumExecutionPolicyTest {
+    /** AAC既定閾値の直前までは通常AE2経路へ戻す。 */
+    @Test
+    void rejectsFinalCountsBelowAacDefault() {
+        assertFalse(
+                BatchMinimumExecutionPolicy.isEligible(
+                        1L,
+                        256L));
+        assertFalse(
+                BatchMinimumExecutionPolicy.isEligible(
+                        255L,
+                        256L));
+    }
+
+    /** 閾値以上とlong最大値は係数を狭めず受理できる。 */
+    @Test
+    void acceptsThresholdAndWideLongCounts() {
+        assertTrue(
+                BatchMinimumExecutionPolicy.isEligible(
+                        256L,
+                        256L));
+        assertTrue(
+                BatchMinimumExecutionPolicy.isEligible(
+                        Long.MAX_VALUE,
+                        256L));
+    }
+
+    /** 在庫制限後に200まで縮小された大量Taskも小口として扱う。 */
+    @Test
+    void usesTheFinalInventoryLimitedCount() {
+        assertFalse(
+                BatchMinimumExecutionPolicy.isEligible(
+                        200L,
+                        256L));
+    }
+
+    /** Adapterの契約違反を通常Fallbackとして隠さない。 */
+    @Test
+    void rejectsInvalidAdapterMinimum() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> BatchMinimumExecutionPolicy.isEligible(
+                        1L,
+                        0L));
+    }
+}


### PR DESCRIPTION
## 概要

V2 Native Batch Adapterが、在庫・waitingFor・電力による制限後の最終実行可能数を基準に、論理一括処理を辞退できる契約を追加します。

## 変更内容

- `TransactionalPatternBatchAdapter.minimumExecutions`を追加
- 既定値を`1`として既存Adapterの挙動を維持
- 動的制限をすべて適用した後、入力抽出前に最小件数を判定
- 閾値未満では入力を動かさずAE2本来の経路へ戻す
- Adapter別の閾値未満Fallback回数を`/aco stats`へ追加
- 境界値と不正契約値を検証するJUnitを追加
- V2 Batch API文書へ判定順序を追記

## 効果

予定Task数は大きいものの中間素材が一個ずつ届く注文で、一回分だけを永続Transactionへ変換し続ける固定費を避けられます。既存Adapterは新APIを実装しなくても従来どおり動作します。

## 検証

- `gradlew clean test --no-daemon`: 成功
- `gradlew build --no-daemon`: 成功
- `git diff --check`: 成功

Issue #58 のNeoForge 1.21.1実装です。
