### PR TITLE
Fix exact plans beyond one-root long boundary (NeoForge 1.21.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.18] - 2026-08-14
+
+### Fixed
+
+- Kept exact BigInteger plans available when one requested root item requires
+  more than `Long.MAX_VALUE` lower-pattern executions or boundary inputs.
+- Separated exact plan publication from the legacy root-count execution window,
+  allowing BigInteger CPU add-ons to receive the unchanged exact Pattern ledger.
+- Prevented ACO's legacy root-window command from submitting an exact-only plan
+  to a checked-long child job.
+- Added regression coverage for the 21-stage 8x compression boundary and the
+  public BigInteger plan sidecar used by optional CPU add-ons.
+
 ## [1.5.17] - 2026-08-14
 
 ### Compatibility

--- a/docs/RELEASE_NOTES_1.5.18.md
+++ b/docs/RELEASE_NOTES_1.5.18.md
@@ -1,0 +1,23 @@
+# AE2 Crafting Optimizer 1.5.18
+
+## English
+
+- Fixes exact BigInteger planning when one root item expands to more than
+  `Long.MAX_VALUE` lower-pattern executions or boundary inputs.
+- Keeps the exact Pattern counts, inventory usage, missing amounts, and CPU byte
+  total available through ACO's public BigInteger plan API.
+- Separates exact-plan publication from the legacy root-count execution window.
+- Preserves existing AE2 calculations and root-window execution below the
+  signed-long boundary.
+- Adds regression tests for a 21-stage 8x compression tree where one final item
+  requires `2^63` base inputs.
+
+## 日本語
+
+- 完成品1個から展開される下位Pattern実行数または境界入力数が
+  `Long.MAX_VALUE`を超える場合も、正確なBigInteger計画を返すよう修正しました。
+- 正確なPattern回数、在庫使用量、不足量、CPU容量を、ACOの公開BigInteger計画APIから
+  そのまま取得できます。
+- 正確な計画の公開可否と、旧root個数単位の実行Window可否を分離しました。
+- signed long境界未満のAE2計算およびroot-window実行は従来どおり維持します。
+- 完成品1個に`2^63`個の最下層素材が必要な、8倍圧縮21段の回帰試験を追加しました。

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ minecraft_version=1.21.1
 neo_version=21.1.247
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.17
+mod_version=1.5.18
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
@@ -569,7 +569,7 @@ public final class Ae2AuthoritativeCraftingPlanner {
                         capture.patternGeneration(),
                         capture.recipeGeneration(),
                         ACOConfig.getBigIntegerMaximumBits());
-        // 一回分すらAE2互換Windowへ写せない計画は提出可能Planとして返さない。
+        // 防御的にnullを扱う。現在のFactoryはExact専用計画も保持するため通常はnullにならない。
         if (prepared == null) {
             return null;
         }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2BigCraftingPlanFactory.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2BigCraftingPlanFactory.java
@@ -146,10 +146,9 @@ public final class Ae2BigCraftingPlanFactory {
     }
 
     /**
-     * 既に厳格検証済みのRoot Programから、再起動後も同じ安全幅を使うBig親Jobを作る。
-     * 呼出側は返却後にProvider・recipe・在庫世代を再検証する。
+     * 既に厳格検証済みのRoot Programから、正確な計画メタデータを作る。
+     * long子Jobへ分割できる場合だけ、再起動後も同じ安全幅を使う親Jobを添える。
      */
