### PR TITLE
[1.21.1] stale計画を再取得し通常long計算へ安全に戻す

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.14] - 2026-08-13
+
+### Fixed
+
+- Retried the first stale Pattern/Recipe generation snapshot with the same
+  immutable AE2 inventory snapshot and current generation numbers.
+- Returned repeatedly stale ordinary long plans to AE2's standard calculation
+  path instead of propagating `StalePlanningSnapshotException`.
+- Kept plans already proven to require wide arithmetic out of AE2's
+  overflowing long calculation path.
+- Preserved calculation cancellation priority and stopped recovered generation
+  races from being counted as planner declines or AE2 fallbacks.
+
 ## [1.5.13] - 2026-08-13
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ minecraft_version=1.21.1
 neo_version=21.1.247
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.13
+mod_version=1.5.14
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
@@ -73,6 +73,23 @@ public final class Ae2AuthoritativeCraftingPlanner {
             AEKey output,
             long requestedAmount,
             CalculationStrategy strategy) {
+        return tryPlanAttempt(
+                capture,
+                output,
+                requestedAmount,
+                strategy,
+                true,
+                false);
+    }
+
+    @Nullable
+    private static ICraftingPlan tryPlanAttempt(
+            @Nullable Capture capture,
+            AEKey output,
+            long requestedAmount,
+            CalculationStrategy strategy,
+            boolean staleSnapshotRetryAvailable,
+            boolean priorAttemptRequiredWideArithmetic) {
         // 無効設定、参照欠落、不正注文はACO計画を作らず呼出側へ戻す。
         if (!planningEnabled()
                 || capture == null
@@ -108,7 +125,7 @@ public final class Ae2AuthoritativeCraftingPlanner {
             throw new PlanningCancelledException(0);
         }
 
-        boolean wideArithmeticRequired = false;
+        boolean wideArithmeticRequired = priorAttemptRequiredWideArithmetic;
         try {
             capture.requireCurrentGenerations();
             Ae2CompiledCraftingGraphCache.Snapshot graphSnapshot =
@@ -118,13 +135,13 @@ public final class Ae2AuthoritativeCraftingPlanner {
             if (optionalProgram.isEmpty()) {
                 CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
                         FallbackReasonCode.AMBIGUOUS_PRODUCER);
-                recordDecline(
+                return declineOrThrow(
                         capture,
                         output,
                         requestedAmount,
+                        wideArithmeticRequired,
                         BigIntegerPlanDeclineReason.NO_COMPILED_PROGRAM,
                         "no compiled root program");
-                return null;
             }
             CompiledRootProgram<AEKey> program = optionalProgram.get();
             Ae2StrictCraftingTopology topology = graphSnapshot
@@ -137,20 +154,21 @@ public final class Ae2AuthoritativeCraftingPlanner {
                         capture.patternGeneration(),
                         capture.recipeGeneration(),
                         topology == null ? FallbackReasonCode.UNSUPPORTED_PATTERN : FallbackReasonCode.INVENTORY_CHANGED);
-                recordDecline(
+                return declineOrThrow(
                         capture,
                         output,
                         requestedAmount,
+                        wideArithmeticRequired,
                         topology == null
                                 ? BigIntegerPlanDeclineReason.UNSUPPORTED_TOPOLOGY
                                 : BigIntegerPlanDeclineReason.INVENTORY_CHANGED,
                         topology == null ? "strict topology was not proven" : "inventory was not accepted");
-                return null;
             }
-            wideArithmeticRequired = topology.mightRequireWideArithmetic(
-                    output,
-                    BigInteger.valueOf(requestedAmount),
-                    ACOConfig.getBigIntegerMaximumBits());
+            wideArithmeticRequired = wideArithmeticRequired
+                    || topology.mightRequireWideArithmetic(
+                            output,
+                            BigInteger.valueOf(requestedAmount),
+                            ACOConfig.getBigIntegerMaximumBits());
             boolean shadowQualified = CompiledRootQualificationRegistry.isQualified(
                     program,
                     ACOConfig.getAuthoritativeMinimumShadowMatches());
@@ -397,23 +415,68 @@ public final class Ae2AuthoritativeCraftingPlanner {
                         "strict topology changed during planning");
             }
             return result;
-        } catch (PlanningCancelledException | StalePlanningSnapshotException retryable) {
+        } catch (PlanningCancelledException cancelled) {
             CraftingFallbackDiagnostics.record(
                     output,
                     capture == null ? ProviderPatternGenerationTracker.generation() : capture.patternGeneration(),
                     capture == null ? RecipeGenerationTracker.generation() : capture.recipeGeneration(),
-                    retryable instanceof PlanningCancelledException
-                            ? FallbackReasonCode.CANCELLED
-                            : FallbackReasonCode.GENERATION_CHANGED);
+                    FallbackReasonCode.CANCELLED);
             recordDecline(
                     capture,
                     output,
                     requestedAmount,
-                    retryable instanceof PlanningCancelledException
-                            ? BigIntegerPlanDeclineReason.CANCELLED
-                            : BigIntegerPlanDeclineReason.GENERATION_CHANGED,
-                    retryable.getMessage());
-            throw retryable;
+                    BigIntegerPlanDeclineReason.CANCELLED,
+                    cancelled.getMessage());
+            throw cancelled;
+        } catch (StalePlanningSnapshotException stale) {
+            StaleSnapshotAction action = staleSnapshotAction(
+                    staleSnapshotRetryAvailable,
+                    Thread.currentThread().isInterrupted(),
+                    wideArithmeticRequired);
+            // AE2が計算をキャンセル済みなら、新しいSnapshotでも計算を再開しない。
+            if (action == StaleSnapshotAction.CANCEL) {
+                CraftingFallbackDiagnostics.record(
+                        output,
+                        capture.patternGeneration(),
+                        capture.recipeGeneration(),
+                        FallbackReasonCode.CANCELLED);
+                recordDecline(
+                        capture,
+                        output,
+                        requestedAmount,
+                        BigIntegerPlanDeclineReason.CANCELLED,
+                        stale.getMessage() + "; recovery=" + action);
+                throw new PlanningCancelledException(stale.expandedRequests());
+            }
+            // 初回の世代競合だけ、同じAE2在庫Snapshotを最新世代へ結び直して再計算する。
+            if (action == StaleSnapshotAction.RETRY) {
+                return tryPlanAttempt(
+                        capture.refreshGenerations(),
+                        output,
+                        requestedAmount,
+                        strategy,
+                        false,
+                        wideArithmeticRequired);
+            }
+            CraftingFallbackDiagnostics.record(
+                    output,
+                    capture.patternGeneration(),
+                    capture.recipeGeneration(),
+                    FallbackReasonCode.GENERATION_CHANGED);
+            recordDecline(
+                    capture,
+                    output,
+                    requestedAmount,
+                    BigIntegerPlanDeclineReason.GENERATION_CHANGED,
+                    stale.getMessage() + "; recovery=" + action);
+            // 通常long計画は入力を動かす前に辞退し、呼出元のAE2標準計算へ戻す。
+            if (action == StaleSnapshotAction.FALLBACK_TO_AE2) {
+                return null;
+            }
+            throw new WidePlanUnavailableException(
+                    output,
+                    "wide planning snapshot changed repeatedly",
+                    stale);
         } catch (ArithmeticException arithmeticFailure) {
             CraftingFallbackDiagnostics.record(
                     output,
@@ -776,6 +839,35 @@ public final class Ae2AuthoritativeCraftingPlanner {
         return proofQualifiedLongPlansEnabled;
     }
 
+    enum StaleSnapshotAction {
+        RETRY,
+        FALLBACK_TO_AE2,
+        REJECT_WIDE,
+        CANCEL
+    }
+
+    /**
+     * 世代競合時の回復方法を、通常long計画とwide計画で分離する。
+     */
+    static StaleSnapshotAction staleSnapshotAction(
+            boolean retryAvailable,
+            boolean interrupted,
+            boolean wideArithmeticRequired) {
+        // AE2のキャンセル要求は再試行や標準計算より優先する。
+        if (interrupted) {
+            return StaleSnapshotAction.CANCEL;
+        }
+        // 一回目の競合は最新世代で取り直し、開始直後の通知競合を吸収する。
+        if (retryAvailable) {
+            return StaleSnapshotAction.RETRY;
+        }
+        // wideと判明済みの計画をoverflowするAE2標準long計算へ落とさない。
+        if (wideArithmeticRequired) {
+            return StaleSnapshotAction.REJECT_WIDE;
+        }
+        return StaleSnapshotAction.FALLBACK_TO_AE2;
+    }
+
     private static boolean normalLongReplacementEnabled() {
         return ACOConfig.enableAuthoritativeCompiledPlanner()
                 || ACOConfig.enableProofQualifiedLongPlans();
@@ -889,6 +981,16 @@ public final class Ae2AuthoritativeCraftingPlanner {
                         new PlanningGenerationSnapshot(patternGeneration, 0L, recipeGeneration),
                         0);
             }
+        }
+
+        private Capture refreshGenerations() {
+            return new Capture(
+                    level,
+                    grid,
+                    source,
+                    inventorySnapshot,
+                    ProviderPatternGenerationTracker.generation(),
+                    RecipeGenerationTracker.generation());
         }
     }
 

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlannerPolicyTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlannerPolicyTest.java
@@ -1,5 +1,6 @@
 package com.syaru.ae2craftingoptimizer.engine;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -57,5 +58,45 @@ class Ae2AuthoritativeCraftingPlannerPolicyTest {
                 false,
                 true,
                 false));
