### PR TITLE
Fix persisted Exact Pattern accounting recovery (1.20.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ All notable changes to this project are documented here.
   while continuing to delegate overlapping execution hooks to InsaneAE.
 - Added regression coverage for fully qualified Mixin names so the compatibility
   audit cannot fail from the same over-broad exclusion again.
+- Persisted each physical Exact CPU Pattern's encoded definition and exact
+  input/output formula before resource ownership begins.
+- Reconciled historical task counters from the transaction-owned identity
+  instead of resolving them again through the current live Pattern graph.
+- Kept temporarily unloaded Providers retryable while quarantining only a
+  proven replacement whose identity or formula changed.
+- Added schema 2 to schema 3 lazy migration without guessing missing Pattern
+  identities or replaying receipts.
 
 ## [1.5.15] - 2026-08-13
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -189,6 +189,31 @@ that `BigIntegerStorageSnapshotBridge.collect()` and nested
 `NetworkStorage.getAvailableStacks()` no longer rebuild once per terminal plus
 once per `StorageService` refresh when no intervening storage mutation occurs.
 
+### Persisted Pattern Identity Recovery (Issue #29)
+
+Use one deterministic physical crafting-table job with at least one accepted
+Worker receipt. Record every exact input, output, task, and `waitingFor` value.
+
+1. Unload the Pattern Provider chunk while the job is running. The transaction
+   must report waiting; it must not quarantine, cancel, refund, or advance.
+2. Reload the unchanged Provider. The same receipt must resume and every exact
+   counter must remain equal to the recorded value.
+3. Repeat across a server save and restart. Reconciliation must use the
+   transaction-owned encoded Pattern definition even before the live graph has
+   rediscovered the Provider.
+4. Reload recipes without changing the Pattern formula. The job must revalidate
+   and continue without creating another receipt.
+5. Replace the encoded Pattern with a definition whose selected inputs or
+   expected outputs differ. The transaction must quarantine while preserving
+   escrow and receipts for administrator recovery.
+6. Repeat each reconciliation twice. Planned, dispatched, introduced, and
+   credited totals must be idempotent; no item may be duplicated or lost.
+
+`PhysicalPatternAccountingSourceContractTest` runs in headless JUnit and locks
+the schema, ownership-boundary capture, live-graph-independent accounting, and
+retry/conflict branches. The lifecycle scenarios above remain GameTest/manual
+checks because AE2 encoded items require the real mod registry lifecycle.
+
 ## Disable Checks
 
 1. Disable the physical path before starting a new job and confirm normal AE2

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/PhysicalCraftingTreeTransaction.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/PhysicalCraftingTreeTransaction.java
@@ -443,6 +443,10 @@ public final class PhysicalCraftingTreeTransaction {
                         TickOutcome.quarantined(
                                 detail);
             };
+        } catch (PatternUnavailableException unavailable) {
+            // Provider unload中は所有権とReceiptを保持し、次tick以降へ再試行する。
+            detail = checkedDetail(unavailable.getMessage());
+            return TickOutcome.waiting(detail);
         } catch (RuntimeException | LinkageError failure) {
             quarantine(
                     "physical crafting-tree transaction failed: "
@@ -531,13 +535,26 @@ public final class PhysicalCraftingTreeTransaction {
             Level level) {
         Objects.requireNonNull(snapshot, "snapshot");
         Objects.requireNonNull(level, "level");
+        // schema 2保存だけは、Providerが戻った時に一度だけ不変identityへ移行する。
+        ensurePatternIdentities(snapshot, level);
+        return accountingSnapshotFromPersistedIdentities();
+    }
+
+    /**
+     * live graphへ触れず、Transactionが所有する不変Pattern identityだけから会計を再構築する。
+     *
+     * <p>package-privateなのは、再起動・Provider unloadの回帰試験で同じ本番経路を使うため。</p>
+     */
+    AccountingSnapshot accountingSnapshotFromPersistedIdentities() {
+        if (!hasCompletePatternIdentities()) {
+            throw new PatternUnavailableException(
+                    "physical pattern accounting identity is not available yet");
+        }
         Map<String, BigInteger> plannedTasks = new LinkedHashMap<>();
         Map<String, BigInteger> dispatchedTasks = new LinkedHashMap<>();
         Map<AEKey, BigInteger> expectedOutputs = new LinkedHashMap<>();
         Map<AEKey, BigInteger> introducedOutputs = new LinkedHashMap<>();
         Map<AEKey, BigInteger> creditedOutputs = new LinkedHashMap<>();
-        // v2 transactions are lazily migrated when the live graph is available.
-        ensurePatternIdentities(snapshot, level);
         // 固有Pattern数だけを一巡し、注文数量ぶんの会計要素は作らない。
         for (StepReceipt receipt : steps) {
             ExactCraftingStep step = plan.craftingSteps().get(receipt.index());
@@ -1799,13 +1816,7 @@ public final class PhysicalCraftingTreeTransaction {
                 (AEItemKey) pattern.getDefinition(),
                 formula.exactInputTotals(step.executions()),
                 formula.exactExpectedOutputTotals(step.executions()));
-        PatternAccountingIdentity saved = patternIdentities.get(step.patternId());
-        if (saved == null) {
-            patternIdentities.put(step.patternId(), current);
-        } else if (!saved.equals(current)) {
-            throw new PatternIdentityConflictException(
-                    "live crafting-table pattern identity changed: " + step.patternId());
-        }
+        rememberOrVerifyPatternIdentity(current);
         return new ResolvedStep(
                 step,
                 pattern,
@@ -2297,6 +2308,32 @@ public final class PhysicalCraftingTreeTransaction {
             if (!patternIdentities.containsKey(step.patternId())) {
                 resolveStepFresh(snapshot, level, index);
             }
+        }
+    }
+
+    /** 同じPattern IDの正本を初回だけ保存し、以後は完全一致だけを受理する。 */
+    void rememberOrVerifyPatternIdentity(PatternAccountingIdentity current) {
+        Objects.requireNonNull(current, "current");
+        ExactCraftingStep matchingStep = null;
+        // identityが現在の物理計画に属するPatternかを確認する。
+        for (ExactCraftingStep step : plan.craftingSteps()) {
+            if (step.patternId().equals(current.patternId())) {
+                matchingStep = step;
+                break;
+            }
+        }
+        if (matchingStep == null || !current.matchesStep(matchingStep)) {
+            throw new PatternIdentityConflictException(
+                    "live crafting-table pattern does not belong to this physical plan");
+        }
+        PatternAccountingIdentity saved = patternIdentities.get(current.patternId());
+        if (saved == null) {
+            patternIdentities.put(current.patternId(), current);
+            return;
+        }
+        if (!saved.equals(current)) {
+            throw new PatternIdentityConflictException(
+                    "live crafting-table pattern identity changed: " + current.patternId());
         }
     }
 

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/PhysicalPatternAccountingSourceContractTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/PhysicalPatternAccountingSourceContractTest.java
@@ -1,0 +1,101 @@
+package com.syaru.ae2craftingoptimizer.engine.craftingtable;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/** live graphを履歴会計へ再導入する回帰を、headless JUnitで検出する。 */
+class PhysicalPatternAccountingSourceContractTest {
+    private static final Path TRANSACTION = Path.of(
+            "src", "main", "java", "com", "syaru", "ae2craftingoptimizer",
+            "engine", "craftingtable", "PhysicalCraftingTreeTransaction.java");
+    private static final Path MANAGER = Path.of(
+            "src", "main", "java", "com", "syaru", "ae2craftingoptimizer",
+            "integration", "AqeBigCraftingExecutionManager.java");
+
+    @Test
+    void persistsACompleteCanonicalIdentityWithLegacyMigration() {
+        String source = read(TRANSACTION);
+
+        assertTrue(source.contains("private static final int SCHEMA_VERSION = 3;"));
+        assertTrue(source.contains("private static final int LEGACY_SCHEMA_VERSION = 2;"));
+        assertTrue(source.contains("encodePatternIdentities(patternIdentities)"));
+        assertTrue(source.contains("decodePatternIdentities(owner, plan)"));
+        assertTrue(source.contains("ensurePatternIdentities(snapshot, level)"));
+        assertTrue(source.contains("PatternUnavailableException"));
+        assertTrue(source.contains("PatternIdentityConflictException"));
+    }
+
+    @Test
+    void buildsHistoricalAccountingOnlyFromPersistedIdentities() {
+        String source = read(TRANSACTION);
+        String method = between(
+                source,
+                "AccountingSnapshot accountingSnapshotFromPersistedIdentities()",
+                "/** GUIへ渡す進捗");
+
+        assertTrue(method.contains("patternIdentities.get(step.patternId())"));
+        assertTrue(method.contains("patternDefinitions(plannedTasks)"));
+        assertFalse(method.contains("snapshot.pattern("));
+        assertFalse(method.contains("resolveStep("));
+        assertFalse(method.contains("graph().generation()"));
+    }
+
+    @Test
+    void capturesIdentityBeforeOwnershipAndNeverReResolvesTasksFromTheLiveGraph() {
+        String source = read(MANAGER);
+
+        assertTrue(count(source, "capturePatternAccounting(") >= 2L);
+        assertTrue(source.contains("accounting.plannedPatternDefinitions()"));
+        assertTrue(source.contains("accounting.dispatchedPatternDefinitions()"));
+        assertFalse(source.contains("exact accounting references an unknown pattern"));
+    }
+
+    @Test
+    void temporaryUnloadWaitsWhileAProvenReplacementConflicts() {
+        String source = read(TRANSACTION);
+        int retryableCatch = source.indexOf(
+                "catch (PatternUnavailableException unavailable)");
+        int quarantineCatch = source.indexOf(
+                "catch (RuntimeException | LinkageError failure)");
+
+        assertTrue(retryableCatch >= 0);
+        assertTrue(quarantineCatch > retryableCatch);
+        assertTrue(source.contains("live crafting-table pattern identity changed:"));
+        assertTrue(source.contains("return TickOutcome.waiting(detail);"));
+    }
+
+    private static String between(String source, String start, String end) {
+        int startIndex = source.indexOf(start);
+        int endIndex = source.indexOf(end, startIndex);
+        // 試験境界が消えた場合は、空文字で誤って通さず明示的に失敗させる。
+        if (startIndex < 0 || endIndex < 0) {
+            throw new IllegalArgumentException("source contract boundary is missing");
+        }
+        return source.substring(startIndex, endIndex);
+    }
+
+    private static long count(String source, String token) {
+        long matches = 0L;
+        int cursor = 0;
+        // 各出現位置を一度だけ数え、同じ開始位置を再評価しない。
+        while ((cursor = source.indexOf(token, cursor)) >= 0) {
+            matches++;
+            cursor += token.length();
+        }
+        return matches;
+    }
+
+    private static String read(Path path) {
+        try {
+            return Files.readString(path);
+        } catch (IOException exception) {
+            throw new UncheckedIOException(path.toString(), exception);
+        }
+    }
+}


### PR DESCRIPTION
## 目的

実行中のExact CPUが、Pattern Providerの一時アンロードや再起動直後のgraph再構築によって誤って隔離される問題を修正します。

Refs #29

## 原因

既に物理リソースを所有しているTransactionの履歴会計を、現在のlive Pattern graphから再解決していました。そのため、Patternが一時的に見えないだけでも`exact accounting references an unknown pattern`となり、CPUとTransactionが隔離されていました。

## 変更内容

- 物理所有開始前に、Pattern ID・encoded definition・正確な入力合計・期待出力合計を不変identityとして保存
- 過去のplanned/dispatched会計を保存済みidentityだけから再構築
- live graphは新規dispatch前の再検証だけに限定
- Provider不在は所有権とReceiptを保持した待機・再試行として処理
- 同じPattern IDで定義または入出力式が変化した場合だけ競合として隔離
- schema 2保存はlive Patternが戻った時にschema 3 identityへ安全に遅延移行
- 回帰を固定するsource-contract JUnitと手動/GameTest手順を追加

## 検証

- `gradlew clean build --no-daemon`: 成功
- JUnit: 321件、失敗0、エラー0、スキップ0
- `git diff --check`: 成功

Minecraft起動試験とGameTest実行は今回の作業範囲外です。
