### PR TITLE
Release ACO 1.5.16 for NeoForge 1.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.16] - 2026-08-13
+
+### Added
+
+- Added adapter-provided Native Batch minimum execution sizing so a safe
+  native batch is not starved by an undersized execution window.
+- Attached exact BigInteger capacity sidecars to plans created through AE2's
+  live crafting-service path, including exact missing-material simulations.
+
 ### Fixed
 
 - Persisted each physical Exact CPU Pattern's encoded definition and exact

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ minecraft_version=1.21.1
 neo_version=21.1.247
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.15
+mod_version=1.5.16
 mod_group=com.syaru.ae2craftingoptimizer


### PR DESCRIPTION
## 目的

NeoForge 1.21.1版をACO 1.5.16として公開するための版上げです。

Refs #71

## 変更内容

- `mod_version`を1.5.16へ更新
- 1.5.15公開後にマージされた変更を1.5.16 Changelogへ確定
- Native Batch最小実行数、BigInteger sidecar、永続Pattern identity修正を収録

## 検証

- `gradlew clean build --no-daemon`: 成功
- JUnit: 352件、失敗0、エラー0、スキップ0
- 生成物: `aco1.5.16_1.21.1.jar`
- `git diff --check`: 成功

Minecraft起動試験とGameTest実行は今回の作業範囲外です。
