### PR TITLE
Release ACO 1.5.16 for Forge 1.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.16] - 2026-08-13
+
+### Added
+
+- Added adapter-provided Native Batch minimum execution sizing so a safe
+  native batch is not starved by an undersized execution window.
+- Attached exact BigInteger capacity sidecars to plans created through AE2's
+  live crafting-service path, including exact missing-material simulations.
+
 ### Fixed
 
 - Synchronized Advanced AE CPU reservations before exact BigInteger promotion.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.15
+mod_version=1.5.16
 minecraft_version=1.20.1
 mod_group=com.syaru.ae2craftingoptimizer


### PR DESCRIPTION
## 目的

Forge 1.20.1版をACO 1.5.16として公開するための版上げです。

Refs #71

## 変更内容

- `mod_version`を1.5.16へ更新
- 1.5.15公開後にマージされた変更を1.5.16 Changelogへ確定
- Native Batch最小実行数、BigInteger sidecar、Advanced AE予約同期、InsaneAE共存、永続Pattern identity修正を収録

## 検証

- `gradlew clean build --no-daemon`: 成功
- JUnit: 321件、失敗0、エラー0、スキップ0
- 生成物: `aco1.5.16_1.20.1.jar`
- `git diff --check`: 成功

Minecraft起動試験とGameTest実行は今回の作業範囲外です。
