### PR TITLE
feat(api): expose canonical Pattern Batch identity on 1.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.15] - 2026-08-13
+
+### Added
+
+- Added `PatternBatchIdentity.canonicalFingerprint` so external adapters use
+  the exact identity stored in ACO's durable journal.
+
+### Compatibility
+
+- Kept the existing public transaction recovery view and all 1.5.x batch API
+  behavior unchanged.
+
 ## [1.5.14] - 2026-08-13
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.14
+mod_version=1.5.15
 minecraft_version=1.20.1
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/PatternBatchIdentity.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/PatternBatchIdentity.java
@@ -1,0 +1,20 @@
+package com.syaru.ae2craftingoptimizer.api.batch.v2;
+
+import com.syaru.ae2craftingoptimizer.api.batch.PatternBatchContext;
+import com.syaru.ae2craftingoptimizer.batch.NativePatternBatchSupport;
+import java.util.Objects;
+
+/** ACO Journalと外部Adapterが共有する、Pattern Batchの正規識別API。 */
+public final class PatternBatchIdentity {
+    private PatternBatchIdentity() {
+    }
+
+    /**
+     * ACOが永続Journalへ保存する値と完全に同じFingerprintを返す。
+     * 外部Adapterは独自に同じ符号化を再実装しないこと。
+     */
+    public static String canonicalFingerprint(PatternBatchContext context) {
+        return NativePatternBatchSupport.fingerprint(
+                Objects.requireNonNull(context, "context"));
+    }
+}


### PR DESCRIPTION
## 概要

Forge 1.20.1のNative Batch公開APIへ、ACO Journalと同じPattern識別値を返す
`PatternBatchIdentity.canonicalFingerprint`を追加します。

## 変更内容

- 外部Adapterによるfingerprint式の重複実装を廃止できる公開入口を追加。
- 既存の公開Transaction snapshotと1.5.x API挙動は変更なし。
- バージョンを1.5.15へ更新。

## 検証

- `gradlew clean check build --no-daemon`: 成功
- JUnit: 308件成功、失敗0件
- `git diff --check`: 成功
- ローカル絶対パス混入: なし

Refs #28
