### PR TITLE
Fix persisted Exact Pattern accounting recovery (1.21.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- Persisted each physical Exact CPU Pattern's encoded definition and exact
+  input/output formula before resource ownership begins.
+- Reconciled historical task counters from the transaction-owned identity
+  instead of resolving them again through the current live Pattern graph.
+- Kept temporarily unloaded Providers retryable while quarantining only a
+  proven replacement whose identity or formula changed.
+- Added schema 2 to schema 3 lazy migration without guessing missing Pattern
+  identities or replaying receipts.
+
 ## [1.5.15] - 2026-08-13
 
 ### Added

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -222,6 +222,31 @@ that `BigIntegerStorageSnapshotBridge.collect()` and nested
 `NetworkStorage.getAvailableStacks()` no longer rebuild once per terminal plus
 once per `StorageService` refresh when no intervening storage mutation occurs.
 
+### Persisted Pattern Identity Recovery (Issue #29)
+
+Use one deterministic physical crafting-table job with at least one accepted
+Worker receipt. Record every exact input, output, task, and `waitingFor` value.
+
+1. Unload the Pattern Provider chunk while the job is running. The transaction
+   must report waiting; it must not quarantine, cancel, refund, or advance.
+2. Reload the unchanged Provider. The same receipt must resume and every exact
+   counter must remain equal to the recorded value.
+3. Repeat across a server save and restart. Reconciliation must use the
+   transaction-owned encoded Pattern definition even before the live graph has
+   rediscovered the Provider.
+4. Reload recipes without changing the Pattern formula. The job must revalidate
+   and continue without creating another receipt.
+5. Replace the encoded Pattern with a definition whose selected inputs or
+   expected outputs differ. The transaction must quarantine while preserving
+   escrow and receipts for administrator recovery.
+6. Repeat each reconciliation twice. Planned, dispatched, introduced, and
+   credited totals must be idempotent; no item may be duplicated or lost.
+
+`PhysicalPatternAccountingSourceContractTest` runs in headless JUnit and locks
+the schema, ownership-boundary capture, live-graph-independent accounting, and
+retry/conflict branches. The lifecycle scenarios above remain GameTest/manual
+checks because AE2 encoded items require the real mod registry lifecycle.
+
 ## Disable Checks
 
 1. Disable the physical path before starting a new job and confirm normal AE2

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/PhysicalCraftingTreeTransaction.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/PhysicalCraftingTreeTransaction.java
@@ -4,6 +4,7 @@ import appeng.api.crafting.IPatternDetails;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.crafting.ICraftingProvider;
 import appeng.api.networking.security.IActionSource;
+import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
 import appeng.me.service.CraftingService;
 import com.syaru.ae2craftingoptimizer.api.batch.ExactPatternFormula;
@@ -20,6 +21,7 @@ import com.syaru.ae2craftingoptimizer.api.vector.ExactVectorStorageService;
 import com.syaru.ae2craftingoptimizer.api.vector.PreparedVectorBatch;
 import com.syaru.ae2craftingoptimizer.api.vector.PreparedVectorBatchCodec;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CompiledCraftingGraphCache;
+import com.syaru.ae2craftingoptimizer.lifecycle.ACORegistryAccess;
 import com.syaru.ae2craftingoptimizer.scheduler.PatternProviderRoutingCache;
 import com.syaru.ae2craftingoptimizer.util.StableFingerprint;
 import java.math.BigInteger;
@@ -53,7 +55,9 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 public final class PhysicalCraftingTreeTransaction {
     public static final String ENGINE_ID =
             "aco:physical-crafting-table-tree-v4";
-    private static final int SCHEMA_VERSION = 2;
+    private static final int SCHEMA_VERSION = 3;
+    /** pattern identityを持たない旧保存を安全に遅延移行するためのschema。 */
+    private static final int LEGACY_SCHEMA_VERSION = 2;
     /** 一つの物理レシピ段をGUI進捗へ換算する固定単位。 */
     private static final int PROGRESS_UNITS_PER_STEP = 100;
     /** 破損NBTによる巨大なキー配列確保を防ぐ固定上限。 */
@@ -62,6 +66,8 @@ public final class PhysicalCraftingTreeTransaction {
     private static final int MAXIMUM_DETAIL_LENGTH = 2_048;
 
     private final PreparedVectorBatch plan;
+    /** 物理所有開始前に固定し、live graph消失後も会計へ使うPattern正本。 */
+    private final Map<String, PatternAccountingIdentity> patternIdentities;
     private final ExactCraftingEscrow<AEKey> escrow;
     private final List<StepReceipt> steps;
     private State state;
@@ -92,8 +98,6 @@ public final class PhysicalCraftingTreeTransaction {
     private long accountingRevision;
     private long statusRevision;
     private long cachedAccountingRevision = -1L;
-    private long cachedAccountingPatternGeneration = Long.MIN_VALUE;
-    private long cachedAccountingRecipeGeneration = Long.MIN_VALUE;
     private AccountingSnapshot cachedAccountingSnapshot;
     private long lastStepsScanned;
     private long lastActiveStepsProcessed;
@@ -103,6 +107,7 @@ public final class PhysicalCraftingTreeTransaction {
 
     private PhysicalCraftingTreeTransaction(
             PreparedVectorBatch plan,
+            Map<String, PatternAccountingIdentity> patternIdentities,
             Map<AEKey, BigInteger> escrow,
             List<StepReceipt> steps,
             State state,
@@ -118,6 +123,10 @@ public final class PhysicalCraftingTreeTransaction {
                 Objects.requireNonNull(
                         plan,
                         "plan");
+        this.patternIdentities =
+                checkedPatternIdentities(
+                        plan,
+                        patternIdentities);
         this.escrow =
                 new ExactCraftingEscrow<>(
                         checkedCounts(
@@ -181,6 +190,12 @@ public final class PhysicalCraftingTreeTransaction {
 
     public static PhysicalCraftingTreeTransaction create(
             PreparedVectorBatch plan) {
+        return create(plan, Map.of());
+    }
+
+    public static PhysicalCraftingTreeTransaction create(
+            PreparedVectorBatch plan,
+            Map<String, PatternAccountingIdentity> patternIdentities) {
         Objects.requireNonNull(
                 plan,
                 "plan");
@@ -217,6 +232,7 @@ public final class PhysicalCraftingTreeTransaction {
         }
         return new PhysicalCraftingTreeTransaction(
                 plan,
+                patternIdentities,
                 Map.of(),
                 receipts,
                 State.VALIDATING,
@@ -239,9 +255,8 @@ public final class PhysicalCraftingTreeTransaction {
          * 旧「全Patternを証明して最終出力を直接生成」方式は意味が異なる。
          * schema移行で出力を推測すると複製し得るため、v4だけを復元する。
          */
-        if (owner.getInt(
-                            "schema")
-                        != SCHEMA_VERSION
+        int schema = owner.getInt("schema");
+        if ((schema != SCHEMA_VERSION && schema != LEGACY_SCHEMA_VERSION)
                 || !owner.contains(
                         "plan",
                         Tag.TAG_COMPOUND)) {
@@ -281,6 +296,9 @@ public final class PhysicalCraftingTreeTransaction {
         PhysicalCraftingTreeTransaction restored =
                 new PhysicalCraftingTreeTransaction(
                 plan,
+                schema == SCHEMA_VERSION
+                        ? decodePatternIdentities(owner, plan)
+                        : Map.of(),
                 decodeCounts(
                         owner,
                         "escrow"),
@@ -312,7 +330,14 @@ public final class PhysicalCraftingTreeTransaction {
                 new CompoundTag();
         owner.putInt(
                 "schema",
-                SCHEMA_VERSION);
+                hasCompletePatternIdentities()
+                        ? SCHEMA_VERSION
+                        : LEGACY_SCHEMA_VERSION);
+        if (hasCompletePatternIdentities()) {
+            owner.put(
+                    "patternIdentities",
+                    encodePatternIdentities(patternIdentities));
+        }
         owner.put(
                 "plan",
                 PreparedVectorBatchCodec.encode(
@@ -370,6 +395,19 @@ public final class PhysicalCraftingTreeTransaction {
                 "steps",
                 encodedSteps);
         return owner;
+    }
+
+    private boolean hasCompletePatternIdentities() {
+        if (patternIdentities.size() != plan.craftingSteps().size()) {
+            return false;
+        }
+        // 各物理Stepに対応する保存済みidentityが一件ずつ存在するか確認する。
+        for (ExactCraftingStep step : plan.craftingSteps()) {
+            if (!patternIdentities.containsKey(step.patternId())) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -459,6 +497,10 @@ public final class PhysicalCraftingTreeTransaction {
                         TickOutcome.quarantined(
                                 detail);
             };
+        } catch (PatternUnavailableException unavailable) {
+            // Provider unload中は所有権とReceiptを保持し、次tick以降へ再試行する。
+            detail = checkedDetail(unavailable.getMessage());
+            return TickOutcome.waiting(detail);
         } catch (RuntimeException | LinkageError failure) {
             quarantine(
                     "physical crafting-tree transaction failed: "
@@ -583,16 +625,30 @@ public final class PhysicalCraftingTreeTransaction {
             Level level) {
         Objects.requireNonNull(snapshot, "snapshot");
         Objects.requireNonNull(level, "level");
-        long patternGeneration = snapshot.graph().generation();
-        long recipeGeneration = snapshot.recipeGeneration();
+        // schema 2保存だけは、Providerが戻った時に一度だけ不変identityへ移行する。
+        ensurePatternIdentities(snapshot, level);
         if (cachedAccountingSnapshot != null
-                && cachedAccountingRevision == accountingRevision
-                && cachedAccountingPatternGeneration == patternGeneration
-                && cachedAccountingRecipeGeneration == recipeGeneration) {
+                && cachedAccountingRevision == accountingRevision) {
             return cachedAccountingSnapshot;
         }
         accountingSnapshotRebuilds++;
         ExactVectorDiagnostics.accountingSnapshotRebuilt();
+        AccountingSnapshot result = accountingSnapshotFromPersistedIdentities();
+        cachedAccountingSnapshot = result;
+        cachedAccountingRevision = accountingRevision;
+        return result;
+    }
+
+    /**
+     * live graphへ触れず、Transactionが所有する不変Pattern identityだけから会計を再構築する。
+     *
+     * <p>package-privateなのは、再起動・Provider unloadの回帰試験で同じ本番経路を使うため。</p>
+     */
+    AccountingSnapshot accountingSnapshotFromPersistedIdentities() {
+        if (!hasCompletePatternIdentities()) {
+            throw new PatternUnavailableException(
+                    "physical pattern accounting identity is not available yet");
+        }
         Map<String, BigInteger> plannedTasks = new LinkedHashMap<>();
         Map<String, BigInteger> dispatchedTasks = new LinkedHashMap<>();
         Map<AEKey, BigInteger> expectedOutputs = new LinkedHashMap<>();
@@ -600,31 +656,33 @@ public final class PhysicalCraftingTreeTransaction {
         Map<AEKey, BigInteger> creditedOutputs = new LinkedHashMap<>();
         // 固有Pattern数だけを一巡し、注文数量ぶんの会計要素は作らない。
         for (StepReceipt receipt : steps) {
-            ResolvedStep resolved = resolveStep(
-                    snapshot,
-                    level,
-                    receipt.index());
-            String patternId = resolved.step().patternId();
-            BigInteger executions = resolved.step().executions();
+            ExactCraftingStep step = plan.craftingSteps().get(receipt.index());
+            PatternAccountingIdentity identity = patternIdentities.get(step.patternId());
+            if (identity == null) {
+                throw new PatternUnavailableException(
+                        "saved accounting identity is not available for pattern "
+                                + step.patternId());
+            }
+            BigInteger executions = step.executions();
             mergePositive(
                     plannedTasks,
-                    patternId,
+                    identity.patternId(),
                     executions);
-            resolved.expectedOutputs().forEach((key, amount) ->
+            identity.expectedOutputs().forEach((key, amount) ->
                     mergePositive(expectedOutputs, key, amount));
             // Pattern Busが一度でも仕事を所有した段だけ、通常AE2のtask減算へ反映する。
             if (receipt.dispatched()) {
                 mergePositive(
                         dispatchedTasks,
-                        patternId,
+                        identity.patternId(),
                         executions);
                 // 通常AE2と同じく、Pattern投入時点でだけそのPatternの全出力をwaitingForへ加える。
-                resolved.expectedOutputs().forEach((key, amount) ->
+                identity.expectedOutputs().forEach((key, amount) ->
                         mergePositive(introducedOutputs, key, amount));
             }
             // 実出力をEscrowへ一度会計した段だけ、通常AE2のwaitingForから差し引く。
             if (receipt.outputCredited()) {
-                resolved.expectedOutputs().forEach((key, amount) ->
+                identity.expectedOutputs().forEach((key, amount) ->
                         mergePositive(creditedOutputs, key, amount));
             }
         }
@@ -632,18 +690,13 @@ public final class PhysicalCraftingTreeTransaction {
                 outputCursor == expectedFinalOutputs().size()
                         && (state == State.RETURNING_RESULTS
                                 || state == State.COMPLETE);
-        AccountingSnapshot result = new AccountingSnapshot(
-                plannedTasks,
-                dispatchedTasks,
+        return new AccountingSnapshot(
+                patternDefinitions(plannedTasks),
+                patternDefinitions(dispatchedTasks),
                 expectedOutputs,
                 introducedOutputs,
                 creditedOutputs,
                 finalOutputReturned);
-        cachedAccountingSnapshot = result;
-        cachedAccountingRevision = accountingRevision;
-        cachedAccountingPatternGeneration = patternGeneration;
-        cachedAccountingRecipeGeneration = recipeGeneration;
-        return result;
     }
 
     /** GUIへ渡す進捗は、実NeoECO Threadと完了済み物理段から求める。 */
@@ -685,13 +738,18 @@ public final class PhysicalCraftingTreeTransaction {
          * 境界素材へ触る前に、材料側から完成品側までの全式と依存順を
          * 仮想Escrowで一度だけ証明する。実行時は同じ式を再探索しない。
          */
-        if (!validateCompiledTree(
-                snapshot,
-                level)) {
-            quarantine(
-                    "compiled crafting-table tree does not conserve its exact inputs and outputs");
-            return TickOutcome.quarantined(
-                    detail);
+        try {
+            if (!validateCompiledTree(
+                    snapshot,
+                    level)) {
+                quarantine(
+                        "compiled crafting-table tree conflicts with its saved pattern identity");
+                return TickOutcome.quarantined(
+                        detail);
+            }
+        } catch (PatternUnavailableException unavailable) {
+            detail = unavailable.getMessage();
+            return TickOutcome.waiting(detail);
         }
         validatedPatternGeneration =
                 snapshot.graph()
@@ -739,16 +797,17 @@ public final class PhysicalCraftingTreeTransaction {
          * Providerまたはレシピ世代が変わった場合だけ、保存式を全体再検証する。
          * 不一致なら新しい式へ勝手に差し替えず、取消経路へ移る。
          */
-        if (!isValidatedFor(
-                        snapshot)
-                && !validateCompiledTree(
-                        snapshot,
-                        level)) {
-            state =
-                    State.CANCELLING_THREADS;
-            detail =
-                    "crafting-table recipe generation changed during execution";
-            return TickOutcome.changed();
+        if (!isValidatedFor(snapshot)) {
+            try {
+                if (!validateCompiledTree(snapshot, level)) {
+                    quarantine(
+                            "live crafting-table pattern conflicts with its saved physical identity");
+                    return TickOutcome.quarantined(detail);
+                }
+            } catch (PatternUnavailableException unavailable) {
+                detail = unavailable.getMessage();
+                return TickOutcome.waiting(detail);
+            }
         }
         validatedPatternGeneration =
                 snapshot.graph()
@@ -1792,6 +1851,8 @@ public final class PhysicalCraftingTreeTransaction {
                 markAccountingChanged();
             }
             return valid;
+        } catch (PatternUnavailableException unavailable) {
+            throw unavailable;
         } catch (RuntimeException | LinkageError invalid) {
             return false;
         }
@@ -1951,28 +2012,42 @@ public final class PhysicalCraftingTreeTransaction {
         IPatternDetails pattern =
                 snapshot.pattern(
                         step.patternId());
-        ExactPatternFormula formula =
-                pattern == null
-                        ? null
-                        : ExactPatternFormula.tryCreate(
-                                        pattern,
-                                        level,
-                                        step.selectedInputs())
-                                .orElse(
-                                        null);
-        // Pattern消失、加工Pattern化、保存済み候補の不一致を推測で補わない。
-        if (formula == null) {
-            throw new IllegalStateException(
-                    "saved crafting-table pattern is no longer deterministic");
+        if (pattern == null || pattern.getDefinition() == null) {
+            throw new PatternUnavailableException(
+                    "saved crafting-table pattern is temporarily unavailable: "
+                            + step.patternId());
         }
+        ExactPatternFormula formula =
+                ExactPatternFormula.tryCreate(
+                                pattern,
+                                level,
+                                step.selectedInputs())
+                        .orElse(null);
+        // 存在するPatternの式が変わった場合は、一時unloadではなく正本競合として扱う。
+        if (formula == null) {
+            throw new PatternIdentityConflictException(
+                    "saved crafting-table pattern is no longer deterministic: "
+                            + step.patternId());
+        }
+        Map<AEKey, BigInteger> inputTotals =
+                formula.exactInputTotals(
+                        step.executions());
+        Map<AEKey, BigInteger> expectedOutputs =
+                formula.exactExpectedOutputTotals(
+                        step.executions());
+        PatternAccountingIdentity current =
+                PatternAccountingIdentity.from(
+                        step,
+                        (AEItemKey) pattern.getDefinition(),
+                        inputTotals,
+                        expectedOutputs);
+        rememberOrVerifyPatternIdentity(current);
         return new ResolvedStep(
                 step,
                 pattern,
                 formula,
-                formula.exactInputTotals(
-                        step.executions()),
-                formula.exactExpectedOutputTotals(
-                        step.executions()));
+                inputTotals,
+                expectedOutputs);
     }
 
     /**
@@ -2401,6 +2476,180 @@ public final class PhysicalCraftingTreeTransaction {
         }
         return immutableOrderedMap(
                 result);
+    }
+
+    private static Map<String, PatternAccountingIdentity> checkedPatternIdentities(
+            PreparedVectorBatch plan,
+            Map<String, PatternAccountingIdentity> source) {
+        Objects.requireNonNull(source, "patternIdentities");
+        if (source.size() > MAXIMUM_EXACT_KEYS) {
+            throw new IllegalArgumentException("too many saved pattern identities");
+        }
+        Map<String, PatternAccountingIdentity> result = new LinkedHashMap<>();
+        // 保存IDとidentity本体を一対一で検証し、重複定義をその場で拒否する。
+        for (Map.Entry<String, PatternAccountingIdentity> entry : source.entrySet()) {
+            String id = Objects.requireNonNull(entry.getKey(), "pattern identity id");
+            PatternAccountingIdentity identity = Objects.requireNonNull(
+                    entry.getValue(),
+                    "pattern identity");
+            if (!id.equals(identity.patternId())
+                    || result.putIfAbsent(id, identity) != null) {
+                throw new IllegalArgumentException("invalid or duplicate pattern identity");
+            }
+        }
+        // 別計画のidentityを同じTransactionへ混入させない。
+        for (ExactCraftingStep step : plan.craftingSteps()) {
+            PatternAccountingIdentity identity = result.get(step.patternId());
+            if (identity != null && !identity.matchesStep(step)) {
+                throw new IllegalArgumentException(
+                        "saved pattern identity does not match its physical step");
+            }
+        }
+        return result;
+    }
+
+    private void ensurePatternIdentities(
+            Ae2CompiledCraftingGraphCache.Snapshot snapshot,
+            Level level) {
+        // schema 2で欠けているidentityだけをlive graphから一度復元する。
+        for (int index = 0; index < plan.craftingSteps().size(); index++) {
+            ExactCraftingStep step = plan.craftingSteps().get(index);
+            if (!patternIdentities.containsKey(step.patternId())) {
+                resolveStepFresh(snapshot, level, index);
+            }
+        }
+    }
+
+    /** 同じPattern IDの正本を初回だけ保存し、以後は完全一致だけを受理する。 */
+    void rememberOrVerifyPatternIdentity(PatternAccountingIdentity current) {
+        Objects.requireNonNull(current, "current");
+        ExactCraftingStep matchingStep = null;
+        // identityが現在の物理計画に属するPatternかを確認する。
+        for (ExactCraftingStep step : plan.craftingSteps()) {
+            if (step.patternId().equals(current.patternId())) {
+                matchingStep = step;
+                break;
+            }
+        }
+        if (matchingStep == null || !current.matchesStep(matchingStep)) {
+            throw new PatternIdentityConflictException(
+                    "live crafting-table pattern does not belong to this physical plan");
+        }
+        PatternAccountingIdentity saved = patternIdentities.get(current.patternId());
+        if (saved == null) {
+            patternIdentities.put(current.patternId(), current);
+            markAccountingChanged();
+            return;
+        }
+        if (!saved.equals(current)) {
+            throw new PatternIdentityConflictException(
+                    "live crafting-table pattern identity changed: " + current.patternId());
+        }
+    }
+
+    private Map<AEItemKey, BigInteger> patternDefinitions(
+            Map<String, BigInteger> patternExecutions) {
+        Map<AEItemKey, BigInteger> definitions = new LinkedHashMap<>();
+        // 安定IDをTransaction保存済みのencoded pattern itemへ一対一で変換する。
+        for (Map.Entry<String, BigInteger> entry : patternExecutions.entrySet()) {
+            PatternAccountingIdentity identity = patternIdentities.get(entry.getKey());
+            if (identity == null) {
+                throw new PatternUnavailableException(
+                        "saved accounting identity is not available for pattern " + entry.getKey());
+            }
+            if (definitions.putIfAbsent(identity.definition(), entry.getValue()) != null) {
+                throw new PatternIdentityConflictException(
+                        "exact accounting contains duplicate saved pattern definitions");
+            }
+        }
+        return Map.copyOf(definitions);
+    }
+
+    public static Map<String, PatternAccountingIdentity> capturePatternAccounting(
+            PreparedVectorBatch plan,
+            Ae2CompiledCraftingGraphCache.Snapshot snapshot,
+            Level level) {
+        Objects.requireNonNull(plan, "plan");
+        Objects.requireNonNull(snapshot, "snapshot");
+        Objects.requireNonNull(level, "level");
+        Map<String, PatternAccountingIdentity> result = new LinkedHashMap<>();
+        // 物理所有開始前に全Patternの定義と正確な式を固定する。
+        for (ExactCraftingStep step : plan.craftingSteps()) {
+            IPatternDetails pattern = snapshot.pattern(step.patternId());
+            if (pattern == null || pattern.getDefinition() == null) {
+                throw new PatternUnavailableException(
+                        "physical crafting pattern is temporarily unavailable: " + step.patternId());
+            }
+            ExactPatternFormula formula = ExactPatternFormula.tryCreate(
+                            pattern,
+                            level,
+                            step.selectedInputs())
+                    .orElseThrow(() -> new PatternIdentityConflictException(
+                            "physical crafting pattern is not deterministic: " + step.patternId()));
+            PatternAccountingIdentity identity = PatternAccountingIdentity.from(
+                    step,
+                    (AEItemKey) pattern.getDefinition(),
+                    formula.exactInputTotals(step.executions()),
+                    formula.exactExpectedOutputTotals(step.executions()));
+            if (result.putIfAbsent(step.patternId(), identity) != null) {
+                throw new IllegalArgumentException("duplicate physical pattern identity");
+            }
+        }
+        return Map.copyOf(result);
+    }
+
+    private static ListTag encodePatternIdentities(
+            Map<String, PatternAccountingIdentity> identities) {
+        ListTag result = new ListTag();
+        // 固有Pattern一件につき一件の正本を保存し、注文数量ぶんには展開しない。
+        for (PatternAccountingIdentity identity : identities.values()) {
+            CompoundTag entry = new CompoundTag();
+            entry.putString("id", identity.patternId());
+            entry.put("definition", identity.definition().toTag(ACORegistryAccess.require()));
+            entry.put("inputs", encodeCounts(identity.inputTotals()));
+            entry.put("outputs", encodeCounts(identity.expectedOutputs()));
+            result.add(entry);
+        }
+        return result;
+    }
+
+    private static Map<String, PatternAccountingIdentity> decodePatternIdentities(
+            CompoundTag owner,
+            PreparedVectorBatch plan) {
+        Tag raw = owner.get("patternIdentities");
+        if (!(raw instanceof ListTag list)
+                || (!list.isEmpty() && list.getElementType() != Tag.TAG_COMPOUND)
+                || list.size() != plan.craftingSteps().size()) {
+            throw new IllegalArgumentException("missing or malformed physical pattern identities");
+        }
+        Map<String, PatternAccountingIdentity> result = new LinkedHashMap<>();
+        // NBT順を維持して全identityを復元し、未知itemと重複IDを拒否する。
+        for (int index = 0; index < list.size(); index++) {
+            CompoundTag entry = list.getCompound(index);
+            AEItemKey definition = AEItemKey.fromTag(
+                    ACORegistryAccess.require(),
+                    entry.getCompound("definition"));
+            if (definition == null) {
+                throw new IllegalArgumentException(
+                        "saved pattern identity has an unknown definition");
+            }
+            PatternAccountingIdentity identity = new PatternAccountingIdentity(
+                    entry.getString("id"),
+                    definition,
+                    decodeCounts(entry, "inputs"),
+                    decodeCounts(entry, "outputs"));
+            if (result.putIfAbsent(identity.patternId(), identity) != null) {
+                throw new IllegalArgumentException("duplicate saved pattern identity");
+            }
+        }
+        // 保存identity集合が物理計画のPattern集合と完全一致するか確認する。
+        for (ExactCraftingStep step : plan.craftingSteps()) {
+            if (!result.containsKey(step.patternId())) {
+                throw new IllegalArgumentException(
+                        "saved pattern identities do not match the physical plan");
+            }
+        }
+        return result;
     }
 
     private static <K> Map<K, BigInteger> immutableOrderedMap(
@@ -3309,6 +3558,51 @@ public final class PhysicalCraftingTreeTransaction {
         }
     }
 
+    public record PatternAccountingIdentity(
+            String patternId,
+            AEItemKey definition,
+            Map<AEKey, BigInteger> inputTotals,
+            Map<AEKey, BigInteger> expectedOutputs) {
+        public PatternAccountingIdentity {
+            patternId = Objects.requireNonNull(patternId, "patternId").trim();
+            definition = Objects.requireNonNull(definition, "definition");
+            if (patternId.isEmpty()) {
+                throw new IllegalArgumentException("pattern identity id is blank");
+            }
+            inputTotals = checkedCounts(inputTotals, "pattern identity inputs", false);
+            expectedOutputs = checkedCounts(expectedOutputs, "pattern identity outputs", false);
+        }
+
+        private static PatternAccountingIdentity from(
+                ExactCraftingStep step,
+                AEItemKey definition,
+                Map<AEKey, BigInteger> inputTotals,
+                Map<AEKey, BigInteger> expectedOutputs) {
+            return new PatternAccountingIdentity(
+                    step.patternId(),
+                    definition,
+                    inputTotals,
+                    expectedOutputs);
+        }
+
+        private boolean matchesStep(ExactCraftingStep step) {
+            return patternId.equals(step.patternId());
+        }
+    }
+
+    /** 一時的なProvider unloadを正本競合と区別し、所有権を保持したまま待機させる。 */
+    public static final class PatternUnavailableException extends RuntimeException {
+        public PatternUnavailableException(String message) {
+            super(message);
+        }
+    }
+
+    private static final class PatternIdentityConflictException extends RuntimeException {
+        private PatternIdentityConflictException(String message) {
+            super(message);
+        }
+    }
+
     private record ResolvedStep(
             ExactCraftingStep step,
             IPatternDetails pattern,
@@ -3438,20 +3732,20 @@ public final class PhysicalCraftingTreeTransaction {
     }
 
     public record AccountingSnapshot(
-            Map<String, BigInteger> plannedPatternExecutions,
-            Map<String, BigInteger> dispatchedPatternExecutions,
+            Map<AEItemKey, BigInteger> plannedPatternDefinitions,
+            Map<AEItemKey, BigInteger> dispatchedPatternDefinitions,
             Map<AEKey, BigInteger> expectedOutputs,
             Map<AEKey, BigInteger> introducedOutputs,
             Map<AEKey, BigInteger> creditedOutputs,
             boolean finalOutputReturned) {
         public AccountingSnapshot {
-            plannedPatternExecutions = checkedCounts(
-                    plannedPatternExecutions,
-                    "plannedPatternExecutions",
+            plannedPatternDefinitions = checkedCounts(
+                    plannedPatternDefinitions,
+                    "plannedPatternDefinitions",
                     false);
-            dispatchedPatternExecutions = checkedCounts(
-                    dispatchedPatternExecutions,
-                    "dispatchedPatternExecutions",
+            dispatchedPatternDefinitions = checkedCounts(
+                    dispatchedPatternDefinitions,
+                    "dispatchedPatternDefinitions",
                     true);
             expectedOutputs = checkedCounts(
                     expectedOutputs,
@@ -3467,8 +3761,8 @@ public final class PhysicalCraftingTreeTransaction {
                     true);
             // 配送済みPatternと受領済み出力は、それぞれ計画総量を超えてはならない。
             if (!containsAll(
-                            plannedPatternExecutions,
-                            dispatchedPatternExecutions)
+                            plannedPatternDefinitions,
+                            dispatchedPatternDefinitions)
                     || !containsAll(
                             expectedOutputs,
                             introducedOutputs)

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/AqeBigCraftingExecutionManager.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/AqeBigCraftingExecutionManager.java
@@ -510,13 +510,16 @@ public final class AqeBigCraftingExecutionManager {
                         }
                         transaction =
                                 PhysicalCraftingTreeTransaction.create(
-                                        plan);
+                                        plan,
+                                        PhysicalCraftingTreeTransaction.capturePatternAccounting(
+                                                plan,
+                                                graphSnapshot,
+                                                cluster.getLevel()));
                         validateExactCpuPlan(
                                 context,
                                 transaction.accountingSnapshot(
                                         graphSnapshot,
-                                        cluster.getLevel()),
-                                graphSnapshot);
+                                        cluster.getLevel()));
                         state.beginPhysicalExecution(
                                 transaction.save());
                         exactCpuTrees.put(
@@ -529,6 +532,9 @@ public final class AqeBigCraftingExecutionManager {
                                 com.syaru.ae2craftingoptimizer.api.vector
                                         .VectorResourceMode.NETWORK_STORAGE);
                     }
+                } catch (PhysicalCraftingTreeTransaction.PatternUnavailableException deferred) {
+                    // 所有開始前にProviderが消えた場合はJobを取消さず、再出現まで待機する。
+                    continue;
                 } catch (RuntimeException | LinkageError preparationFailure) {
                     /*
                      * 物理Transaction開始前の再構築不一致は入力へ触れていない。
@@ -606,11 +612,13 @@ public final class AqeBigCraftingExecutionManager {
                                         cluster.getLevel());
                         reconcileExactCpuAccounting(
                                 context,
-                                accounting,
-                                graphSnapshot);
+                                accounting);
                         state.updatePhysicalExecution(
                                 transaction.save());
                         context.cpu().markDirty();
+                    } catch (PhysicalCraftingTreeTransaction.PatternUnavailableException deferred) {
+                        // schema 2の旧ReceiptはProvider復帰時に不変identityへ安全に移行する。
+                        continue;
                     } catch (RuntimeException | LinkageError accountingFailure) {
                         quarantineExactCpu(
                                 context,
@@ -788,12 +796,9 @@ public final class AqeBigCraftingExecutionManager {
 
         private void validateExactCpuPlan(
                 ExactCpuContext context,
-                PhysicalCraftingTreeTransaction.AccountingSnapshot accounting,
-                Ae2CompiledCraftingGraphCache.Snapshot graphSnapshot) {
+                PhysicalCraftingTreeTransaction.AccountingSnapshot accounting) {
             Map<AEItemKey, BigInteger> plannedTasks =
-                    patternDefinitions(
-                            accounting.plannedPatternExecutions(),
-                            graphSnapshot);
+                    accounting.plannedPatternDefinitions();
             /*
              * 再構築した物理式は、提出時に実Jobへ載せた全taskと完全一致させる。
              * 確定作業台経路はEmitterを許さないため、初期待機出力も存在してはならない。
@@ -810,16 +815,12 @@ public final class AqeBigCraftingExecutionManager {
 
         private void reconcileExactCpuAccounting(
                 ExactCpuContext context,
-                PhysicalCraftingTreeTransaction.AccountingSnapshot accounting,
-                Ae2CompiledCraftingGraphCache.Snapshot graphSnapshot) {
+                PhysicalCraftingTreeTransaction.AccountingSnapshot accounting) {
             validateExactCpuPlan(
                     context,
-                    accounting,
-                    graphSnapshot);
+                    accounting);
             Map<AEItemKey, BigInteger> dispatchedTasks =
-                    patternDefinitions(
-                            accounting.dispatchedPatternExecutions(),
-                            graphSnapshot);
+                    accounting.dispatchedPatternDefinitions();
             BigInteger remainingOutput =
                     accounting.finalOutputReturned()
                             ? BigInteger.ZERO
@@ -840,36 +841,6 @@ public final class AqeBigCraftingExecutionManager {
                                     context.state().requestedKey(),
                                     ExactCraftingJobLedger.saturatedLong(
                                             exactRemaining)));
-        }
-
-        private Map<AEItemKey, BigInteger> patternDefinitions(
-                Map<String, BigInteger> patternExecutions,
-                Ae2CompiledCraftingGraphCache.Snapshot graphSnapshot) {
-            Map<AEItemKey, BigInteger> definitions =
-                    new HashMap<>();
-            // 安定Pattern IDを現在検証済みSnapshotのEncoded Pattern itemへ一対一で戻す。
-            for (var entry : patternExecutions.entrySet()) {
-                IPatternDetails pattern =
-                        graphSnapshot.pattern(
-                                entry.getKey());
-                if (pattern == null
-                        || pattern.getDefinition() == null) {
-                    throw new IllegalArgumentException(
-                            "exact accounting references an unknown pattern");
-                }
-                /*
-                 * Receiptの安定IDと実TaskProgressを一対一で照合する。
-                 * 同じ定義を複数IDから合算すると、どの実Taskが進んだか証明できない。
-                 */
-                if (definitions.putIfAbsent(
-                                pattern.getDefinition(),
-                                entry.getValue())
-                        != null) {
-                    throw new IllegalArgumentException(
-                            "exact accounting contains duplicate pattern definitions");
-                }
-            }
-            return Map.copyOf(definitions);
         }
 
         private boolean isExactStateStale(
@@ -1181,7 +1152,11 @@ public final class AqeBigCraftingExecutionManager {
                 try {
                     PhysicalCraftingTreeTransaction transaction =
                             PhysicalCraftingTreeTransaction.create(
-                                    plan);
+                                    plan,
+                                    PhysicalCraftingTreeTransaction.capturePatternAccounting(
+                                            plan,
+                                            graphSnapshot,
+                                            cluster.getLevel()));
                     host.prepareVector(
                             candidate.jobId(),
                             plan.transactionId(),

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/PhysicalPatternAccountingSourceContractTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/PhysicalPatternAccountingSourceContractTest.java
@@ -1,0 +1,101 @@
+package com.syaru.ae2craftingoptimizer.engine.craftingtable;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/** live graphを履歴会計へ再導入する回帰を、headless JUnitで検出する。 */
+class PhysicalPatternAccountingSourceContractTest {
+    private static final Path TRANSACTION = Path.of(
+            "src", "main", "java", "com", "syaru", "ae2craftingoptimizer",
+            "engine", "craftingtable", "PhysicalCraftingTreeTransaction.java");
+    private static final Path MANAGER = Path.of(
+            "src", "main", "java", "com", "syaru", "ae2craftingoptimizer",
+            "integration", "AqeBigCraftingExecutionManager.java");
+
+    @Test
+    void persistsACompleteCanonicalIdentityWithLegacyMigration() {
+        String source = read(TRANSACTION);
+
+        assertTrue(source.contains("private static final int SCHEMA_VERSION = 3;"));
+        assertTrue(source.contains("private static final int LEGACY_SCHEMA_VERSION = 2;"));
+        assertTrue(source.contains("encodePatternIdentities(patternIdentities)"));
+        assertTrue(source.contains("decodePatternIdentities(owner, plan)"));
+        assertTrue(source.contains("ensurePatternIdentities(snapshot, level)"));
+        assertTrue(source.contains("PatternUnavailableException"));
+        assertTrue(source.contains("PatternIdentityConflictException"));
+    }
+
+    @Test
+    void buildsHistoricalAccountingOnlyFromPersistedIdentities() {
+        String source = read(TRANSACTION);
+        String method = between(
+                source,
+                "AccountingSnapshot accountingSnapshotFromPersistedIdentities()",
+                "/** GUIへ渡す進捗");
+
+        assertTrue(method.contains("patternIdentities.get(step.patternId())"));
+        assertTrue(method.contains("patternDefinitions(plannedTasks)"));
+        assertFalse(method.contains("snapshot.pattern("));
+        assertFalse(method.contains("resolveStep("));
+        assertFalse(method.contains("graph().generation()"));
+    }
+
+    @Test
+    void capturesIdentityBeforeOwnershipAndNeverReResolvesTasksFromTheLiveGraph() {
+        String source = read(MANAGER);
+
+        assertTrue(count(source, "capturePatternAccounting(") >= 2L);
+        assertTrue(source.contains("accounting.plannedPatternDefinitions()"));
+        assertTrue(source.contains("accounting.dispatchedPatternDefinitions()"));
+        assertFalse(source.contains("exact accounting references an unknown pattern"));
+    }
+
+    @Test
+    void temporaryUnloadWaitsWhileAProvenReplacementConflicts() {
+        String source = read(TRANSACTION);
+        int retryableCatch = source.indexOf(
+                "catch (PatternUnavailableException unavailable)");
+        int quarantineCatch = source.indexOf(
+                "catch (RuntimeException | LinkageError failure)");
+
+        assertTrue(retryableCatch >= 0);
+        assertTrue(quarantineCatch > retryableCatch);
+        assertTrue(source.contains("live crafting-table pattern identity changed:"));
+        assertTrue(source.contains("return TickOutcome.waiting(detail);"));
+    }
+
+    private static String between(String source, String start, String end) {
+        int startIndex = source.indexOf(start);
+        int endIndex = source.indexOf(end, startIndex);
+        // 試験境界が消えた場合は、空文字で誤って通さず明示的に失敗させる。
+        if (startIndex < 0 || endIndex < 0) {
+            throw new IllegalArgumentException("source contract boundary is missing");
+        }
+        return source.substring(startIndex, endIndex);
+    }
+
+    private static long count(String source, String token) {
+        long matches = 0L;
+        int cursor = 0;
+        // 各出現位置を一度だけ数え、同じ開始位置を再評価しない。
+        while ((cursor = source.indexOf(token, cursor)) >= 0) {
+            matches++;
+            cursor += token.length();
+        }
+        return matches;
+    }
+
+    private static String read(Path path) {
+        try {
+            return Files.readString(path);
+        } catch (IOException exception) {
+            throw new UncheckedIOException(path.toString(), exception);
+        }
+    }
+}


### PR DESCRIPTION
## 目的

実行中のExact CPUが、Pattern Providerの一時アンロードや再起動直後のgraph再構築によって誤って隔離される問題を修正します。

Refs #29

## 原因

1.21.1側は保存schema 2のまま、既に物理リソースを所有しているTransactionの履歴会計を現在のlive Pattern graphから再解決していました。そのため、Patternが一時的に見えないだけでもCPUとTransactionが隔離されていました。

## 変更内容

- 保存schemaを3へ更新し、schema 2の読み込みを維持
- 物理所有開始前に、Pattern ID・encoded definition・正確な入力合計・期待出力合計を不変identityとして保存
- 過去のplanned/dispatched会計を保存済みidentityだけから再構築
- live graphは新規dispatch前の再検証だけに限定
- Provider不在は所有権とReceiptを保持した待機・再試行として処理
- 同じPattern IDで定義または入出力式が変化した場合だけ競合として隔離
- schema 2保存はlive Patternが戻った時にschema 3 identityへ安全に遅延移行
- 回帰を固定するsource-contract JUnitと手動/GameTest手順を追加

## 検証

- `gradlew clean build --no-daemon`: 成功
- JUnit: 352件、失敗0、エラー0、スキップ0
- `git diff --check`: 成功

Minecraft起動試験とGameTest実行は今回の作業範囲外です。
