### PR TITLE
fix(api): publish recovery records on 1.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.15] - 2026-08-13
+
+### Added
+
+- Added the read-only public `BatchTransactionRecord` recovery view to the
+  NeoForge 1.21.1 API, matching the Forge 1.20.1 contract.
+- Added `PatternBatchIdentity.canonicalFingerprint` so external adapters use
+  the exact identity stored in ACO's durable journal.
+
+### Fixed
+
+- Removed ACO's internal journal record type from the public transactional
+  batch adapter and source reconciler signatures.
+- Kept adapters compiled against the earlier 1.5.x recovery ABI callable
+  through an explicit compatibility bridge.
+- Preserved the old optional recovery-cleanup default as a no-op when a legacy
+  adapter did not override it.
+
 ## [1.5.14] - 2026-08-13
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ minecraft_version=1.21.1
 neo_version=21.1.247
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.14
+mod_version=1.5.15
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/BatchPayloadFingerprint.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/BatchPayloadFingerprint.java
@@ -2,7 +2,6 @@ package com.syaru.ae2craftingoptimizer.api.batch.v2;
 
 import appeng.api.stacks.GenericStack;
 import com.syaru.ae2craftingoptimizer.util.StableFingerprint;
-import com.syaru.ae2craftingoptimizer.transaction.BatchTransactionRecord;
 
 /** 取引IDとは独立した、入力・期待出力・実行数の決定的Fingerprint。 */
 public final class BatchPayloadFingerprint {
@@ -14,7 +13,23 @@ public final class BatchPayloadFingerprint {
     }
 
     public static String of(BatchTransactionRecord record) {
+        if (record == null) {
+            throw new NullPointerException("record");
+        }
         return of(record.offeredExecutions(), record.extractedInputs(), record.expectedOutputs());
+    }
+
+    /**
+     * ACO 1.5.x旧ABI向けの互換入口。
+     * 新しい外部連携は公開Recordのoverloadを使用する。
+     */
+    @Deprecated(forRemoval = false)
+    public static String of(
+            com.syaru.ae2craftingoptimizer.transaction.BatchTransactionRecord record) {
+        if (record == null) {
+            throw new NullPointerException("record");
+        }
+        return record.toPublicView().payloadDigest();
     }
 
     private static String of(

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/BatchSourceReconciler.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/BatchSourceReconciler.java
@@ -1,15 +1,24 @@
 package com.syaru.ae2craftingoptimizer.api.batch.v2;
 
-import com.syaru.ae2craftingoptimizer.transaction.BatchTransactionRecord;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 
 public interface BatchSourceReconciler {
     ResourceLocation id();
 
-    SourceRecoveryResult rollbackPrepared(ServerLevel level, BatchTransactionRecord record);
+    default SourceRecoveryResult rollbackPrepared(
+            ServerLevel level,
+            BatchTransactionRecord record) {
+        throw new UnsupportedOperationException(
+                "source reconciler does not implement public transaction recovery");
+    }
 
-    SourceRecoveryResult accountAccepted(ServerLevel level, BatchTransactionRecord record);
+    default SourceRecoveryResult accountAccepted(
+            ServerLevel level,
+            BatchTransactionRecord record) {
+        throw new UnsupportedOperationException(
+                "source reconciler does not implement public transaction recovery");
+    }
 
     /** Called after the matching durable journal record reached a terminal phase. */
     default void forgetResolvedSource(ServerLevel level, BatchTransactionRecord record) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/BatchTransactionRecord.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/BatchTransactionRecord.java
@@ -1,0 +1,127 @@
+package com.syaru.ae2craftingoptimizer.api.batch.v2;
+
+import appeng.api.stacks.GenericStack;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+
+/**
+ * Native Batchの永続Journalを外部Adapterへ公開する読み取り専用Snapshot。
+ *
+ * <p>ACO内部の可変Recordは公開せず、復旧判定に必要な値だけを防御コピーで渡す。</p>
+ */
+public final class BatchTransactionRecord {
+    private final UUID id;
+    private final ResourceLocation adapterId;
+    private final ResourceLocation sourceId;
+    private final ResourceLocation dimensionId;
+    private final BlockPos targetPos;
+    private final String patternFingerprint;
+    private final long offeredExecutions;
+    private final long acceptedExecutions;
+    private final long createdTick;
+    private final long updatedTick;
+    private final String phase;
+    private final List<GenericStack> extractedInputs;
+    private final List<GenericStack> expectedOutputs;
+    private final CompoundTag sourceData;
+    private final CompoundTag adapterData;
+    private final String receipt;
+
+    private BatchTransactionRecord(
+            UUID id,
+            ResourceLocation adapterId,
+            ResourceLocation sourceId,
+            ResourceLocation dimensionId,
+            BlockPos targetPos,
+            String patternFingerprint,
+            long offeredExecutions,
+            long acceptedExecutions,
+            long createdTick,
+            long updatedTick,
+            String phase,
+            List<GenericStack> extractedInputs,
+            List<GenericStack> expectedOutputs,
+            CompoundTag sourceData,
+            CompoundTag adapterData,
+            String receipt) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.adapterId = Objects.requireNonNull(adapterId, "adapterId");
+        this.sourceId = Objects.requireNonNull(sourceId, "sourceId");
+        this.dimensionId = Objects.requireNonNull(dimensionId, "dimensionId");
+        this.targetPos = Objects.requireNonNull(targetPos, "targetPos").immutable();
+        this.patternFingerprint = Objects.requireNonNull(patternFingerprint, "patternFingerprint");
+        this.phase = Objects.requireNonNull(phase, "phase");
+        this.extractedInputs = List.copyOf(Objects.requireNonNull(extractedInputs, "extractedInputs"));
+        this.expectedOutputs = List.copyOf(Objects.requireNonNull(expectedOutputs, "expectedOutputs"));
+        this.sourceData = Objects.requireNonNull(sourceData, "sourceData").copy();
+        this.adapterData = Objects.requireNonNull(adapterData, "adapterData").copy();
+        this.receipt = Objects.requireNonNull(receipt, "receipt");
+        this.offeredExecutions = offeredExecutions;
+        this.acceptedExecutions = acceptedExecutions;
+        this.createdTick = createdTick;
+        this.updatedTick = updatedTick;
+    }
+
+    public UUID id() { return id; }
+    public ResourceLocation adapterId() { return adapterId; }
+    public ResourceLocation sourceId() { return sourceId; }
+    public ResourceLocation dimensionId() { return dimensionId; }
+    public BlockPos targetPos() { return targetPos; }
+    public String patternFingerprint() { return patternFingerprint; }
+    public long offeredExecutions() { return offeredExecutions; }
+    public long acceptedExecutions() { return acceptedExecutions; }
+    public long createdTick() { return createdTick; }
+    public long updatedTick() { return updatedTick; }
+    public String phase() { return phase; }
+    public List<GenericStack> extractedInputs() { return extractedInputs; }
+    public List<GenericStack> expectedOutputs() { return expectedOutputs; }
+    public CompoundTag sourceData() { return sourceData.copy(); }
+    public CompoundTag adapterData() { return adapterData.copy(); }
+    public String receipt() { return receipt; }
+
+    /** ACOが永続化した入力・出力・実行数から正規の所有権Digestを返す。 */
+    public String payloadDigest() {
+        return BatchPayloadFingerprint.of(this);
+    }
+
+    /** ACO内部Journalから不変の公開Snapshotを作る。 */
+    public static BatchTransactionRecord snapshot(
+            UUID id,
+            ResourceLocation adapterId,
+            ResourceLocation sourceId,
+            ResourceLocation dimensionId,
+            BlockPos targetPos,
+            String patternFingerprint,
+            long offeredExecutions,
+            long acceptedExecutions,
+            long createdTick,
+            long updatedTick,
+            String phase,
+            List<GenericStack> extractedInputs,
+            List<GenericStack> expectedOutputs,
+            CompoundTag sourceData,
+            CompoundTag adapterData,
+            String receipt) {
+        return new BatchTransactionRecord(
+                id,
+                adapterId,
+                sourceId,
+                dimensionId,
+                targetPos,
+                patternFingerprint,
+                offeredExecutions,
+                acceptedExecutions,
+                createdTick,
+                updatedTick,
+                phase,
+                extractedInputs,
+                expectedOutputs,
+                sourceData,
+                adapterData,
+                receipt);
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/PatternBatchIdentity.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/PatternBatchIdentity.java
@@ -1,0 +1,20 @@
+package com.syaru.ae2craftingoptimizer.api.batch.v2;
+
+import com.syaru.ae2craftingoptimizer.api.batch.PatternBatchContext;
+import com.syaru.ae2craftingoptimizer.batch.NativePatternBatchSupport;
+import java.util.Objects;
+
+/** ACO Journalと外部Adapterが共有する、Pattern Batchの正規識別API。 */
+public final class PatternBatchIdentity {
+    private PatternBatchIdentity() {
+    }
+
+    /**
+     * ACOが永続Journalへ保存する値と完全に同じFingerprintを返す。
+     * 外部Adapterは独自に同じ符号化を再実装しないこと。
+     */
+    public static String canonicalFingerprint(PatternBatchContext context) {
+        return NativePatternBatchSupport.fingerprint(
+                Objects.requireNonNull(context, "context"));
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/TransactionalPatternBatchAdapter.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/batch/v2/TransactionalPatternBatchAdapter.java
@@ -2,7 +2,6 @@ package com.syaru.ae2craftingoptimizer.api.batch.v2;
 
 import com.syaru.ae2craftingoptimizer.api.batch.PatternBatchBudget;
 import com.syaru.ae2craftingoptimizer.api.batch.PatternBatchContext;
-import com.syaru.ae2craftingoptimizer.transaction.BatchTransactionRecord;
 import java.util.UUID;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
@@ -51,7 +50,13 @@ public interface TransactionalPatternBatchAdapter {
     /** Called only before durable target acceptance. */
     void rollback(PatternBatchContext context, PreparedPatternBatch prepared);
 
-    BatchRecoveryResult reconcileTarget(ServerLevel level, BatchTransactionRecord record);
+    /** 復旧処理はACO内部Journalではなく、読み取り専用の公開Snapshotだけを受け取る。 */
+    default BatchRecoveryResult reconcileTarget(
+            ServerLevel level,
+            BatchTransactionRecord record) {
+        throw new UnsupportedOperationException(
+                "adapter does not implement public transaction recovery");
+    }
 
     /** Called after the matching durable journal record reached a terminal phase. */
     default void forgetResolvedTarget(PatternBatchContext context, UUID transactionId) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/batch/Ae2BatchSourceReconciler.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/batch/Ae2BatchSourceReconciler.java
@@ -17,7 +17,7 @@ import com.syaru.ae2craftingoptimizer.access.CraftingJobTransactionAccess;
 import com.syaru.ae2craftingoptimizer.access.CraftingLogicTransactionAccess;
 import com.syaru.ae2craftingoptimizer.access.CraftingOwnerTransactionAccess;
 import com.syaru.ae2craftingoptimizer.access.CraftingTaskProgressAccess;
-import com.syaru.ae2craftingoptimizer.transaction.BatchTransactionRecord;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord;
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/TransactionalCraftingExecutorV2.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/TransactionalCraftingExecutorV2.java
@@ -317,7 +317,7 @@ public final class TransactionalCraftingExecutorV2 {
                         selection.adapter().rollback(selection.context(), prepared);
                         SourceRecoveryResult rollback = Ae2BatchSourceReconciler.INSTANCE.rollbackPrepared(
                                 serverLevel,
-                                transaction.record());
+                                transaction.record().toPublicView());
                         return finishRollback(
                                 transaction,
                                 rollback,
@@ -343,7 +343,7 @@ public final class TransactionalCraftingExecutorV2 {
                         commitStarted = false;
                         selection.adapter().rollback(selection.context(), prepared);
                         SourceRecoveryResult rollback = Ae2BatchSourceReconciler.INSTANCE.rollbackPrepared(
-                                serverLevel, transaction.record());
+                                serverLevel, transaction.record().toPublicView());
                         return finishRollback(
                                 transaction,
                                 rollback,
@@ -363,7 +363,7 @@ public final class TransactionalCraftingExecutorV2 {
                     owner.aco$markCraftingOwnerDirty();
 
                     SourceRecoveryResult accounting = Ae2BatchSourceReconciler.INSTANCE.accountAccepted(
-                            serverLevel, transaction.record());
+                            serverLevel, transaction.record().toPublicView());
                     if (accounting == SourceRecoveryResult.RETRY) {
                         safeReconciliation(
                                 transaction,
@@ -394,7 +394,7 @@ public final class TransactionalCraftingExecutorV2 {
                         try {
                             selection.adapter().rollback(selection.context(), prepared);
                             SourceRecoveryResult rollback = Ae2BatchSourceReconciler.INSTANCE.rollbackPrepared(
-                                    serverLevel, transaction.record());
+                                    serverLevel, transaction.record().toPublicView());
                             logFailure(logic.getClass(), failure);
                             return finishRollback(
                                     transaction,
@@ -741,7 +741,9 @@ public final class TransactionalCraftingExecutorV2 {
             PatternBatchContext context,
             BatchTransactionRecord record) {
         try {
-            Ae2BatchSourceReconciler.INSTANCE.forgetResolvedSource(level, record);
+            Ae2BatchSourceReconciler.INSTANCE.forgetResolvedSource(
+                    level,
+                    record.toPublicView());
         } catch (RuntimeException | LinkageError cleanupFailure) {
             AE2CraftingOptimizer.LOGGER.warn(
                     "ACO retained a terminal source receipt after journal completion {}: {}",

--- a/src/main/java/com/syaru/ae2craftingoptimizer/transaction/BatchRecoveryCompatibilityBridge.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/transaction/BatchRecoveryCompatibilityBridge.java
@@ -1,0 +1,178 @@
+package com.syaru.ae2craftingoptimizer.transaction;
+
+import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchRecoveryResult;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchSourceReconciler;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.SourceRecoveryResult;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.TransactionalPatternBatchAdapter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import net.minecraft.server.level.ServerLevel;
+
+/**
+ * 公開Recordへ移行した後も、ACO 1.5.x旧ABIでビルド済みのAdapterを復旧時に呼び出す。
+ */
+final class BatchRecoveryCompatibilityBridge {
+    private BatchRecoveryCompatibilityBridge() {
+    }
+
+    static BatchRecoveryResult reconcileTarget(
+            TransactionalPatternBatchAdapter adapter,
+            ServerLevel level,
+            BatchTransactionRecord record) {
+        Method publicMethod = publicMethod(
+                adapter,
+                "reconcileTarget",
+                ServerLevel.class,
+                com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord.class);
+        // 外部Adapterが公開APIを実装済みなら、内部Journalを渡さずSnapshotを使う。
+        if (publicMethod.getDeclaringClass() != TransactionalPatternBatchAdapter.class) {
+            return adapter.reconcileTarget(level, record.toPublicView());
+        }
+        return invokeLegacy(
+                adapter,
+                "reconcileTarget",
+                BatchRecoveryResult.class,
+                level,
+                record);
+    }
+
+    static SourceRecoveryResult rollbackPrepared(
+            BatchSourceReconciler source,
+            ServerLevel level,
+            BatchTransactionRecord record) {
+        Method publicMethod = publicMethod(
+                source,
+                "rollbackPrepared",
+                ServerLevel.class,
+                com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord.class);
+        // 公開API実装と旧ABI実装をmethod descriptorで区別する。
+        if (publicMethod.getDeclaringClass() != BatchSourceReconciler.class) {
+            return source.rollbackPrepared(level, record.toPublicView());
+        }
+        return invokeLegacy(
+                source,
+                "rollbackPrepared",
+                SourceRecoveryResult.class,
+                level,
+                record);
+    }
+
+    static SourceRecoveryResult accountAccepted(
+            BatchSourceReconciler source,
+            ServerLevel level,
+            BatchTransactionRecord record) {
+        Method publicMethod = publicMethod(
+                source,
+                "accountAccepted",
+                ServerLevel.class,
+                com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord.class);
+        // 公開API実装と旧ABI実装をmethod descriptorで区別する。
+        if (publicMethod.getDeclaringClass() != BatchSourceReconciler.class) {
+            return source.accountAccepted(level, record.toPublicView());
+        }
+        return invokeLegacy(
+                source,
+                "accountAccepted",
+                SourceRecoveryResult.class,
+                level,
+                record);
+    }
+
+    static void forgetTarget(
+            TransactionalPatternBatchAdapter adapter,
+            ServerLevel level,
+            BatchTransactionRecord record) {
+        Method publicMethod = publicMethod(
+                adapter,
+                "forgetResolvedTarget",
+                ServerLevel.class,
+                com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord.class);
+        // 公開API実装済みのAdapterへは防御コピーだけを渡す。
+        if (publicMethod.getDeclaringClass() != TransactionalPatternBatchAdapter.class) {
+            adapter.forgetResolvedTarget(level, record.toPublicView());
+            return;
+        }
+        invokeLegacyVoidIfPresent(adapter, "forgetResolvedTarget", level, record);
+    }
+
+    static void forgetSource(
+            BatchSourceReconciler source,
+            ServerLevel level,
+            BatchTransactionRecord record) {
+        Method publicMethod = publicMethod(
+                source,
+                "forgetResolvedSource",
+                ServerLevel.class,
+                com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord.class);
+        // 公開API実装済みのSourceへは防御コピーだけを渡す。
+        if (publicMethod.getDeclaringClass() != BatchSourceReconciler.class) {
+            source.forgetResolvedSource(level, record.toPublicView());
+            return;
+        }
+        invokeLegacyVoidIfPresent(source, "forgetResolvedSource", level, record);
+    }
+
+    private static Method publicMethod(
+            Object target,
+            String name,
+            Class<?>... parameterTypes) {
+        try {
+            return target.getClass().getMethod(name, parameterTypes);
+        } catch (NoSuchMethodException missing) {
+            throw new IllegalStateException("recovery implementation has no " + name, missing);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T invokeLegacy(
+            Object target,
+            String name,
+            Class<T> resultType,
+            ServerLevel level,
+            BatchTransactionRecord record) {
+        try {
+            Method method = target.getClass().getMethod(
+                    name,
+                    ServerLevel.class,
+                    BatchTransactionRecord.class);
+            Object result = method.invoke(target, level, record);
+            return resultType.cast(result);
+        } catch (ReflectiveOperationException failure) {
+            throw unwrap(name, failure);
+        }
+    }
+
+    private static void invokeLegacyVoidIfPresent(
+            Object target,
+            String name,
+            ServerLevel level,
+            BatchTransactionRecord record) {
+        try {
+            Method method = target.getClass().getMethod(
+                    name,
+                    ServerLevel.class,
+                    BatchTransactionRecord.class);
+            method.invoke(target, level, record);
+        } catch (NoSuchMethodException missingLegacyDefault) {
+            // 旧1.5系interfaceの任意default cleanupを未overrideなら、従来どおりno-opにする。
+            return;
+        } catch (ReflectiveOperationException failure) {
+            throw unwrap(name, failure);
+        }
+    }
+
+    private static RuntimeException unwrap(
+            String name,
+            ReflectiveOperationException failure) {
+        Throwable cause = failure instanceof InvocationTargetException invocation
+                ? invocation.getCause()
+                : failure;
+        if (cause instanceof RuntimeException runtime) {
+            return runtime;
+        }
+        if (cause instanceof Error error) {
+            throw error;
+        }
+        return new IllegalStateException("legacy recovery method failed: " + name, cause);
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/transaction/BatchTransactionRecord.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/transaction/BatchTransactionRecord.java
@@ -152,6 +152,31 @@ public final class BatchTransactionRecord {
         return receipt;
     }
 
+    /** 内部Journalを公開せず、復旧に必要な不変Snapshotだけを作る。 */
+    public com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord toPublicView() {
+        return com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord.snapshot(
+                id,
+                adapterId,
+                sourceId,
+                dimensionId,
+                targetPos,
+                patternFingerprint,
+                offeredExecutions,
+                acceptedExecutions,
+                createdTick,
+                updatedTick,
+                phase.name(),
+                extractedInputs,
+                expectedOutputs,
+                sourceData,
+                adapterData,
+                receipt);
+    }
+
+    public String payloadDigest() {
+        return toPublicView().payloadDigest();
+    }
+
     public BatchTransactionRecord transition(
             BatchTransactionPhase next,
             long accepted,

--- a/src/main/java/com/syaru/ae2craftingoptimizer/transaction/BatchTransactionRecovery.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/transaction/BatchTransactionRecovery.java
@@ -53,7 +53,10 @@ public final class BatchTransactionRecovery {
             return;
         }
         try {
-            BatchRecoveryResult target = adapter.reconcileTarget(level, record);
+            BatchRecoveryResult target = BatchRecoveryCompatibilityBridge.reconcileTarget(
+                    adapter,
+                    level,
+                    record);
             switch (target.targetState()) {
                 case RETRY -> {
                     return;
@@ -86,7 +89,7 @@ public final class BatchTransactionRecovery {
                 record,
                 gameTick,
                 adapter,
-                source.rollbackPrepared(level, record),
+                BatchRecoveryCompatibilityBridge.rollbackPrepared(source, level, record),
                 source,
                 level,
                 BatchTransactionPhase.ROLLED_BACK);
@@ -125,7 +128,7 @@ public final class BatchTransactionRecovery {
                 acceptedRecord,
                 gameTick,
                 adapter,
-                source.accountAccepted(level, acceptedRecord),
+                BatchRecoveryCompatibilityBridge.accountAccepted(source, level, acceptedRecord),
                 source,
                 level,
                 BatchTransactionPhase.ACCOUNTED);
@@ -169,14 +172,14 @@ public final class BatchTransactionRecovery {
             ServerLevel level,
             BatchTransactionRecord record) {
         try {
-            source.forgetResolvedSource(level, record);
+            BatchRecoveryCompatibilityBridge.forgetSource(source, level, record);
         } catch (RuntimeException | LinkageError cleanupFailure) {
             AE2CraftingOptimizer.LOGGER.warn(
                     "ACO retained a recovered terminal source receipt {}: {}",
                     record.id(), cleanupFailure.toString());
         }
         try {
-            adapter.forgetResolvedTarget(level, record);
+            BatchRecoveryCompatibilityBridge.forgetTarget(adapter, level, record);
         } catch (RuntimeException | LinkageError cleanupFailure) {
             AE2CraftingOptimizer.LOGGER.warn(
                     "ACO retained a recovered terminal target receipt {}: {}",

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/ExternalBatchRecoveryFixture.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/ExternalBatchRecoveryFixture.java
@@ -1,0 +1,13 @@
+package com.syaru.ae2craftingoptimizer.api;
+
+import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord;
+
+/** 外部Adapter相当のcompile fixture。ACO実装packageを一切importしない。 */
+public final class ExternalBatchRecoveryFixture {
+    private ExternalBatchRecoveryFixture() {
+    }
+
+    public static String canonicalDigest(BatchTransactionRecord record) {
+        return record.payloadDigest();
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/ExternalBatchRecoveryFixtureTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/ExternalBatchRecoveryFixtureTest.java
@@ -1,0 +1,38 @@
+package com.syaru.ae2craftingoptimizer.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord;
+import java.util.List;
+import java.util.UUID;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import org.junit.jupiter.api.Test;
+
+class ExternalBatchRecoveryFixtureTest {
+    @Test
+    void consumesOnlyThePublicRecoveryContract() {
+        BatchTransactionRecord record = BatchTransactionRecord.snapshot(
+                UUID.randomUUID(),
+                ResourceLocation.fromNamespaceAndPath("test", "adapter"),
+                ResourceLocation.fromNamespaceAndPath("test", "source"),
+                ResourceLocation.fromNamespaceAndPath("minecraft", "overworld"),
+                new BlockPos(1, 2, 3),
+                "pattern",
+                1L,
+                0L,
+                1L,
+                1L,
+                "PREPARED",
+                List.of(),
+                List.of(),
+                new CompoundTag(),
+                new CompoundTag(),
+                "");
+
+        assertEquals(
+                record.payloadDigest(),
+                ExternalBatchRecoveryFixture.canonicalDigest(record));
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/transaction/BatchRecoveryCompatibilityBridgeTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/transaction/BatchRecoveryCompatibilityBridgeTest.java
@@ -1,0 +1,199 @@
+package com.syaru.ae2craftingoptimizer.transaction;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.syaru.ae2craftingoptimizer.api.batch.PatternBatchBudget;
+import com.syaru.ae2craftingoptimizer.api.batch.PatternBatchContext;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchRecoveryResult;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchSourceReconciler;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.PatternBatchCommit;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.PreparedPatternBatch;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.SourceRecoveryResult;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.TransactionalPatternBatchAdapter;
+import java.util.List;
+import java.util.UUID;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import org.junit.jupiter.api.Test;
+
+class BatchRecoveryCompatibilityBridgeTest {
+    private static final BatchRecoveryResult NOT_ACCEPTED =
+            new BatchRecoveryResult(
+                    BatchRecoveryResult.TargetState.NOT_ACCEPTED,
+                    0L,
+                    "test");
+
+    @Test
+    void invokesThePublicRecoveryContractWithAReadOnlySnapshot() {
+        PublicAdapter adapter = new PublicAdapter();
+
+        BatchRecoveryResult result =
+                BatchRecoveryCompatibilityBridge.reconcileTarget(
+                        adapter,
+                        null,
+                        record());
+
+        assertEquals(NOT_ACCEPTED, result);
+        assertNotNull(adapter.received);
+        assertEquals("PREPARED", adapter.received.phase());
+    }
+
+    @Test
+    void invokesTheLegacyRecoveryDescriptorForExistingAdapters() {
+        LegacyAdapter adapter = new LegacyAdapter();
+
+        BatchRecoveryResult result =
+                BatchRecoveryCompatibilityBridge.reconcileTarget(
+                        adapter,
+                        null,
+                        record());
+
+        assertEquals(NOT_ACCEPTED, result);
+        assertNotNull(adapter.received);
+    }
+
+    @Test
+    void preservesTheLegacyDefaultNoOpCleanup() {
+        LegacyAdapter adapter = new LegacyAdapter();
+        LegacySource source = new LegacySource();
+        BatchTransactionRecord record = record();
+
+        assertDoesNotThrow(
+                () -> BatchRecoveryCompatibilityBridge.forgetTarget(
+                        adapter,
+                        null,
+                        record));
+        assertDoesNotThrow(
+                () -> BatchRecoveryCompatibilityBridge.forgetSource(
+                        source,
+                        null,
+                        record));
+    }
+
+    @Test
+    void invokesLegacySourceRecoveryDescriptors() {
+        LegacySource source = new LegacySource();
+        BatchTransactionRecord record = record();
+
+        assertEquals(
+                SourceRecoveryResult.COMPLETE,
+                BatchRecoveryCompatibilityBridge.rollbackPrepared(
+                        source,
+                        null,
+                        record));
+        assertEquals(
+                SourceRecoveryResult.COMPLETE,
+                BatchRecoveryCompatibilityBridge.accountAccepted(
+                        source,
+                        null,
+                        record));
+        assertEquals(2, source.calls);
+    }
+
+    private static BatchTransactionRecord record() {
+        return new BatchTransactionRecord(
+                UUID.randomUUID(),
+                ResourceLocation.fromNamespaceAndPath("test", "adapter"),
+                ResourceLocation.fromNamespaceAndPath("test", "source"),
+                ResourceLocation.fromNamespaceAndPath("minecraft", "overworld"),
+                BlockPos.ZERO,
+                "pattern",
+                1L,
+                0L,
+                1L,
+                1L,
+                BatchTransactionPhase.PREPARED,
+                List.of(),
+                List.of(),
+                new CompoundTag(),
+                new CompoundTag(),
+                "");
+    }
+
+    private abstract static class BaseAdapter
+            implements TransactionalPatternBatchAdapter {
+        @Override
+        public ResourceLocation id() {
+            return ResourceLocation.fromNamespaceAndPath("test", "adapter");
+        }
+
+        @Override
+        public boolean supports(PatternBatchContext context) {
+            return false;
+        }
+
+        @Override
+        public PreparedPatternBatch prepare(
+                PatternBatchContext context,
+                PatternBatchBudget budget,
+                UUID transactionId) {
+            throw new UnsupportedOperationException("not used by this recovery test");
+        }
+
+        @Override
+        public PatternBatchCommit commit(
+                PatternBatchContext context,
+                PreparedPatternBatch prepared) {
+            throw new UnsupportedOperationException("not used by this recovery test");
+        }
+
+        @Override
+        public void rollback(
+                PatternBatchContext context,
+                PreparedPatternBatch prepared) {
+            throw new UnsupportedOperationException("not used by this recovery test");
+        }
+    }
+
+    private static final class PublicAdapter extends BaseAdapter {
+        private com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord received;
+
+        @Override
+        public BatchRecoveryResult reconcileTarget(
+                ServerLevel level,
+                com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord record) {
+            received = record;
+            return NOT_ACCEPTED;
+        }
+    }
+
+    /** ACO 1.5.xでコンパイル済みのAdapterと同じ旧method descriptorを持つfixture。 */
+    private static final class LegacyAdapter extends BaseAdapter {
+        private BatchTransactionRecord received;
+
+        public BatchRecoveryResult reconcileTarget(
+                ServerLevel level,
+                BatchTransactionRecord record) {
+            received = record;
+            return NOT_ACCEPTED;
+        }
+    }
+
+    /** ACO 1.5.xのSource実装と同じ旧method descriptorを持つfixture。 */
+    private static final class LegacySource implements BatchSourceReconciler {
+        private int calls;
+
+        @Override
+        public ResourceLocation id() {
+            return ResourceLocation.fromNamespaceAndPath("test", "source");
+        }
+
+        public SourceRecoveryResult rollbackPrepared(
+                ServerLevel level,
+                BatchTransactionRecord record) {
+            calls++;
+            return SourceRecoveryResult.COMPLETE;
+        }
+
+        public SourceRecoveryResult accountAccepted(
+                ServerLevel level,
+                BatchTransactionRecord record) {
+            calls++;
+            return SourceRecoveryResult.COMPLETE;
+        }
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/transaction/BatchTransactionRecordTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/transaction/BatchTransactionRecordTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchPayloadFingerprint;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.PreparedPatternBatch;
 import java.util.List;
 import java.util.UUID;
 import net.minecraft.core.BlockPos;
@@ -23,6 +25,22 @@ class BatchTransactionRecordTest {
         assertEquals(original.targetPos(), restored.targetPos());
         assertEquals(original.phase(), restored.phase());
         assertEquals(original.offeredExecutions(), restored.offeredExecutions());
+    }
+
+    @Test
+    void publicRecoveryDigestMatchesPreparedAndPersistedPayloads() {
+        BatchTransactionRecord original = record();
+        PreparedPatternBatch prepared = new PreparedPatternBatch(
+                original.id(),
+                original.offeredExecutions(),
+                original.extractedInputs(),
+                original.expectedOutputs(),
+                new CompoundTag());
+        BatchTransactionRecord restored = BatchTransactionRecord.load(original.save());
+
+        assertEquals(BatchPayloadFingerprint.of(prepared), original.payloadDigest());
+        assertEquals(original.payloadDigest(), original.toPublicView().payloadDigest());
+        assertEquals(original.payloadDigest(), restored.toPublicView().payloadDigest());
     }
 
     @Test


### PR DESCRIPTION
## 概要

NeoForge 1.21.1のNative Batch復旧契約を、Forge 1.20.1と同じ公開・読み取り専用
APIへ統一します。

## 変更内容

- 公開`BatchTransactionRecord` snapshotを追加し、NBTとListを防御コピー。
- AdapterとSource Reconcilerの公開signatureからACO内部Journal classを除去。
- ACO Journalと同じ`PatternBatchIdentity.canonicalFingerprint`を公開。
- 既存1.5.x向けAdapterを呼び出す互換橋を追加。
- 旧任意cleanupを未実装のAdapterでは従来どおりno-opを維持。
- バージョンを1.5.15へ更新。

## 検証

- `gradlew clean check build --no-daemon`: 成功
- JUnit: 341件成功、失敗0件
- 新旧復旧descriptor、公開snapshot防御コピー、payload digestを回帰試験
- `git diff --check`: 成功
- ローカル絶対パス混入: なし

Closes #28
