### PR TITLE
NeoForge 1.21.1: ACO 1.5.17リリース番号へ更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.17] - 2026-08-14
+
+### Compatibility
+
+- Aligned the NeoForge 1.21.1 artifact version with the Forge 1.20.1 hotfix
+  release. Neo ECO 21.1.x compatibility remains unchanged.
+
 ## [1.5.16] - 2026-08-13
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ minecraft_version=1.21.1
 neo_version=21.1.247
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.16
+mod_version=1.5.17
 mod_group=com.syaru.ae2craftingoptimizer


### PR DESCRIPTION
## 概要

Forge 1.20.1向けhotfixと同じACO 1.5.17として配布できるよう、NeoForge 1.21.1成果物のリリース番号を揃えます。

Closes #77

## 変更内容

- `mod_version`を1.5.17へ更新
- Changelogへ版合わせであることを記録

## 非変更範囲

- Neo ECO 21.1.xのMixin、依存範囲、実行処理は変更しません。
- AE2クラフト計算、BigInteger会計、在庫、レシピ結果は変更しません。

## 検証

- `gradlew clean build --no-daemon`: 成功
- JUnit: 352件、失敗0、エラー0、スキップ0
- 生成物: `aco1.5.17_1.21.1.jar`
- SHA-256: `FBC730813F18A200711672F5F89C0F4A0138F3452531CB9C741E54A23DE9B586`
