### PR TITLE
[1.20.1] 全Wide計画のexact Sidecarを公開する

### DIFF
--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java
@@ -7,6 +7,7 @@ import com.syaru.ae2craftingoptimizer.engine.OverflowPromotingCraftingPlanner;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
 import com.syaru.ae2craftingoptimizer.engine.BigCapacityCraftingPlan;
 import com.syaru.ae2craftingoptimizer.engine.BigIntegerCraftingPlan;
+import com.syaru.ae2craftingoptimizer.engine.BigIntegerSimulationPlan;
 import com.syaru.ae2craftingoptimizer.engine.WideCraftingPlan;
 import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import java.math.BigInteger;
@@ -82,9 +83,11 @@ public final class BigCraftingEngineApi {
     /**
      * Returns the exact plan sidecar for an ACO-created wide plan.
      *
-     * <p>This includes plans whose individual counters fit in {@code long} but
-     * whose exact CPU byte total does not. The returned view is empty for ordinary
-     * AE2 plans, preventing add-ons from treating unrelated saturated plans as exact.</p>
+     * <p>This includes missing simulations and plans whose individual counters fit
+     * in {@code long} but whose exact CPU byte total does not. Add-ons must never
+     * execute a view whose {@link BigIntegerCraftingPlanView#simulation()} flag is
+     * {@code true}. The returned view is empty for ordinary AE2 plans, preventing
+     * add-ons from treating unrelated saturated plans as exact.</p>
      */
     public static Optional<BigIntegerCraftingPlanView> inspectBigIntegerPlan(
             ICraftingPlan plan) {
@@ -109,6 +112,11 @@ public final class BigCraftingEngineApi {
             return Optional.of(viewOf(bigPlan));
         }
 
+        // 素材不足のwide計画も、実行不可フラグと正確な不足量を同じ公開Viewへ渡す。
+        if (metadata instanceof BigIntegerSimulationPlan simulationPlan) {
+            return Optional.of(viewOf(simulationPlan));
+        }
+
         // 合計bytesだけがlongを超えた計画も、同じ公開Viewで正確に取得できるようにする。
         if (metadata instanceof BigCapacityCraftingPlan capacityPlan) {
             return Optional.of(viewOf(capacityPlan));
@@ -125,6 +133,18 @@ public final class BigCraftingEngineApi {
                 bigPlan.exactPlan().usedInventory(),
                 bigPlan.exactPlan().emitted(),
                 bigPlan.exactPlan().missing());
+    }
+
+    private static BigIntegerCraftingPlanView viewOf(
+            BigIntegerSimulationPlan simulationPlan) {
+        return new BigIntegerCraftingPlanView(
+                simulationPlan.finalOutput(),
+                simulationPlan.exactBytes(),
+                simulationPlan.simulation(),
+                simulationPlan.exactPatternTimes(),
+                simulationPlan.exactPlan().usedInventory(),
+                simulationPlan.exactPlan().emitted(),
+                simulationPlan.exactPlan().missing());
     }
 
     private static BigIntegerCraftingPlanView viewOf(BigCapacityCraftingPlan capacityPlan) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java
@@ -5,12 +5,19 @@ import com.syaru.ae2craftingoptimizer.engine.BigCraftingKeyCodec;
 import com.syaru.ae2craftingoptimizer.engine.BigCountMath;
 import com.syaru.ae2craftingoptimizer.engine.OverflowPromotingCraftingPlanner;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
+import com.syaru.ae2craftingoptimizer.engine.BigCapacityCraftingPlan;
 import com.syaru.ae2craftingoptimizer.engine.BigIntegerCraftingPlan;
+import com.syaru.ae2craftingoptimizer.engine.WideCraftingPlan;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import java.math.BigInteger;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import appeng.api.crafting.IPatternDetails;
 import appeng.api.networking.crafting.ICraftingPlan;
 import appeng.api.stacks.AEKey;
+import appeng.api.stacks.KeyCounter;
 import com.syaru.ae2craftingoptimizer.network.BigCraftingNetwork;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
@@ -73,28 +80,81 @@ public final class BigCraftingEngineApi {
     }
 
     /**
-     * Returns the exact plan sidecar for an ACO-created plan.
+     * Returns the exact plan sidecar for an ACO-created wide plan.
      *
-     * <p>The returned view is empty for ordinary AE2 plans. This identity check
-     * prevents an add-on from treating a saturated or unrelated plan as exact.</p>
+     * <p>This includes plans whose individual counters fit in {@code long} but
+     * whose exact CPU byte total does not. The returned view is empty for ordinary
+     * AE2 plans, preventing add-ons from treating unrelated saturated plans as exact.</p>
      */
     public static Optional<BigIntegerCraftingPlanView> inspectBigIntegerPlan(
             ICraftingPlan plan) {
+        // BigInteger計算が無効な環境やnull計画へ、Sidecarの有無を推測して返さない。
         if (!isCalculationProfileActive() || plan == null) {
             return Optional.empty();
         }
-        BigIntegerCraftingPlan bigPlan = Ae2CraftingPlanSidecars.bigInteger(plan).orElse(null);
-        if (bigPlan == null) {
+        return inspectAttachedExactPlan(plan);
+    }
+
+    /** 設定判定を除いたSidecar変換本体。単体試験でも実経路と同じ変換を使う。 */
+    static Optional<BigIntegerCraftingPlanView> inspectAttachedExactPlan(
+            ICraftingPlan plan) {
+        WideCraftingPlan metadata = Ae2CraftingPlanSidecars.metadata(plan).orElse(null);
+        // ACOが作成していない通常AE2計画には、正確なWide値を捏造しない。
+        if (metadata == null) {
             return Optional.empty();
         }
-        return Optional.of(new BigIntegerCraftingPlanView(
+
+        // 個別数量までlongを超えた計画は、従来どおりBigInteger正本をそのまま公開する。
+        if (metadata instanceof BigIntegerCraftingPlan bigPlan) {
+            return Optional.of(viewOf(bigPlan));
+        }
+
+        // 合計bytesだけがlongを超えた計画も、同じ公開Viewで正確に取得できるようにする。
+        if (metadata instanceof BigCapacityCraftingPlan capacityPlan) {
+            return Optional.of(viewOf(capacityPlan));
+        }
+        return Optional.empty();
+    }
+
+    private static BigIntegerCraftingPlanView viewOf(BigIntegerCraftingPlan bigPlan) {
+        return new BigIntegerCraftingPlanView(
                 bigPlan.finalOutput(),
                 bigPlan.exactBytes(),
                 bigPlan.simulation(),
                 bigPlan.exactPatternTimes(),
                 bigPlan.exactPlan().usedInventory(),
                 bigPlan.exactPlan().emitted(),
-                bigPlan.exactPlan().missing()));
+                bigPlan.exactPlan().missing());
+    }
+
+    private static BigIntegerCraftingPlanView viewOf(BigCapacityCraftingPlan capacityPlan) {
+        return new BigIntegerCraftingPlanView(
+                capacityPlan.finalOutput(),
+                capacityPlan.exactBytes(),
+                capacityPlan.simulation(),
+                widenPatternTimes(capacityPlan.patternTimes()),
+                widenCounter(capacityPlan.usedItems()),
+                widenCounter(capacityPlan.emittedItems()),
+                widenCounter(capacityPlan.missingItems()));
+    }
+
+    private static Map<IPatternDetails, BigInteger> widenPatternTimes(
+            Map<IPatternDetails, Long> patternTimes) {
+        Map<IPatternDetails, BigInteger> exact = new LinkedHashMap<>();
+        // BigCapacity計画では各Pattern回数がlong内なので、符号も含めて損失なく拡張する。
+        for (Map.Entry<IPatternDetails, Long> entry : patternTimes.entrySet()) {
+            exact.put(entry.getKey(), BigInteger.valueOf(entry.getValue()));
+        }
+        return exact;
+    }
+
+    private static Map<AEKey, BigInteger> widenCounter(KeyCounter counter) {
+        Map<AEKey, BigInteger> exact = new LinkedHashMap<>();
+        // BigCapacity計画のAEKey量を、longへ戻さず公開BigInteger Viewへ移す。
+        for (Object2LongMap.Entry<AEKey> entry : counter) {
+            exact.put(entry.getKey(), BigInteger.valueOf(entry.getLongValue()));
+        }
+        return exact;
     }
 
     public static <K> BigCraftingRuntime<K> create(

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigIntegerCraftingPlanView.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigIntegerCraftingPlanView.java
@@ -9,11 +9,12 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Immutable exact view of an ACO BigInteger plan for optional CPU add-ons.
+ * Immutable exact view of an ACO wide plan for optional CPU add-ons.
  *
  * <p>The standard AE2 {@link ICraftingPlan} remains the compatibility facade.
- * Add-ons that can execute bounded windows may opt into this view without
- * depending on ACO's engine implementation classes.</p>
+ * Add-ons that can execute bounded windows may opt into this view for both
+ * BigInteger counters and capacity-only overflow, without depending on ACO's
+ * engine implementation classes.</p>
  */
 public record BigIntegerCraftingPlanView(
         GenericStack finalOutput,

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigIntegerCraftingPlanView.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigIntegerCraftingPlanView.java
@@ -12,9 +12,10 @@ import java.util.Objects;
  * Immutable exact view of an ACO wide plan for optional CPU add-ons.
  *
  * <p>The standard AE2 {@link ICraftingPlan} remains the compatibility facade.
- * Add-ons that can execute bounded windows may opt into this view for both
- * BigInteger counters and capacity-only overflow, without depending on ACO's
- * engine implementation classes.</p>
+ * Add-ons that can execute bounded windows may opt into this view for BigInteger
+ * counters, capacity-only overflow, and exact missing simulations without depending
+ * on ACO's engine implementation classes. A view with {@link #simulation()} set must
+ * only be displayed or diagnosed and must never be submitted for execution.</p>
  */
 public record BigIntegerCraftingPlanView(
         GenericStack finalOutput,

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigCapacityCraftingPlan.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigCapacityCraftingPlan.java
@@ -12,8 +12,8 @@ import java.util.Objects;
  * 各AEKey量とPattern回数はlongに収まるが、合計CPU容量だけがlongを超える厳密計画。
  *
  * <p>AE2の公開APIは容量をlongでしか受け取れないため、{@link #bytes()}は互換用に
- * {@link Long#MAX_VALUE}を返す。AQE Quantum Computerは{@link #exactBytes()}をSidecarへ
- * 予約し、互換値を容量会計の正本として使用しない。</p>
+ * {@link Long#MAX_VALUE}を返す。対応CPUアドオンは{@link #exactBytes()}を公開Sidecarから
+ * 取得し、互換値を容量会計の正本として使用しない。</p>
  */
 public final class BigCapacityCraftingPlan implements WideCraftingPlan {
     private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApiPlanInspectionTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApiPlanInspectionTest.java
@@ -2,6 +2,7 @@ package com.syaru.ae2craftingoptimizer.api.big;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import appeng.api.crafting.IPatternDetails;
@@ -13,9 +14,19 @@ import appeng.api.stacks.KeyCounter;
 import appeng.crafting.CraftingPlan;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
 import com.syaru.ae2craftingoptimizer.engine.BigCapacityCraftingPlan;
+import com.syaru.ae2craftingoptimizer.engine.BigExactCraftingByteCounter;
+import com.syaru.ae2craftingoptimizer.engine.CompiledCraftingGraph;
+import com.syaru.ae2craftingoptimizer.engine.CompiledPattern;
+import com.syaru.ae2craftingoptimizer.engine.CompiledRootProgram;
+import com.syaru.ae2craftingoptimizer.engine.LongCraftingPlan;
+import com.syaru.ae2craftingoptimizer.engine.OverflowPromotingCraftingPlanner;
+import com.syaru.ae2craftingoptimizer.engine.PlanningGuard;
 import java.math.BigInteger;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
@@ -26,51 +37,109 @@ import net.minecraft.world.level.Level;
 import org.junit.jupiter.api.Test;
 
 class BigCraftingEngineApiPlanInspectionTest {
-    /** 再現報告で在庫に存在した鉄塊数。signed long内の境界値として使う。 */
-    private static final long USED_AMOUNT = 8_600_000_000_000_000_000L;
-    /** 再現報告で要求した鉄ブロック数。Pattern回数自体はsigned long内に収まる。 */
-    private static final long PATTERN_EXECUTIONS = 106_000_000_000_000_000L;
-    /** 再現報告相当のCPU容量。Long.MAX_VALUEを超えるためBigCapacity計画になる。 */
+    /** 診断GameTestでME在庫へ投入される鉄ナゲット数。 */
+    private static final long NUGGET_INVENTORY = 8_600_000_000_000_000_000L;
+    /** 診断GameTestで注文される鉄ブロック数。 */
+    private static final long BLOCK_REQUEST = 106_000_000_000_000_000L;
+    /** 9ナゲットから1鉄塊、9鉄塊から1鉄ブロックを作る圧縮比。 */
+    private static final long COMPRESSION_RATIO = 9L;
+    /** 二段圧縮が実際に消費する鉄ナゲット数。 */
+    private static final long EXPECTED_NUGGET_USAGE = 8_586_000_000_000_000_000L;
+    /** 全注文を満たした後にME在庫へ残る鉄ナゲット数。 */
+    private static final long EXPECTED_NUGGET_REMAINDER = 14_000_000_000_000_000L;
+    /** 鉄塊Patternの実行回数。 */
+    private static final long EXPECTED_INGOT_EXECUTIONS = 954_000_000_000_000_000L;
+    /** AE2 15.4.10でitem key 1 byteが表す個数。 */
+    private static final long ITEM_AMOUNT_PER_BYTE = 8L;
+    /** この試験のBigInteger演算に十分で、境界を小さく保てるbit上限。 */
+    private static final int TEST_MAXIMUM_BITS = 256;
+    /** 仮想Pattern/recipe snapshotが変化しないことを示す世代番号。 */
+    private static final long TEST_GENERATION = 0L;
+    /** AE2の容量式で二段圧縮ツリーを数えた正確なCPU bytes。 */
     private static final BigInteger EXACT_BYTES =
-            new BigInteger("10700000000000000000");
-    private static final TestKey INPUT = new TestKey("iron_ingot");
-    private static final TestKey OUTPUT = new TestKey("iron_block");
-    private static final IPatternDetails PATTERN = new TestPattern();
+            new BigInteger("10706000000000000024");
+    private static final String INGOT_PATTERN_ID = "minecraft:iron_ingot_from_nuggets";
+    private static final String BLOCK_PATTERN_ID = "minecraft:iron_block";
+    private static final TestKey NUGGET = new TestKey("iron_nugget");
+    private static final TestKey INGOT = new TestKey("iron_ingot");
+    private static final TestKey BLOCK = new TestKey("iron_block");
+    private static final IPatternDetails INGOT_PATTERN = new TestPattern(INGOT_PATTERN_ID);
+    private static final IPatternDetails BLOCK_PATTERN = new TestPattern(BLOCK_PATTERN_ID);
+    private static final Map<String, IPatternDetails> PATTERNS_BY_ID = Map.of(
+            INGOT_PATTERN_ID, INGOT_PATTERN,
+            BLOCK_PATTERN_ID, BLOCK_PATTERN);
 
     @Test
-    void exposesCapacityOnlyOverflowThroughPublicExactPlanView() {
-        KeyCounter used = new KeyCounter();
-        used.add(INPUT, USED_AMOUNT);
-        KeyCounter emitted = new KeyCounter();
-        emitted.add(OUTPUT, PATTERN_EXECUTIONS);
+    void exposesVirtualTwoStageAe2AutocraftingPlanThroughPublicExactView() throws Exception {
+        CompiledRootProgram<AEKey> program = twoStageCompressionProgram();
+        var inventory = program.captureLongInventory(
+                key -> key == NUGGET ? NUGGET_INVENTORY : 0L);
+        var promoted = new OverflowPromotingCraftingPlanner<AEKey>(TEST_MAXIMUM_BITS).plan(
+                program,
+                BigInteger.valueOf(BLOCK_REQUEST),
+                inventory,
+                PlanningGuard.none());
+        var longResult = assertInstanceOf(
+                OverflowPromotingCraftingPlanner.LongResult.class,
+                promoted);
+        @SuppressWarnings("unchecked")
+        LongCraftingPlan<AEKey> exactPlan =
+                ((OverflowPromotingCraftingPlanner.LongResult<AEKey>) longResult).plan();
+
+        assertTrue(exactPlan.craftable());
+        assertEquals(EXPECTED_NUGGET_USAGE, exactPlan.usedInventory().get(NUGGET));
+        assertEquals(EXPECTED_INGOT_EXECUTIONS, exactPlan.patternExecutions().get(INGOT_PATTERN_ID));
+        assertEquals(BLOCK_REQUEST, exactPlan.patternExecutions().get(BLOCK_PATTERN_ID));
+        assertEquals(
+                EXPECTED_NUGGET_REMAINDER,
+                NUGGET_INVENTORY - exactPlan.usedInventory().get(NUGGET));
+
+        BigInteger exactBytes = BigExactCraftingByteCounter.calculate(
+                BLOCK,
+                BigInteger.valueOf(BLOCK_REQUEST),
+                program.patternsByOutput(),
+                widenPatternExecutions(exactPlan.patternExecutions()),
+                ignored -> ITEM_AMOUNT_PER_BYTE,
+                TEST_MAXIMUM_BITS);
+        assertEquals(EXACT_BYTES, exactBytes);
+        assertTrue(exactBytes.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0);
+
         BigCapacityCraftingPlan metadata = new BigCapacityCraftingPlan(
-                new GenericStack(OUTPUT, PATTERN_EXECUTIONS),
+                new GenericStack(BLOCK, BLOCK_REQUEST),
                 false,
                 false,
-                used,
-                emitted,
-                new KeyCounter(),
-                Map.of(PATTERN, PATTERN_EXECUTIONS),
-                EXACT_BYTES,
-                0L,
-                0L);
+                keyCounter(exactPlan.usedInventory()),
+                keyCounter(exactPlan.emitted()),
+                keyCounter(exactPlan.missing()),
+                resolvePatterns(exactPlan.patternExecutions()),
+                exactBytes,
+                TEST_GENERATION,
+                TEST_GENERATION);
 
         CraftingPlan facade = Ae2CraftingPlanSidecars.expose(metadata);
+        Future<appeng.api.networking.crafting.ICraftingPlan> simulatedCalculation =
+                CompletableFuture.completedFuture(facade);
+        var returnedPlan = simulatedCalculation.get();
         BigIntegerCraftingPlanView view =
-                BigCraftingEngineApi.inspectAttachedExactPlan(facade).orElseThrow();
+                BigCraftingEngineApi.inspectAttachedExactPlan(returnedPlan).orElseThrow();
 
+        assertInstanceOf(CraftingPlan.class, returnedPlan);
+        assertEquals(Long.MAX_VALUE, returnedPlan.bytes());
         assertFalse(view.simulation());
         assertEquals(EXACT_BYTES, view.exactBytes());
-        assertEquals(BigInteger.valueOf(PATTERN_EXECUTIONS), view.patternTimes().get(PATTERN));
-        assertEquals(BigInteger.valueOf(USED_AMOUNT), view.usedItems().get(INPUT));
-        assertEquals(BigInteger.valueOf(PATTERN_EXECUTIONS), view.emittedItems().get(OUTPUT));
+        assertEquals(
+                BigInteger.valueOf(EXPECTED_INGOT_EXECUTIONS),
+                view.patternTimes().get(INGOT_PATTERN));
+        assertEquals(BigInteger.valueOf(BLOCK_REQUEST), view.patternTimes().get(BLOCK_PATTERN));
+        assertEquals(BigInteger.valueOf(EXPECTED_NUGGET_USAGE), view.usedItems().get(NUGGET));
+        assertEquals(Map.of(), view.emittedItems());
         assertEquals(Map.of(), view.missingItems());
     }
 
     @Test
     void doesNotInventSidecarForUnrelatedSaturatedAe2Plan() {
         CraftingPlan ordinary = new CraftingPlan(
-                new GenericStack(OUTPUT, 1L),
+                new GenericStack(BLOCK, 1L),
                 Long.MAX_VALUE,
                 false,
                 false,
@@ -83,8 +152,68 @@ class BigCraftingEngineApiPlanInspectionTest {
         assertTrue(BigCraftingEngineApi.inspectAttachedExactPlan(ordinary).isEmpty());
     }
 
+    private static CompiledRootProgram<AEKey> twoStageCompressionProgram() {
+        var ingot = compressionPattern(INGOT_PATTERN_ID, NUGGET, INGOT);
+        var block = compressionPattern(BLOCK_PATTERN_ID, INGOT, BLOCK);
+        var graph = CompiledCraftingGraph.compile(
+                TEST_GENERATION,
+                List.of(ingot, block));
+        return CompiledRootProgram.tryCompile(graph, BLOCK, ignored -> false).orElseThrow();
+    }
+
+    private static CompiledPattern<AEKey> compressionPattern(
+            String id,
+            AEKey input,
+            AEKey output) {
+        return new CompiledPattern<>(
+                id,
+                List.of(new CompiledPattern.InputSlot<>(
+                        List.of(new CompiledPattern.Stack<>(input, COMPRESSION_RATIO)))),
+                Map.of(output, 1L),
+                false);
+    }
+
+    private static Map<String, BigInteger> widenPatternExecutions(
+            Map<String, Long> executions) {
+        Map<String, BigInteger> widened = new LinkedHashMap<>();
+        // Plannerが算出した各Pattern回数を、byte式へ損失なく渡す。
+        for (Map.Entry<String, Long> entry : executions.entrySet()) {
+            widened.put(entry.getKey(), BigInteger.valueOf(entry.getValue()));
+        }
+        return Map.copyOf(widened);
+    }
+
+    private static Map<IPatternDetails, Long> resolvePatterns(Map<String, Long> executions) {
+        Map<IPatternDetails, Long> resolved = new LinkedHashMap<>();
+        // 実経路と同様に、コンパイル済みIDを同一世代の実Pattern参照へ戻す。
+        for (Map.Entry<String, Long> entry : executions.entrySet()) {
+            IPatternDetails pattern = PATTERNS_BY_ID.get(entry.getKey());
+            // この固定テストグラフに未登録IDが混ざった場合は、曖昧な計画を作らず失敗させる。
+            if (pattern == null) {
+                throw new IllegalStateException("unresolved test pattern: " + entry.getKey());
+            }
+            resolved.put(pattern, entry.getValue());
+        }
+        return Map.copyOf(resolved);
+    }
+
+    private static KeyCounter keyCounter(Map<AEKey, Long> counts) {
+        KeyCounter counter = new KeyCounter();
+        // Plannerの正確なlong会計を、AE2互換FacadeのKeyCounterへ写す。
+        for (Map.Entry<AEKey, Long> entry : counts.entrySet()) {
+            counter.add(entry.getKey(), entry.getValue());
+        }
+        return counter;
+    }
+
     /** Patternの識別だけを試すため、実レシピ処理を持たないテスト用定義。 */
     private static final class TestPattern implements IPatternDetails {
+        private final String id;
+
+        private TestPattern(String id) {
+            this.id = id;
+        }
+
         @Override
         public AEItemKey getDefinition() {
             return null;
@@ -98,6 +227,11 @@ class BigCraftingEngineApiPlanInspectionTest {
         @Override
         public GenericStack[] getOutputs() {
             return new GenericStack[0];
+        }
+
+        @Override
+        public String toString() {
+            return id;
         }
     }
 

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApiPlanInspectionTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApiPlanInspectionTest.java
@@ -14,7 +14,10 @@ import appeng.api.stacks.KeyCounter;
 import appeng.crafting.CraftingPlan;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
 import com.syaru.ae2craftingoptimizer.engine.BigCapacityCraftingPlan;
+import com.syaru.ae2craftingoptimizer.engine.BigCraftingPlan;
 import com.syaru.ae2craftingoptimizer.engine.BigExactCraftingByteCounter;
+import com.syaru.ae2craftingoptimizer.engine.BigIntegerSimulationPlan;
+import com.syaru.ae2craftingoptimizer.engine.BigIntegerSimulationPlanTestFactory;
 import com.syaru.ae2craftingoptimizer.engine.CompiledCraftingGraph;
 import com.syaru.ae2craftingoptimizer.engine.CompiledPattern;
 import com.syaru.ae2craftingoptimizer.engine.CompiledRootProgram;
@@ -41,6 +44,8 @@ class BigCraftingEngineApiPlanInspectionTest {
     private static final long NUGGET_INVENTORY = 8_600_000_000_000_000_000L;
     /** 診断GameTestで注文される鉄ブロック数。 */
     private static final long BLOCK_REQUEST = 106_000_000_000_000_000L;
+    /** 中間素材と不足数がsigned longを超えるsimulation用の鉄ブロック注文数。 */
+    private static final long WIDE_MISSING_BLOCK_REQUEST = 1_200_000_000_000_000_000L;
     /** 9ナゲットから1鉄塊、9鉄塊から1鉄ブロックを作る圧縮比。 */
     private static final long COMPRESSION_RATIO = 9L;
     /** 二段圧縮が実際に消費する鉄ナゲット数。 */
@@ -58,6 +63,15 @@ class BigCraftingEngineApiPlanInspectionTest {
     /** AE2の容量式で二段圧縮ツリーを数えた正確なCPU bytes。 */
     private static final BigInteger EXACT_BYTES =
             new BigInteger("10706000000000000024");
+    /** wide不足注文で必要になる鉄塊Pattern回数。 */
+    private static final BigInteger WIDE_MISSING_INGOT_EXECUTIONS =
+            new BigInteger("10800000000000000000");
+    /** wide不足注文で不足する鉄ナゲット数。 */
+    private static final BigInteger WIDE_MISSING_NUGGETS =
+            new BigInteger("97200000000000000000");
+    /** wide不足注文をAE2の容量式で数えた正確なCPU bytes。 */
+    private static final BigInteger WIDE_MISSING_EXACT_BYTES =
+            new BigInteger("121200000000000000024");
     private static final String INGOT_PATTERN_ID = "minecraft:iron_ingot_from_nuggets";
     private static final String BLOCK_PATTERN_ID = "minecraft:iron_block";
     private static final TestKey NUGGET = new TestKey("iron_nugget");
@@ -137,6 +151,63 @@ class BigCraftingEngineApiPlanInspectionTest {
     }
 
     @Test
+    void exposesWideMissingSimulationThroughPublicExactView() throws Exception {
+        CompiledRootProgram<AEKey> program = twoStageCompressionProgram();
+        var inventory = program.captureLongInventory(ignored -> 0L);
+        var promoted = new OverflowPromotingCraftingPlanner<AEKey>(TEST_MAXIMUM_BITS).plan(
+                program,
+                BigInteger.valueOf(WIDE_MISSING_BLOCK_REQUEST),
+                inventory,
+                PlanningGuard.none());
+        var bigResult = assertInstanceOf(
+                OverflowPromotingCraftingPlanner.BigResult.class,
+                promoted);
+        @SuppressWarnings("unchecked")
+        BigCraftingPlan<AEKey> exactPlan =
+                ((OverflowPromotingCraftingPlanner.BigResult<AEKey>) bigResult).plan();
+
+        assertFalse(exactPlan.craftable());
+        assertEquals(WIDE_MISSING_INGOT_EXECUTIONS,
+                exactPlan.patternExecutions().get(INGOT_PATTERN_ID));
+        assertEquals(BigInteger.valueOf(WIDE_MISSING_BLOCK_REQUEST),
+                exactPlan.patternExecutions().get(BLOCK_PATTERN_ID));
+        assertEquals(WIDE_MISSING_NUGGETS, exactPlan.missing().get(NUGGET));
+
+        BigInteger exactBytes = BigExactCraftingByteCounter.calculate(
+                BLOCK,
+                BigInteger.valueOf(WIDE_MISSING_BLOCK_REQUEST),
+                program.patternsByOutput(),
+                exactPlan.patternExecutions(),
+                ignored -> ITEM_AMOUNT_PER_BYTE,
+                TEST_MAXIMUM_BITS);
+        assertEquals(WIDE_MISSING_EXACT_BYTES, exactBytes);
+
+        BigIntegerSimulationPlan metadata = BigIntegerSimulationPlanTestFactory.create(
+                new GenericStack(BLOCK, WIDE_MISSING_BLOCK_REQUEST),
+                exactPlan,
+                resolveBigPatterns(exactPlan.patternExecutions()),
+                exactBytes,
+                TEST_MAXIMUM_BITS);
+        CraftingPlan facade = Ae2CraftingPlanSidecars.expose(metadata);
+        Future<appeng.api.networking.crafting.ICraftingPlan> simulatedCalculation =
+                CompletableFuture.completedFuture(facade);
+        var returnedPlan = simulatedCalculation.get();
+        BigIntegerCraftingPlanView view =
+                BigCraftingEngineApi.inspectAttachedExactPlan(returnedPlan).orElseThrow();
+
+        assertTrue(returnedPlan.simulation());
+        assertEquals(Long.MAX_VALUE, returnedPlan.missingItems().get(NUGGET));
+        assertTrue(view.simulation());
+        assertEquals(WIDE_MISSING_EXACT_BYTES, view.exactBytes());
+        assertEquals(WIDE_MISSING_NUGGETS, view.missingItems().get(NUGGET));
+        assertEquals(WIDE_MISSING_INGOT_EXECUTIONS, view.patternTimes().get(INGOT_PATTERN));
+        assertEquals(BigInteger.valueOf(WIDE_MISSING_BLOCK_REQUEST),
+                view.patternTimes().get(BLOCK_PATTERN));
+        assertEquals(Map.of(), view.usedItems());
+        assertEquals(Map.of(), view.emittedItems());
+    }
+
+    @Test
     void doesNotInventSidecarForUnrelatedSaturatedAe2Plan() {
         CraftingPlan ordinary = new CraftingPlan(
                 new GenericStack(BLOCK, 1L),
@@ -189,6 +260,21 @@ class BigCraftingEngineApiPlanInspectionTest {
         for (Map.Entry<String, Long> entry : executions.entrySet()) {
             IPatternDetails pattern = PATTERNS_BY_ID.get(entry.getKey());
             // この固定テストグラフに未登録IDが混ざった場合は、曖昧な計画を作らず失敗させる。
+            if (pattern == null) {
+                throw new IllegalStateException("unresolved test pattern: " + entry.getKey());
+            }
+            resolved.put(pattern, entry.getValue());
+        }
+        return Map.copyOf(resolved);
+    }
+
+    private static Map<IPatternDetails, BigInteger> resolveBigPatterns(
+            Map<String, BigInteger> executions) {
+        Map<IPatternDetails, BigInteger> resolved = new LinkedHashMap<>();
+        // BigInteger PlannerのPattern IDを、同じ仮想世代の実Pattern参照へ戻す。
+        for (Map.Entry<String, BigInteger> entry : executions.entrySet()) {
+            IPatternDetails pattern = PATTERNS_BY_ID.get(entry.getKey());
+            // 未登録Patternを黙って落とすと不足計画の容量と表示がずれるため、試験を失敗させる。
             if (pattern == null) {
                 throw new IllegalStateException("unresolved test pattern: " + entry.getKey());
             }

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApiPlanInspectionTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApiPlanInspectionTest.java
@@ -1,0 +1,156 @@
+package com.syaru.ae2craftingoptimizer.api.big;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import appeng.api.crafting.IPatternDetails;
+import appeng.api.stacks.AEItemKey;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.AEKeyType;
+import appeng.api.stacks.GenericStack;
+import appeng.api.stacks.KeyCounter;
+import appeng.crafting.CraftingPlan;
+import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
+import com.syaru.ae2craftingoptimizer.engine.BigCapacityCraftingPlan;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import org.junit.jupiter.api.Test;
+
+class BigCraftingEngineApiPlanInspectionTest {
+    /** 再現報告で在庫に存在した鉄塊数。signed long内の境界値として使う。 */
+    private static final long USED_AMOUNT = 8_600_000_000_000_000_000L;
+    /** 再現報告で要求した鉄ブロック数。Pattern回数自体はsigned long内に収まる。 */
+    private static final long PATTERN_EXECUTIONS = 106_000_000_000_000_000L;
+    /** 再現報告相当のCPU容量。Long.MAX_VALUEを超えるためBigCapacity計画になる。 */
+    private static final BigInteger EXACT_BYTES =
+            new BigInteger("10700000000000000000");
+    private static final TestKey INPUT = new TestKey("iron_ingot");
+    private static final TestKey OUTPUT = new TestKey("iron_block");
+    private static final IPatternDetails PATTERN = new TestPattern();
+
+    @Test
+    void exposesCapacityOnlyOverflowThroughPublicExactPlanView() {
+        KeyCounter used = new KeyCounter();
+        used.add(INPUT, USED_AMOUNT);
+        KeyCounter emitted = new KeyCounter();
+        emitted.add(OUTPUT, PATTERN_EXECUTIONS);
+        BigCapacityCraftingPlan metadata = new BigCapacityCraftingPlan(
+                new GenericStack(OUTPUT, PATTERN_EXECUTIONS),
+                false,
+                false,
+                used,
+                emitted,
+                new KeyCounter(),
+                Map.of(PATTERN, PATTERN_EXECUTIONS),
+                EXACT_BYTES,
+                0L,
+                0L);
+
+        CraftingPlan facade = Ae2CraftingPlanSidecars.expose(metadata);
+        BigIntegerCraftingPlanView view =
+                BigCraftingEngineApi.inspectAttachedExactPlan(facade).orElseThrow();
+
+        assertFalse(view.simulation());
+        assertEquals(EXACT_BYTES, view.exactBytes());
+        assertEquals(BigInteger.valueOf(PATTERN_EXECUTIONS), view.patternTimes().get(PATTERN));
+        assertEquals(BigInteger.valueOf(USED_AMOUNT), view.usedItems().get(INPUT));
+        assertEquals(BigInteger.valueOf(PATTERN_EXECUTIONS), view.emittedItems().get(OUTPUT));
+        assertEquals(Map.of(), view.missingItems());
+    }
+
+    @Test
+    void doesNotInventSidecarForUnrelatedSaturatedAe2Plan() {
+        CraftingPlan ordinary = new CraftingPlan(
+                new GenericStack(OUTPUT, 1L),
+                Long.MAX_VALUE,
+                false,
+                false,
+                new KeyCounter(),
+                new KeyCounter(),
+                new KeyCounter(),
+                Map.of());
+
+        // bytesが同じLong.MAX_VALUEでも、ACOが付けたIdentity Sidecarだけを信頼する。
+        assertTrue(BigCraftingEngineApi.inspectAttachedExactPlan(ordinary).isEmpty());
+    }
+
+    /** Patternの識別だけを試すため、実レシピ処理を持たないテスト用定義。 */
+    private static final class TestPattern implements IPatternDetails {
+        @Override
+        public AEItemKey getDefinition() {
+            return null;
+        }
+
+        @Override
+        public IInput[] getInputs() {
+            return new IInput[0];
+        }
+
+        @Override
+        public GenericStack[] getOutputs() {
+            return new GenericStack[0];
+        }
+    }
+
+    /** Minecraft Registryを起動せずKeyCounter変換を検証する最小AEKey。 */
+    private static final class TestKey extends AEKey {
+        private final String path;
+
+        private TestKey(String path) {
+            this.path = path;
+        }
+
+        @Override
+        public AEKeyType getType() {
+            return null;
+        }
+
+        @Override
+        public AEKey dropSecondary() {
+            return this;
+        }
+
+        @Override
+        public CompoundTag toTag() {
+            return new CompoundTag();
+        }
+
+        @Override
+        public Object getPrimaryKey() {
+            return this;
+        }
+
+        @Override
+        public ResourceLocation getId() {
+            return new ResourceLocation("ae2_crafting_optimizer", path);
+        }
+
+        @Override
+        public void writeToPacket(FriendlyByteBuf buffer) {
+            // この試験はネットワーク同期を行わないため書き込みは不要。
+        }
+
+        @Override
+        protected Component computeDisplayName() {
+            return Component.literal(path);
+        }
+
+        @Override
+        public void addDrops(
+                long amount,
+                List<ItemStack> drops,
+                Level level,
+                BlockPos pos) {
+            // この試験はワールド内ドロップを作らないため処理は不要。
+        }
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerSimulationPlanTestFactory.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerSimulationPlanTestFactory.java
@@ -1,0 +1,27 @@
+package com.syaru.ae2craftingoptimizer.engine;
+
+import appeng.api.crafting.IPatternDetails;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.GenericStack;
+import java.math.BigInteger;
+import java.util.Map;
+
+/** MinecraftのConfigロードなしで、実コンストラクタを検証するテスト専用境界。 */
+public final class BigIntegerSimulationPlanTestFactory {
+    private BigIntegerSimulationPlanTestFactory() {
+    }
+
+    public static BigIntegerSimulationPlan create(
+            GenericStack finalOutput,
+            BigCraftingPlan<AEKey> exactPlan,
+            Map<IPatternDetails, BigInteger> exactPatternTimes,
+            BigInteger exactBytes,
+            int maximumBits) {
+        return new BigIntegerSimulationPlan(
+                finalOutput,
+                exactPlan,
+                exactPatternTimes,
+                exactBytes,
+                maximumBits);
+    }
+}


### PR DESCRIPTION
## 概要

`CraftingService.beginCraftingCalculation`実経路で生成されたACO Wide計画を、既存の`BigCraftingEngineApi.inspectBigIntegerPlan(plan)`から種類に関係なく正確に取得できるようにします。

Refs #64

## 原因

Identity Sidecar自体は`CraftingPlan`へ付いていましたが、公開APIが実行用`BigIntegerCraftingPlan`だけを想定していました。

そのため次の二種類が`Optional.empty`になっていました。

- 各数量はlong内だが、合計CPU容量だけがlongを超える`BigCapacityCraftingPlan`
- 中間素材または不足量がlongを超える`BigIntegerSimulationPlan`

## 変更

- 実行計画、容量overflow計画、不足simulationを同じ`BigIntegerCraftingPlanView`へ無損失変換
- capacity-only overflowのPattern回数とused/emitted/missingを`BigInteger.valueOf`で拡張
- wide不足simulationの正確なPattern回数、CPU容量、不足量を公開
- `simulation=true`のViewを実行へ提出してはいけないことを公開契約へ明記
- ACOと無関係な`bytes=Long.MAX_VALUE`計画にはSidecarを捏造しない

## 仮想クラフト試験

Minecraftを起動せず、ACOのコンパイル済みグラフ、Planner、正確な容量計算を使用しています。

成功計画:
- 在庫: 鉄ナゲット `8,600,000,000,000,000,000`
- 注文: 鉄ブロック `106,000,000,000,000,000`
- 正確なCPU容量: `10,706,000,000,000,000,024 B`

不足simulation:
- 在庫: 0
- 注文: 鉄ブロック `1,200,000,000,000,000,000`
- 正確な不足ナゲット: `97,200,000,000,000,000,000`
- 正確なCPU容量: `121,200,000,000,000,000,024 B`
- AE2 Facadeはlongへ飽和するが、公開ViewはBigInteger真値を維持

## 互換性

- 公開メソッドのシグネチャとAPI契約番号は変更しません
- AE2の通常計算結果を変更しません
- InsaneAEのCPU実行、Task Fusion、構造、GUI、モデル、レシピへ介入しません

## 検証

- `gradlew.bat clean build --no-daemon`: 成功
- JUnit 311件: 失敗0
- GitHub Actionsで通常AE2とUELMを確認

Minecraftクライアント、専用サーバー、GameTestの起動は今回実施しません。
