### PR TITLE
Document Issue #79 regression guard (Forge 1.20.1)

### DIFF
--- a/docs/REGRESSION_HISTORY.md
+++ b/docs/REGRESSION_HISTORY.md
@@ -1,0 +1,59 @@
+# 回帰履歴
+
+この文書は、過去に実際に発生した不具合について、症状、原因、修正、不変条件、
+対応する自動試験を残すための記録です。最適化経路を変更する際は、関連する項目を
+先に確認してください。
+
+## Issue #79: 一つのroot内部だけでsigned long境界を超える計画が失われる
+
+- 発生日: 2026-08-14
+- 影響版: ACO 1.5.17
+- 修正版: ACO 1.5.18
+- 報告: https://github.com/syarukasu/ae2-crafting-optimizer/issues/79
+- Forge 1.20.1修正: https://github.com/syarukasu/ae2-crafting-optimizer/pull/80
+- NeoForge 1.21.1修正: https://github.com/syarukasu/ae2-crafting-optimizer/pull/81
+
+### 症状
+
+8個から1個を作る圧縮Patternを21段つなぐと、完成品1個でも最下層素材の需要は
+`8^21 = 2^63`になります。ACO 1.5.17では、十分な在庫があってもexact計画を
+公開できず、`WidePlanUnavailableException`で計算が失敗しました。
+
+### 原因
+
+`Ae2BigCraftingPlanFactory`が次の二つを同じ条件として扱っていました。
+
+1. BigIntegerで計算したexact計画が正しいこと
+2. 完成品個数単位でAE2標準のchecked-long子Jobへ分割できること
+
+一つのroot自体がlongへ収まらない場合、最大root windowは0になります。旧実装は
+これを計画失敗として扱い、既に正確に求めたPattern回数、在庫使用量、不足量、
+CPU byte数まで破棄していました。
+
+### 修正
+
+exact計画の公開とlegacy root-window実行を分離しました。
+
+- root単位で安全に分割できる場合は`ROOT_WINDOWS`を使います。
+- 一つのrootがlongへ収まらない場合は`EXACT_PATTERN_EXECUTOR`を使います。
+- Exact方式でもexact sidecarは保持します。
+- Exact方式では`rootWindowJob`だけを作りません。
+- legacy root-windowコマンドはExact専用計画を誤実行せず、明確に拒否します。
+
+### 維持すべき不変条件
+
+- root windowが0でもexact計画を`null`へ変えてはいけません。
+- Exact専用計画を偽の`window=1`へ丸めてはいけません。
+- BigIntegerのPattern回数、在庫、missing、CPU byte数をlongへクランプしてはいけません。
+- signed long境界未満では従来のroot-window経路を維持します。
+- ACOはexact計画と公開APIを提供し、外部CPUアドオンの実行ロジックを置換しません。
+
+### 回帰試験
+
+- `Ae2BigCraftingPlanFactoryRootWindowTest`
+  - 21段8倍圧縮、在庫`2^63`: craftable exact plan
+  - 21段8倍圧縮、在庫0: missing `2^63`
+  - 20段8倍圧縮: 従来のroot-window経路
+- `BigCraftingEngineApiPlanInspectionTest`
+  - Exact専用計画でも公開APIから正確なPattern回数、在庫、CPU byte数を取得できること
+

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2BigCraftingPlanFactory.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2BigCraftingPlanFactory.java
@@ -162,6 +162,19 @@ public final class Ae2BigCraftingPlanFactory {
         Objects.requireNonNull(plan, "plan");
         Objects.requireNonNull(bytes, "bytes");
         Objects.requireNonNull(program, "program");
+        /*
+         * 回帰防止: ACO Issue #79
+         * https://github.com/syarukasu/ae2-crafting-optimizer/issues/79
+         * 詳細履歴: docs/REGRESSION_HISTORY.md
+         *
+         * 8倍圧縮21段では、完成品1個だけでも最下層需要が8^21 = 2^63となる。
+         * 以前は「root個数でlong子Jobへ分割できない」ことを「exact計画を作れない」ことと
+         * 同一視し、正確に計算済みのBigInteger計画まで破棄していた。
+         *
+         * exact計画の公開可否とlegacy root-windowの可否は必ず別々に扱うこと。
+         * 一回分がlongへ収まらなくてもnullを返したり、偽のwindow=1へ丸めたりせず、
+         * EXACT_PATTERN_EXECUTORとしてexact sidecarを保持し、rootWindowJobだけを省略する。
+         */
         RootWindowDecision rootWindow = rootWindowDecision(
                 program,
                 requestedAmount,
@@ -198,6 +211,7 @@ public final class Ae2BigCraftingPlanFactory {
     /**
      * 子AE2計画の各カウンタがsigned longへ収まる最大完成品数を二分探索する。
      * CPU byte総量だけのlong超過はBigCapacityCraftingPlanで扱えるため、ここでは除外しない。
+     * Issue #79の再発を防ぐため、一回分すら収まらない場合は失敗ではなくExact方式を返す。
      */
     static <K> RootWindowDecision rootWindowDecision(
             CompiledRootProgram<K> program,

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/Ae2BigCraftingPlanFactoryRootWindowTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/Ae2BigCraftingPlanFactoryRootWindowTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
+/** ACO Issue #79で再発した、一つのroot内部だけでsigned longを超える計画の回帰試験。 */
 class Ae2BigCraftingPlanFactoryRootWindowTest {
     /** 8^21 = 2^63。signed long境界を一段だけ超える再現条件である。 */
     private static final int OVERFLOWING_COMPRESSION_STAGES = 21;


### PR DESCRIPTION
## 概要

ACO Issue #79で再発したBigInteger exact計画の境界不具合について、修正理由と禁止すべき旧挙動をJava本体へ直接記録します。

## 追加した回帰防止情報

- 再現境界が8倍圧縮21段の`8^21 = 2^63`であること
- exact計画の公開可否とlegacy root-window実行可否を同一視してはいけないこと
- 一回分がlongへ収まらなくても`null`を返してはいけないこと
- 偽の`window=1`へ丸めて旧long実行へ戻してはいけないこと
- `EXACT_PATTERN_EXECUTOR`としてsidecarを保持し、root-window Jobだけを省略すること

回帰試験クラスにもIssue #79を明記しました。挙動と版番号は変更していません。

`docs/REGRESSION_HISTORY.md`を追加し、症状、原因、修正、不変条件、対応試験、
版別PRを今後参照できる形で記録しました。

## 検証

- Issue #79境界JUnit: 成功
- `git diff --check`: 成功

Refs #79