-    @Nullable
     static PreparedBigRootPlan prepareCompiledRoot(
             AEKey output,
             BigInteger requestedAmount,
@@ -163,49 +162,45 @@ public final class Ae2BigCraftingPlanFactory {
         Objects.requireNonNull(plan, "plan");
         Objects.requireNonNull(bytes, "bytes");
         Objects.requireNonNull(program, "program");
-        long safeWindow = maximumSafeRootWindow(
+        RootWindowDecision rootWindow = rootWindowDecision(
                 program,
                 requestedAmount,
                 ACOConfig.getBigIntegerExecutionWindow(),
                 maximumBits);
-        boolean exactVectorRequired = safeWindow <= 0L;
-        /*
-         * A single finished root can itself require counters above long. AQE's exact job owns the full
-         * BigInteger vector and does not need an AE2 child window, so retain that plan when Exact Vector
-         * execution is enabled. The placeholder limit is never scheduled by BigCraftingCpuLedger.
-         */
-        if (exactVectorRequired && !ACOConfig.enableAqeBigIntegerVectorParents()) {
-            return null;
+        String planningEpoch = PlanningRuntimeEpoch.current();
+        String fingerprint = programFingerprint(program);
+        BigCraftingJob<AEKey> rootWindowJob = null;
+        // ルート個数で安全に分割できる計画だけ、旧checked-long子Job用の親Jobを用意する。
+        if (rootWindow.mode() == ExecutionMode.ROOT_WINDOWS) {
+            rootWindowJob = BigCraftingJob.rootWindowed(
+                    UUID.randomUUID(),
+                    output,
+                    requestedAmount,
+                    bytes,
+                    patternGeneration,
+                    recipeGeneration,
+                    rootWindow.maximumRootExecutions(),
+                    planningEpoch,
+                    fingerprint);
         }
-        if (exactVectorRequired) {
-            safeWindow = 1L;
-        }
-        BigCraftingJob<AEKey> job = BigCraftingJob.rootWindowed(
-                UUID.randomUUID(),
-                output,
-                requestedAmount,
-                bytes,
-                patternGeneration,
-                recipeGeneration,
-                safeWindow,
-                PlanningRuntimeEpoch.current(),
-                programFingerprint(program),
-                exactVectorRequired);
         return new PreparedBigRootPlan(
-                job,
+                rootWindowJob,
                 plan,
                 bytes,
                 patternGeneration,
                 recipeGeneration,
-                safeWindow);
+                rootWindow.mode(),
+                rootWindow.maximumRootExecutions(),
+                planningEpoch,
+                fingerprint);
     }
 
     /**
      * 子AE2計画の各カウンタがsigned longへ収まる最大完成品数を二分探索する。
      * CPU byte総量だけのlong超過はBigCapacityCraftingPlanで扱えるため、ここでは除外しない。
      */
-    private static long maximumSafeRootWindow(
-            CompiledRootProgram<AEKey> program,
+    static <K> RootWindowDecision rootWindowDecision(
+            CompiledRootProgram<K> program,
             BigInteger requestedAmount,
             long configuredMaximum,
             int maximumBits) {
@@ -214,17 +209,20 @@ public final class Ae2BigCraftingPlanFactory {
                 .longValueExact();
         // 呼出元は正数注文だけを渡すが、境界を単独利用しても0幅を作らない。
         if (upper <= 0L) {
-            return 0L;
+            return new RootWindowDecision(ExecutionMode.EXACT_PATTERN_EXECUTOR, 0L);
         }
-        CompiledRootProgram.BigInventorySnapshot<AEKey> emptyInventory =
+        CompiledRootProgram.BigInventorySnapshot<K> emptyInventory =
                 program.captureBigInventory(ignored -> BigInteger.ZERO, maximumBits);
         // 設定上限のまま全個別カウンタがlongへ収まる場合は探索を省略する。
         if (fitsLongChild(program, emptyInventory, upper, maximumBits)) {
-            return upper;
+            return new RootWindowDecision(ExecutionMode.ROOT_WINDOWS, upper);
         }
-        // 一回分が収まらない場合、標準AE2 APIへ安全に分割できる正のWindowは存在しない。
+        /*
+         * 一回分が収まらない場合もBigInteger計画自体は正確である。
+         * rootを0件へ丸めず、Pattern単位のExact executorが必要な計画として残す。
+         */
         if (!fitsLongChild(program, emptyInventory, 1L, maximumBits)) {
-            return 0L;
+            return new RootWindowDecision(ExecutionMode.EXACT_PATTERN_EXECUTOR, 0L);
         }
 
         long low = 1L;
@@ -239,7 +237,7 @@ public final class Ae2BigCraftingPlanFactory {
                 high = middle - 1L;
             }
         }
-        return low;
+        return new RootWindowDecision(ExecutionMode.ROOT_WINDOWS, low);
     }
 
     /**
@@ -318,13 +316,13 @@ public final class Ae2BigCraftingPlanFactory {
                         + String.join("\n", nodes));
     }
 
-    private static boolean fitsLongChild(
-            CompiledRootProgram<AEKey> program,
-            CompiledRootProgram.BigInventorySnapshot<AEKey> emptyInventory,
+    private static <K> boolean fitsLongChild(
+            CompiledRootProgram<K> program,
+            CompiledRootProgram.BigInventorySnapshot<K> emptyInventory,
             long requestedAmount,
             int maximumBits) {
         try {
-            BigCraftingPlan<AEKey> child = program.planBig(
+            BigCraftingPlan<K> child = program.planBig(
                     BigInteger.valueOf(requestedAmount),
                     emptyInventory,
                     PlanningGuard.none(),
@@ -350,22 +348,64 @@ public final class Ae2BigCraftingPlanFactory {
         return true;
     }
 
+    public enum ExecutionMode {
+        /** 同じ完成品の正数個を、AE2標準long子Jobへ安全に分割できる。 */
+        ROOT_WINDOWS,
+        /** 完成品一個の内部がlongを超えるため、正確なPattern単位executorが必要。 */
+        EXACT_PATTERN_EXECUTOR
+    }
+
+    static record RootWindowDecision(
+            ExecutionMode mode,
+            long maximumRootExecutions) {
+        RootWindowDecision {
+            Objects.requireNonNull(mode, "mode");
+            // root-window方式だけが正のWindowを持ち、Exact方式は0を明示する。
+            if ((mode == ExecutionMode.ROOT_WINDOWS && maximumRootExecutions <= 0L)
+                    || (mode == ExecutionMode.EXACT_PATTERN_EXECUTOR
+                            && maximumRootExecutions != 0L)) {
+                throw new IllegalArgumentException("invalid BigInteger root-window decision");
+            }
+        }
+    }
+
     public record PreparedBigRootPlan(
-            BigCraftingJob<AEKey> job,
+            @Nullable BigCraftingJob<AEKey> rootWindowJob,
             BigCraftingPlan<AEKey> symbolicPlan,
             BigInteger reservedBytes,
             long patternGeneration,
             long recipeGeneration,
-            long maximumExecutionsPerWindow) {
+            ExecutionMode executionMode,
+            long maximumRootExecutionsPerWindow,
+            String planningEpoch,
+            String programFingerprint) {
         public PreparedBigRootPlan {
-            Objects.requireNonNull(job, "job");
             Objects.requireNonNull(symbolicPlan, "symbolicPlan");
             Objects.requireNonNull(reservedBytes, "reservedBytes");
-            // 保存Jobと計画メタデータのWindow上限が食い違う結果を外へ出さない。
-            if (maximumExecutionsPerWindow <= 0L
-                    || maximumExecutionsPerWindow != job.maximumExecutionsPerWindow()) {
-                throw new IllegalArgumentException("invalid prepared BigInteger execution-window limit");
+            Objects.requireNonNull(executionMode, "executionMode");
+            planningEpoch = Objects.requireNonNull(planningEpoch, "planningEpoch");
+            programFingerprint = Objects.requireNonNull(programFingerprint, "programFingerprint");
+            // root-window方式では、永続Jobと計画メタデータのWindow上限を一致させる。
+            if (executionMode == ExecutionMode.ROOT_WINDOWS
+                    && (rootWindowJob == null
+                            || maximumRootExecutionsPerWindow <= 0L
+                            || maximumRootExecutionsPerWindow
+                                    != rootWindowJob.maximumExecutionsPerWindow())) {
+                throw new IllegalArgumentException("invalid prepared BigInteger root-window job");
             }
+            // Exact方式は誤ってchecked-long子Jobへ渡らないよう、JobとWindowを持たない。
+            if (executionMode == ExecutionMode.EXACT_PATTERN_EXECUTOR
+                    && (rootWindowJob != null || maximumRootExecutionsPerWindow != 0L)) {
+                throw new IllegalArgumentException("invalid prepared BigInteger exact-pattern plan");
+            }
+            // 再計算に必要な識別子がない計画は、永続実行へ渡さない。
+            if (planningEpoch.isBlank() || programFingerprint.isBlank()) {
+                throw new IllegalArgumentException("missing prepared BigInteger planning identity");
+            }
+        }
+
+        public boolean supportsRootWindows() {
+            return executionMode == ExecutionMode.ROOT_WINDOWS;
         }
     }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerCraftingPlan.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerCraftingPlan.java
@@ -51,7 +51,9 @@ public final class BigIntegerCraftingPlan implements WideCraftingPlan {
         if (!finalOutput.what().equals(exactPlan.requestedKey())
                 || !BigInteger.valueOf(finalOutput.amount()).equals(exactPlan.requestedAmount())
                 || !preparedRoot.symbolicPlan().equals(exactPlan)
-                || !preparedRoot.reservedBytes().equals(preparedRoot.job().reservedCapacity())) {
+                || (preparedRoot.rootWindowJob() != null
+                        && !preparedRoot.reservedBytes().equals(
+                                preparedRoot.rootWindowJob().reservedCapacity()))) {
             throw new IllegalArgumentException("BigInteger plan metadata is inconsistent");
         }
         // 個別値がlong超過、またはキー別合計がlong超過してAE2の乗算を使えない計画だけを運ぶ。

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/ExactCraftingJobState.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/ExactCraftingJobState.java
@@ -84,15 +84,14 @@ public final class ExactCraftingJobState {
             }
         });
         var prepared = plan.preparedRoot();
-        var parentJob = prepared.job();
         return new ExactCraftingJobState(
                 plan.finalOutput().what(),
                 plan.exactBytes(),
                 plan.exactPlan().usedInventory(),
                 prepared.patternGeneration(),
                 prepared.recipeGeneration(),
-                parentJob.planningEpoch(),
-                parentJob.programFingerprint(),
+                prepared.planningEpoch(),
+                prepared.programFingerprint(),
                 ExactCraftingJobLedger.planned(
                         tasks,
                         plan.exactPlan().emitted(),

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/AqeBigCraftingExecutionManager.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/AqeBigCraftingExecutionManager.java
@@ -156,7 +156,14 @@ public final class AqeBigCraftingExecutionManager {
                     "The request is missing, ambiguous, cyclic, fuzzy, or changed during planning; nothing was submitted."));
             return 0;
         }
-        if (!host.submit(prepared.job())) {
+        BigCraftingJob<AEKey> rootWindowJob = prepared.rootWindowJob();
+        // 旧コマンド経路はroot単位子Jobしか実行できないため、Exact専用計画を誤送信しない。
+        if (rootWindowJob == null) {
+            source.sendFailure(Component.literal(
+                    "This request requires an exact-pattern BigInteger CPU executor; the legacy root-window command cannot run it."));
+            return 0;
+        }
+        if (!host.submit(rootWindowJob)) {
             source.sendFailure(Component.literal(
                     "The Quantum Computer does not have enough unreserved BigInteger crafting storage."));
             return 0;
@@ -167,7 +174,7 @@ public final class AqeBigCraftingExecutionManager {
         source.sendSuccess(
                 () -> Component.literal(
                         "Submitted ACO BigInteger job "
-                                + prepared.job().id()
+                                + rootWindowJob.id()
                                 + ": "
                                 + amount
                                 + " x "

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApiPlanInspectionTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApiPlanInspectionTest.java
@@ -13,9 +13,11 @@ import appeng.api.stacks.GenericStack;
 import appeng.api.stacks.KeyCounter;
 import appeng.crafting.CraftingPlan;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
+import com.syaru.ae2craftingoptimizer.engine.Ae2BigCraftingPlanFactory;
 import com.syaru.ae2craftingoptimizer.engine.BigCapacityCraftingPlan;
 import com.syaru.ae2craftingoptimizer.engine.BigCraftingPlan;
 import com.syaru.ae2craftingoptimizer.engine.BigExactCraftingByteCounter;
+import com.syaru.ae2craftingoptimizer.engine.BigIntegerCraftingPlan;
 import com.syaru.ae2craftingoptimizer.engine.BigIntegerSimulationPlan;
 import com.syaru.ae2craftingoptimizer.engine.BigIntegerSimulationPlanTestFactory;
 import com.syaru.ae2craftingoptimizer.engine.CompiledCraftingGraph;
@@ -206,6 +208,45 @@ class BigCraftingEngineApiPlanInspectionTest {
                 view.patternTimes().get(BLOCK_PATTERN));
         assertEquals(Map.of(), view.usedItems());
         assertEquals(Map.of(), view.emittedItems());
+    }
+
+    @Test
+    void exposesExactPatternPlanWhenNoRootWindowCanRepresentOneOutput() {
+        BigInteger exactPatternExecutions = BigInteger.ONE.shiftLeft(63);
+        BigInteger exactBytes = BigInteger.ONE.shiftLeft(64);
+        BigCraftingPlan<AEKey> exactPlan = new BigCraftingPlan<>(
+                BLOCK,
+                BigInteger.ONE,
+                Map.of(INGOT_PATTERN_ID, exactPatternExecutions),
+                Map.of(NUGGET, exactPatternExecutions),
+                Map.of(),
+                Map.of(),
+                1);
+        var prepared = new Ae2BigCraftingPlanFactory.PreparedBigRootPlan(
+                null,
+                exactPlan,
+                exactBytes,
+                TEST_GENERATION,
+                TEST_GENERATION,
+                Ae2BigCraftingPlanFactory.ExecutionMode.EXACT_PATTERN_EXECUTOR,
+                0L,
+                "test-epoch",
+                "test-fingerprint");
+        BigIntegerCraftingPlan metadata = new BigIntegerCraftingPlan(
+                new GenericStack(BLOCK, 1L),
+                exactPlan,
+                Map.of(INGOT_PATTERN, exactPatternExecutions),
+                prepared,
+                true);
+
+        CraftingPlan facade = Ae2CraftingPlanSidecars.expose(metadata);
+        BigIntegerCraftingPlanView view =
+                BigCraftingEngineApi.inspectAttachedExactPlan(facade).orElseThrow();
+
+        assertFalse(view.simulation());
+        assertEquals(exactBytes, view.exactBytes());
+        assertEquals(exactPatternExecutions, view.patternTimes().get(INGOT_PATTERN));
+        assertEquals(exactPatternExecutions, view.usedItems().get(NUGGET));
     }
 
     @Test

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/Ae2BigCraftingPlanFactoryRootWindowTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/Ae2BigCraftingPlanFactoryRootWindowTest.java
@@ -1,0 +1,103 @@
+package com.syaru.ae2craftingoptimizer.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class Ae2BigCraftingPlanFactoryRootWindowTest {
+    /** 8^21 = 2^63。signed long境界を一段だけ超える再現条件である。 */
+    private static final int OVERFLOWING_COMPRESSION_STAGES = 21;
+    /** 試験値2^63と中間演算を十分収める小さなBigInteger上限。 */
+    private static final int TEST_MAXIMUM_BITS = 128;
+    /** 実Config既定と同じroot実行Window上限。 */
+    private static final long DEFAULT_ROOT_WINDOW = 65_536L;
+
+    @Test
+    void keepsAnExactPlanWhenOneRootNeedsMoreThanLongMaximumInputs() {
+        CompiledRootProgram<String> program = compressionProgram(
+                OVERFLOWING_COMPRESSION_STAGES);
+        BigInteger requiredRaw = BigInteger.ONE.shiftLeft(63);
+        var inventory = program.captureBigInventory(
+                key -> key.equals("stage_0") ? requiredRaw : BigInteger.ZERO,
+                TEST_MAXIMUM_BITS);
+
+        BigCraftingPlan<String> exactPlan = program.planBig(
+                BigInteger.ONE,
+                inventory,
+                PlanningGuard.none(),
+                TEST_MAXIMUM_BITS);
+        var decision = Ae2BigCraftingPlanFactory.rootWindowDecision(
+                program,
+                BigInteger.ONE,
+                DEFAULT_ROOT_WINDOW,
+                TEST_MAXIMUM_BITS);
+
+        assertTrue(exactPlan.craftable());
+        assertEquals(requiredRaw, exactPlan.usedInventory().get("stage_0"));
+        assertEquals(
+                Ae2BigCraftingPlanFactory.ExecutionMode.EXACT_PATTERN_EXECUTOR,
+                decision.mode());
+        assertEquals(0L, decision.maximumRootExecutions());
+    }
+
+    @Test
+    void keepsTheSameBoundaryExactForAMissingSimulation() {
+        CompiledRootProgram<String> program = compressionProgram(
+                OVERFLOWING_COMPRESSION_STAGES);
+        var emptyInventory = program.captureBigInventory(
+                ignored -> BigInteger.ZERO,
+                TEST_MAXIMUM_BITS);
+
+        BigCraftingPlan<String> simulation = program.planBig(
+                BigInteger.ONE,
+                emptyInventory,
+                PlanningGuard.none(),
+                TEST_MAXIMUM_BITS);
+
+        assertEquals(
+                BigInteger.ONE.shiftLeft(63),
+                simulation.missing().get("stage_0"));
+    }
+
+    @Test
+    void retainsRootWindowsImmediatelyBelowTheBoundary() {
+        CompiledRootProgram<String> program = compressionProgram(
+                OVERFLOWING_COMPRESSION_STAGES - 1);
+
+        var decision = Ae2BigCraftingPlanFactory.rootWindowDecision(
+                program,
+                BigInteger.ONE,
+                DEFAULT_ROOT_WINDOW,
+                TEST_MAXIMUM_BITS);
+
+        assertEquals(
+                Ae2BigCraftingPlanFactory.ExecutionMode.ROOT_WINDOWS,
+                decision.mode());
+        assertEquals(1L, decision.maximumRootExecutions());
+    }
+
+    private static CompiledRootProgram<String> compressionProgram(int stages) {
+        List<CompiledPattern<String>> patterns = new ArrayList<>(stages);
+        // 各段は下位素材8個を上位素材1個へ圧縮する、単一路線の確定Patternである。
+        for (int stage = 1; stage <= stages; stage++) {
+            String input = "stage_" + (stage - 1);
+            String output = "stage_" + stage;
+            patterns.add(new CompiledPattern<>(
+                    "pattern_" + stage,
+                    List.of(new CompiledPattern.InputSlot<>(
+                            List.of(new CompiledPattern.Stack<>(input, 8L)))),
+                    Map.of(output, 1L),
+                    false));
+        }
+        return CompiledRootProgram.tryCompile(
+                        CompiledCraftingGraph.compile(1L, patterns),
+                        "stage_" + stages,
+                        ignored -> false)
+                .orElseThrow();
+    }
+}


### PR DESCRIPTION
## 概要

Issue #79の修正をNeoForge 1.21.1へ同じ意味で反映します。完成品1個の内部需要が`Long.MAX_VALUE`を超えても、exact BigInteger planと公開sidecarを保持します。

## 原因

1.21.1側では安全なroot windowが0の場合に擬似的な1件windowを作る分岐があり、exact計画を旧long実行モデルへ押し戻していました。

## 変更内容

- exact plan公開とlegacy root-window実行を分離
- 擬似的な1件windowを廃止
- exact-only planを表す`EXACT_PATTERN_EXECUTOR`モードを追加
- Pattern回数、使用在庫、不足量、CPU byte数を公開BigInteger APIへ無損失で渡す
- legacy root-windowコマンドへexact-only planを誤投入しない
- 21段8倍圧縮境界および公開sidecarの回帰試験を追加

## 互換性

- signed long境界未満は従来の`ROOT_WINDOWS`経路を維持します。
- 公開APIの型やメソッドは変更していません。
- ACOは計画とAPIを提供し、外部CPUアドオンの実行ロジックへ介入しません。

## 検証

- `gradlew.bat clean build --no-daemon`: 成功
- JUnit: 356件、失敗0、エラー0
- `git diff --check`: 成功

Refs #79