+    }
+
+    @Test
+    void retriesTheFirstStaleSnapshot() {
+        assertEquals(
+                Ae2AuthoritativeCraftingPlanner.StaleSnapshotAction.RETRY,
+                Ae2AuthoritativeCraftingPlanner.staleSnapshotAction(
+                        true,
+                        false,
+                        false));
+    }
+
+    @Test
+    void fallsBackToAe2AfterARepeatedOrdinaryStaleSnapshot() {
+        assertEquals(
+                Ae2AuthoritativeCraftingPlanner.StaleSnapshotAction.FALLBACK_TO_AE2,
+                Ae2AuthoritativeCraftingPlanner.staleSnapshotAction(
+                        false,
+                        false,
+                        false));
+    }
+
+    @Test
+    void neverFallsBackAProvenWidePlanToLongArithmetic() {
+        assertEquals(
+                Ae2AuthoritativeCraftingPlanner.StaleSnapshotAction.REJECT_WIDE,
+                Ae2AuthoritativeCraftingPlanner.staleSnapshotAction(
+                        false,
+                        false,
+                        true));
+    }
+
+    @Test
+    void cancellationTakesPriorityOverSnapshotRetry() {
+        assertEquals(
+                Ae2AuthoritativeCraftingPlanner.StaleSnapshotAction.CANCEL,
+                Ae2AuthoritativeCraftingPlanner.staleSnapshotAction(
+                        true,
+                        true,
+                        false));
     }
 }


### PR DESCRIPTION
## 概要

ACO 1.5.13で通常のクラフト計算まで`StalePlanningSnapshotException`が呼び出し元へ伝播する回帰を修正します。

初回の世代競合は最新世代で一度だけ再試行し、それでも競合した通常`long`計画はACOが辞退してAE2標準計算へ戻します。

Refs #61

## 根本原因

`CraftingCalculation`構築時に取得したPattern/Recipe世代が、計算開始前のProvider更新フラッシュで古くなる場合があります。1.5.13ではこのstale例外を再送出していたため、`computePlan`のAE2標準経路が実行されませんでした。

## 変更内容

- 初回のstale競合時だけPattern/Recipe世代を最新値へ更新して再試行
- 再試行中も、元の不変AE2在庫Snapshotを維持
- 再競合した通常`long`計画は`null`で辞退し、AE2標準`computePlan`を継続
- wide演算が必要と証明済みの計画はAE2標準`long`計算へ落とさず明示的に拒否
- スレッド割り込みによるキャンセルを再試行より優先
- 回復できた初回競合を辞退・fallback統計へ誤計上しない
- 回復ポリシー4経路のJUnitを追加

## 維持する挙動

- #44で追加した`CraftingService.beginCraftingCalculation`実経路のBigInteger昇格
- #55で修正した共有Futureの戻り値とキャンセル所有権
- 通常AE2計画の結果、在庫、不足数
- wide計画をoverflowする`long`演算へ無言で戻さない契約

## 検証

- `gradlew.bat clean build --no-daemon -PacoLocalModsDir=...`: 成功
- JUnit: 成功
- `git diff --check`: 成功

Minecraft/GameTestの実行は利用環境側で確認します。
