### PR TITLE
Document class responsibilities and centralize exact count maps (Forge 1.20.1)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,4 @@ gradlew text eol=lf
 *.yaml text eol=lf
 *.md text eol=lf
 *.bat text eol=crlf
+*.ps1 text eol=lf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,10 @@
 1. GitHub Issue番号を確定する。
 2. `docs/PROJECT_CHARTER.md`を読む。
 3. `docs/REGRESSION_HISTORY.md`を読む。
-4. `docs/issues/ISSUE-<番号>.md`を作成または更新する。
-5. そのIssue仕様書の状態を`Ready`にする。
-6. `docs/ISSUE_WORKFLOW.md`に従ってから実装を始める。
+4. `docs/CLASS_RESPONSIBILITIES.md`を読み、変更対象の所有クラスと依存方向を確定する。
+5. `docs/issues/ISSUE-<番号>.md`を作成または更新する。
+6. そのIssue仕様書の状態を`Ready`にする。
+7. `docs/ISSUE_WORKFLOW.md`に従ってから実装を始める。
 
 実装中に前提が変わった場合は、コードより先にIssue仕様書を更新してください。
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,11 @@ resources, configs, persistence, or build logic:
 
 1. Read `docs/PROJECT_CHARTER.md`.
 2. Read `docs/REGRESSION_HISTORY.md`.
-3. Create or update `docs/issues/ISSUE-<number>.md` from the template.
-4. Document the problem, evidence, ownership, invariants, forbidden changes,
+3. Read `docs/CLASS_RESPONSIBILITIES.md` and identify the owning class or layer.
+4. Create or update `docs/issues/ISSUE-<number>.md` from the template.
+5. Document the problem, evidence, ownership, invariants, forbidden changes,
    implementation plan, and tests.
-5. Mark the specification `Ready` only after every pre-implementation check is complete.
+6. Mark the specification `Ready` only after every pre-implementation check is complete.
 
 Do not begin implementation while the Issue specification is `Draft`. If the
 code proves an assumption wrong, update the specification before changing the

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ contract before moving any input.
 
 Development is governed by the [project charter](docs/PROJECT_CHARTER.md) and
 [Issue-first workflow](docs/ISSUE_WORKFLOW.md). Every implementation starts by
-reading a numbered specification under [`docs/issues`](docs/issues/README.md).
+reading the [class responsibility catalog](docs/CLASS_RESPONSIBILITIES.md) and a
+numbered specification under [`docs/issues`](docs/issues/README.md).
 
 The persistent branch for this line is `mc/1.20.1`. Its next release artifact
 uses `aco<version>_1.20.1.jar`; the NeoForge line is maintained separately on

--- a/README_ja.md
+++ b/README_ja.md
@@ -15,6 +15,7 @@ AE2 Crafting Optimizer（ACO）は、Applied Energistics 2向けのForge
 
 開発変更は[プロジェクト憲章](docs/PROJECT_CHARTER.md)と
 [Issue先行開発手順](docs/ISSUE_WORKFLOW.md)に従います。実装前に必ず
+[クラス責務一覧](docs/CLASS_RESPONSIBILITIES.md)と
 [`docs/issues`](docs/issues/README.md)の番号付き仕様書を読みます。
 
 ## 対象環境

--- a/docs/CLASS_RESPONSIBILITIES.md
+++ b/docs/CLASS_RESPONSIBILITIES.md
@@ -1,0 +1,554 @@
+# ACOクラス責務一覧
+
+この文書は、各本番トップレベル型が所有する仕事と依存境界を確認する正本です。
+クラス追加・削除・責務変更時は、コードより先にIssue仕様書を更新し、本一覧も更新します。
+一覧は`tools/update-class-responsibilities.ps1`で生成し、重要クラスの説明は同scriptのoverrideで管理します。
+入れ子型は所有元の実装詳細です。独立した所有権を持たせる場合はトップレベル型へ抽出して本一覧へ載せます。
+
+## ACOの目的
+
+ACOはAE2を置き換えるMODではなく、結果・在庫・欠品・容量・進捗・取消・復旧を変えずに、
+巨大自動クラフトの計算と実行負荷を減らす最適化・連携レイヤーです。速度より正確さと所有権を優先します。
+
+## 依存方向
+
+```text
+AE2 / optional add-ons
+          |
+          v
+mixin + access  ->  integration  ->  optimization / scheduler
+                                           |
+                                           v
+                     engine / batch / transaction / craftingtable
+                                           |
+                                           v
+                                  public api value contracts
+```
+
+- `mixin`は入口、`access`は型付き窓口であり、計算・会計を所有しません。
+- `engine`以下から`mixin`を参照しません。Common初期化から`client`を直接ロードしません。
+- 外部CPUアドオンは構造、実行、GUI、電力、進捗を所有し、ACOは計画と公開APIだけを提供します。
+- 所有権移転前だけ安全なfallbackを許可し、移転後は再開、正確な取消返却、隔離のいずれかにします。
+
+## 禁止事項
+
+- BigInteger正本を`long`へクランプ、飽和、切り捨てして判定する。
+- 所有権移転後に通常AE2へfallbackし、同じ入力を二重実行する。
+- 計画値から、実クラフトまたは検証済みReceiptなしで成果物を生成する。
+- 非同期スレッドからWorld、Grid、Block Entity、実在庫へ直接触る。
+- MixinへPlanner、会計、外部CPU実行ロジックを実装する。
+- 外部MODの構造、GUI、レシピ、テクスチャをACOの所有物として変更する。
+
+## 大規模クラスのレビュー
+
+| クラス | 行数 | 判断 |
+|---|---:|---|
+| `PhysicalCraftingTreeTransaction` | 3493 | 高。state machineと永続Codecが同居。Issue #87では数量Mapだけ分離し、Receipt/Codec分割は専用回帰試験を伴う別Issueにする。 |
+| `ACOConfig` | 1828 | 中。長大だがConfig IDと既定値の正本として凝集している。key互換を固定する試験なしに分割しない。 |
+| `AqeBigCraftingExecutionManager` | 1631 | 高。外部CPU所有権と復旧境界。起動・再起動・取消試験を用意してから段階分割する。 |
+| `CompiledRootProgram` | 1294 | 中。計算核として大きいが副作用は限定的。コンパイルと評価の分離候補。 |
+| `BigCraftingJob` | 1215 | 高。永続状態とWindow貸出を所有。NBT Codec分離はschema回帰試験と同時に行う。 |
+| `Ae2AuthoritativeCraftingPlanner` | 949 | 中。採用判定と計画生成の境界を維持し、fallback条件を別クラスへ散らさない。 |
+| `TransactionalCraftingExecutorV2` | 933 | 高。所有権移転後の処理。見た目の短縮目的では分割せず、phase単位の試験を先に増やす。 |
+| `ExactNetworkStorageBridge` | 906 | 高。実在庫境界。snapshotとmutationの分離候補だが原子性試験が先。 |
+| `BigCraftingRuntime` | 873 | 中。公開API側のruntime registry。Host runtimeとの責務重複を監視する。 |
+| `BigCraftingHostRuntime` | 861 | 高。外部Host容量と予約を所有。複数Job仕様を勝手に導入しない。 |
+
+## パッケージ責務
+
+| パッケージ | 責務 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer` | 起動、Forge/NeoForgeイベント接続、全体初期化。 |
+| `com.syaru.ae2craftingoptimizer.access` | Mixinが外部クラスの内部状態を型付きで公開する契約。判断ロジックは持たない。 |
+| `com.syaru.ae2craftingoptimizer.api.batch` | 旧Pattern Batch公開API。互換性維持を優先する。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.v2` | 所有権、Receipt、commit、復旧を明示するTransactional Batch公開API。 |
+| `com.syaru.ae2craftingoptimizer.api.big` | BigInteger計画、Host、進捗、公開連携API。 |
+| `com.syaru.ae2craftingoptimizer.api.craftingtable` | 作業台物理Batch Workerとの公開契約。 |
+| `com.syaru.ae2craftingoptimizer.api.execution` | Exact Vector実行所有者を宣言する公開契約。 |
+| `com.syaru.ae2craftingoptimizer.api.vector` | exact数量のVector計画、保存、Storage境界API。 |
+| `com.syaru.ae2craftingoptimizer.batch` | Pattern Batchの完全一致、Escrow、Receipt、再照合。 |
+| `com.syaru.ae2craftingoptimizer.client` | クライアント表示、入力、BigInteger表示用state。 |
+| `com.syaru.ae2craftingoptimizer.command` | 観測と安全な失効だけを行う診断コマンド。 |
+| `com.syaru.ae2craftingoptimizer.config` | 機能スイッチ、上限、時間予算のCommon Config。 |
+| `com.syaru.ae2craftingoptimizer.craftingamount` | long注文数をAE2 Menuへ渡すserver側境界。 |
+| `com.syaru.ae2craftingoptimizer.engine` | コンパイル済みグラフ、Planner、BigInteger会計の計算核。 |
+| `com.syaru.ae2craftingoptimizer.engine.craftingtable` | 所有権移転後の作業台物理クラフト取引、Escrow、復旧。 |
+| `com.syaru.ae2craftingoptimizer.engine.vector` | exact Vector計画の検証、在庫snapshot、表示投影。 |
+| `com.syaru.ae2craftingoptimizer.gtceu` | GTCEu Recipe IntentとNative Batchの任意連携。 |
+| `com.syaru.ae2craftingoptimizer.integration` | AE2、Advanced AE、任意MOD、exact storageへの版別接続。 |
+| `com.syaru.ae2craftingoptimizer.intent` | Providerが意図するrecipeを短期間伝える検索hint。 |
+| `com.syaru.ae2craftingoptimizer.lifecycle` | server起動、停止、reload、registry accessの順序管理。 |
+| `com.syaru.ae2craftingoptimizer.mekanism` | Mekanism Recipe IntentとNative Batchの任意連携。 |
+| `com.syaru.ae2craftingoptimizer.mixin` | 外部処理へ薄い入口を追加するMixinと適用plugin。 |
+| `com.syaru.ae2craftingoptimizer.network` | BigInteger容量と進捗を同期する版付き通信路。 |
+| `com.syaru.ae2craftingoptimizer.optimization` | 世代付きcache、時間予算、診断、保守的高速経路。 |
+| `com.syaru.ae2craftingoptimizer.scheduler` | ジョブとProviderへtick予算を公平配分するscheduler。 |
+| `com.syaru.ae2craftingoptimizer.transaction` | Native Batch取引、Journal、再起動復旧、収支検査。 |
+| `com.syaru.ae2craftingoptimizer.util` | 副作用を持たないfingerprintなどの共通処理。 |
+
+## 全トップレベル型一覧
+
+本版の本番トップレベル型: **328件**
+
+### `com.syaru.ae2craftingoptimizer`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer` | MOD entrypoint。Config、network、lifecycle、optional integrationを登録し、個別計算は各層へ委譲する。 |
+
+### `com.syaru.ae2craftingoptimizer.access`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.access.AdvancedAeClusterExecutionAccess` | AdvancedAeClusterExecutionAccessが示す外部状態を型付きで公開するMixin用Access契約。判断や会計は持たない。 |
+| `com.syaru.ae2craftingoptimizer.access.AdvancedAeExactCraftingJobAccess` | Advanced AE実JobへBigInteger正本を設置・同期するためのversion-pinned契約。 |
+| `com.syaru.ae2craftingoptimizer.access.AdvancedAeExactCraftingLogicAccess` | Advanced AE標準の完了・取消通知経路へExact Jobを戻すための最小Invoker契約。 |
+| `com.syaru.ae2craftingoptimizer.access.BigCapacityPlanBoundaryAccess` | Big容量計画を受理または拒否する専用Mixinが対象CPUへ適用済みであることを示す。 |
+| `com.syaru.ae2craftingoptimizer.access.CheckedCraftingArithmeticHookAccess` | AE2クラフト計算のlong境界検査Mixinが適用済みであることを示す印。 |
+| `com.syaru.ae2craftingoptimizer.access.CraftingClusterHostTransactionAccess` | CraftingClusterHostTransactionAccessが示す外部状態を型付きで公開するMixin用Access契約。判断や会計は持たない。 |
+| `com.syaru.ae2craftingoptimizer.access.CraftingClusterRecoveryAccess` | CraftingClusterRecoveryAccessが示す外部状態を型付きで公開するMixin用Access契約。判断や会計は持たない。 |
+| `com.syaru.ae2craftingoptimizer.access.CraftingJobTransactionAccess` | CraftingJobTransactionAccessが示す外部状態を型付きで公開するMixin用Access契約。判断や会計は持たない。 |
+| `com.syaru.ae2craftingoptimizer.access.CraftingLogicTransactionAccess` | CraftingLogicTransactionAccessが示す外部状態を型付きで公開するMixin用Access契約。判断や会計は持たない。 |
+| `com.syaru.ae2craftingoptimizer.access.CraftingOwnerTransactionAccess` | CraftingOwnerTransactionAccessが示す外部状態を型付きで公開するMixin用Access契約。判断や会計は持たない。 |
+| `com.syaru.ae2craftingoptimizer.access.CraftingServiceCalculationHookAccess` | CraftingServiceの計算共有・事前判定Mixinが適用済みであることを示す印。 |
+| `com.syaru.ae2craftingoptimizer.access.CraftingTaskProgressAccess` | CraftingTaskProgressAccessが示す外部状態を型付きで公開するMixin用Access契約。判断や会計は持たない。 |
+| `com.syaru.ae2craftingoptimizer.access.DelegatingMEInventoryAccess` | DelegatingMEInventoryAccessが示す外部状態を型付きで公開するMixin用Access契約。判断や会計は持たない。 |
+| `com.syaru.ae2craftingoptimizer.access.ExactBigIntegerInventoryHookAccess` | 正確なBigInteger在庫Snapshotの生成・伝播・失効Mixinが適用済みであることを示す印。 |
+| `com.syaru.ae2craftingoptimizer.access.ExactCraftingInventoryAccess` | AE2のListCraftingInventoryへBigInteger数量を保持させる拡張契約。 |
+| `com.syaru.ae2craftingoptimizer.access.ExtendedAePlusBigIntegerCellInventoryAccess` | ExtendedAePlusBigIntegerCellInventoryAccessが示す外部状態を型付きで公開するMixin用Access契約。判断や会計は持たない。 |
+| `com.syaru.ae2craftingoptimizer.access.MekanismCachedRecipeAccess` | MekanismCachedRecipeAccessが示す外部状態を型付きで公開するMixin用Access契約。判断や会計は持たない。 |
+| `com.syaru.ae2craftingoptimizer.access.NetworkStorageMountsAccess` | NetworkStorageMountsAccessが示す外部状態を型付きで公開するMixin用Access契約。判断や会計は持たない。 |
+| `com.syaru.ae2craftingoptimizer.access.NumberEntryWidgetAccess` | NumberEntryWidgetAccessが示す外部状態を型付きで公開するMixin用Access契約。判断や会計は持たない。 |
+| `com.syaru.ae2craftingoptimizer.access.PatternProviderTransactionAccess` | PatternProviderTransactionAccessが示す外部状態を型付きで公開するMixin用Access契約。判断や会計は持たない。 |
+
+### `com.syaru.ae2craftingoptimizer.api.batch`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.api.batch.ExactPatternFormula` | 一意な作業台Patternを、入力slotと出力係数だけの不変式へ変換する。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.PatternBatchAdapter` | 完全なProcessing Patternを一回以上、機械側の所有物として受理するAdapter契約。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.PatternBatchApi` | PatternBatchApiが示す機能を外部MODへ公開する安定Facade。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.PatternBatchBudget` | 一回のAdapter commitに対する不変の操作数・実時間境界。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.PatternBatchContext` | PatternBatchContextが示す一回の要求に必要な入力、所有者、実行条件を保持する。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.PatternBatchResult` | PatternBatchResultが示す処理結果、受理量、次状態を不変値として返す。 |
+
+### `com.syaru.ae2craftingoptimizer.api.batch.v2`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.api.batch.v2.BatchCpuAccountingMode` | Batch一件をCrafting CPUのtick予算へどう数えるか。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.v2.BatchEnergyAccountingMode` | Transactional Batchの電力を送信元と実機のどちらが所有するか。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.v2.BatchOwnershipProof` | Batch入力の所有権が送信先へ移ったことを示す証明。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.v2.BatchPayloadFingerprint` | 取引IDとは独立した、入力・期待出力・実行数の決定的Fingerprint。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.v2.BatchRecoveryResult` | BatchRecoveryResultが示す処理結果、受理量、次状態を不変値として返す。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.v2.BatchSourceReceipt` | BatchSourceReceiptが示す所有権移転または完了事実を、検証可能な証跡として保持する。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.v2.BatchSourceReceiptStore` | BatchSourceReceiptStoreが示す記録を保存、検索、削除する。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.v2.BatchSourceReconciler` | BatchSourceReconcilerが示す計画、Receipt、実状態を照合し、一意に証明できる結果だけを返す。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.v2.BatchTransactionRecord` | BatchTransactionRecordが示す計画または取引の一要素を、不変のexact値として保持する。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.v2.NativeBatchReceipt` | NativeBatchReceiptが示す所有権移転または完了事実を、検証可能な証跡として保持する。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.v2.NativeBatchReceiptStore` | NativeBatchReceiptStoreが示す記録を保存、検索、削除する。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.v2.PatternBatchCommit` | prepare済みBatchの所有権証明、受理数、Receiptをまとめ、commit可否を表す。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.v2.PatternBatchIdentity` | ACO Journalと外部Adapterが共有する、Pattern Batchの正規識別API。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.v2.PatternBatchV2Api` | PatternBatchV2Apiが示す機能を外部MODへ公開する安定Facade。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.v2.PreparedPatternBatch` | Adapterへ渡す前にidentity、payload、要求回数を固定した不変Batch。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.v2.ProviderOwnedPatternBatchTarget` | 外部Inventoryではなく、Pattern Provider自身がBatchの永続所有者になることを示す。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.v2.SourceRecoveryResult` | SourceRecoveryResultが示す処理結果、受理量、次状態を不変値として返す。 |
+| `com.syaru.ae2craftingoptimizer.api.batch.v2.TransactionalPatternBatchAdapter` | TransactionalPatternBatchAdapterが示す二つのAPI境界を接続し、対応不能時は元の所有者へ判断を戻す。 |
+
+### `com.syaru.ae2craftingoptimizer.api.big`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.api.big.AeKeyBigCraftingCodec` | AeKeyBigCraftingCodecが示す値を、上限とschemaを検証しながら保存・通信形式へ相互変換する。 |
+| `com.syaru.ae2craftingoptimizer.api.big.AeKeyBigCraftingPacketCodec` | AeKeyBigCraftingPacketCodecが示す値を、上限とschemaを検証しながら保存・通信形式へ相互変換する。 |
+| `com.syaru.ae2craftingoptimizer.api.big.BigCraftingEngineApi` | AQE、InsaneAEなどへexact計画、容量、台帳を公開する版付きFacade。 |
+| `com.syaru.ae2craftingoptimizer.api.big.BigCraftingHostBackendState` | BigInteger Hostの原子的な状態表示に使う安定ラベル。 |
+| `com.syaru.ae2craftingoptimizer.api.big.BigCraftingHostRegistration` | 一つのCPU所有者とBigCraftingHostRuntimeを結ぶ世代付き登録ハンドル。 |
+| `com.syaru.ae2craftingoptimizer.api.big.BigCraftingHostRegistry` | CPU所有者ごとのBigInteger Hostを、GCではなく明示的なライフサイクルで管理する。 |
+| `com.syaru.ae2craftingoptimizer.api.big.BigCraftingHostRuntime` | 明示登録された外部CPU Hostのexact容量予約、snapshot、復旧を管理する。 |
+| `com.syaru.ae2craftingoptimizer.api.big.BigCraftingHostSnapshot` | 一回の会計世代から取得した、分割読み取りを避ける不変Snapshot。 |
+| `com.syaru.ae2craftingoptimizer.api.big.BigCraftingPacketKeyCodec` | BigCraftingPacketKeyCodecが示す値を、上限とschemaを検証しながら保存・通信形式へ相互変換する。 |
+| `com.syaru.ae2craftingoptimizer.api.big.BigCraftingRuntime` | BigInteger計画sidecarとruntime jobの登録、照会、寿命管理を行う。 |
+| `com.syaru.ae2craftingoptimizer.api.big.BigCraftingStatusInbox` | 分割受信したBigInteger進捗pageをHost世代ごとに集約するclient側受信箱。 |
+| `com.syaru.ae2craftingoptimizer.api.big.BigCraftingStatusPage` | BigInteger容量・使用量・Job進捗の一部分を運ぶ版付きpage。 |
+| `com.syaru.ae2craftingoptimizer.api.big.BigCraftingStatusPageCodec` | BigCraftingStatusPageCodecが示す値を、上限とschemaを検証しながら保存・通信形式へ相互変換する。 |
+| `com.syaru.ae2craftingoptimizer.api.big.BigIntegerAmountLedger` | Add-on向けの正確な量会計。 |
+| `com.syaru.ae2craftingoptimizer.api.big.BigIntegerCraftingPlanView` | 外部MODがACO計画のexact bytes、要求量、不足量を切り捨てず読むための公開view。 |
+
+### `com.syaru.ae2craftingoptimizer.api.craftingtable`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.api.craftingtable.CraftingTableBatchMode` | 一括作業台仕事の数量会計を誰が所有するか。 |
+| `com.syaru.ae2craftingoptimizer.api.craftingtable.CraftingTableBatchRequest` | 一つの確定作業台Patternを一つの物理Worker仕事へ渡す不変Request。 |
+| `com.syaru.ae2craftingoptimizer.api.craftingtable.CraftingTableBatchSnapshot` | 物理Workerの小さな進捗Receipt。 |
+| `com.syaru.ae2craftingoptimizer.api.craftingtable.CraftingTableBatchTarget` | Pattern Provider配下の物理作業台設備が実装する最小契約。 |
+
+### `com.syaru.ae2craftingoptimizer.api.execution`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.api.execution.VectorBatchExecutionOwner` | 外部クラフトエンジンが、大量の論理クラフトを一つの定数時間Batchとして処理できることをACOへ伝える。 |
+
+### `com.syaru.ae2craftingoptimizer.api.vector`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.api.vector.ExactCraftingInputSlot` | 一つの作業台Pattern slotでPlannerが選んだ、一回実行当たりの具体入力。 |
+| `com.syaru.ae2craftingoptimizer.api.vector.ExactCraftingStep` | 決定的な作業台Pattern一種類を、実Workerが一度組み立てて係数展開する実行Step。 |
+| `com.syaru.ae2craftingoptimizer.api.vector.ExactStack` | AEKey一種類と、その正確な非負longを超えられる数量。 |
+| `com.syaru.ae2craftingoptimizer.api.vector.ExactStorageMutationResult` | 一AEKeyの正確在庫操作結果。 |
+| `com.syaru.ae2craftingoptimizer.api.vector.ExactVectorCraftingApi` | ACO Exact Vector Craftingの、既存BigInteger APIとは独立した公開契約版。 |
+| `com.syaru.ae2craftingoptimizer.api.vector.ExactVectorDiagnostics` | 外部Exact Vector設備が、数量非依存の低コスト統計をACOへ通知するAPI。 |
+| `com.syaru.ae2craftingoptimizer.api.vector.ExactVectorExecutionBudget` | Exact Vector Executorが、同じME Gridの空き時間から論理段をまとめて取得する公開境界。 |
+| `com.syaru.ae2craftingoptimizer.api.vector.ExactVectorStoragePolicy` | Infinity BigInteger Cellの派生実装が、ACOの直接BigInteger挿入へ追加制約を伝える契約。 |
+| `com.syaru.ae2craftingoptimizer.api.vector.ExactVectorStorageService` | Exact Vector Executorが使用する、数量分割を行わないBigInteger在庫境界。 |
+| `com.syaru.ae2craftingoptimizer.api.vector.PreparedVectorBatch` | 計算スレッドで完成し、実行中に再びグラフ探索しない不変Vector計画。 |
+| `com.syaru.ae2craftingoptimizer.api.vector.PreparedVectorBatchCodec` | exact Vector計画を上限付きNBTへ符号化・復号し、schemaを検証する。 |
+| `com.syaru.ae2craftingoptimizer.api.vector.VectorResourceMode` | Exact Vector Transactionで、境界入出力を所有・配送する側を明示する。 |
+
+### `com.syaru.ae2craftingoptimizer.batch`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.batch.Ae2BatchSourceReconciler` | Ae2BatchSourceReconcilerが示す計画、Receipt、実状態を照合し、一意に証明できる結果だけを返す。 |
+| `com.syaru.ae2craftingoptimizer.batch.BatchSourceReceiptLedger` | BatchSourceReceiptLedgerが示す所有量、Receipt、収支をexact値で記録・検証する。 |
+| `com.syaru.ae2craftingoptimizer.batch.ExactMultisetMatcher` | ExactMultisetMatcherが示す入力や互換条件を検証し、証明不能な高速経路を拒否する。 |
+| `com.syaru.ae2craftingoptimizer.batch.ExactPatternSnapshot` | ExactPatternSnapshotが示す時点の状態を、検証可能な値として保持する。 |
+| `com.syaru.ae2craftingoptimizer.batch.NativeBatchReceiptLedger` | NativeBatchReceiptLedgerが示す所有量、Receipt、収支をexact値で記録・検証する。 |
+| `com.syaru.ae2craftingoptimizer.batch.NativePatternBatchSupport` | NativePatternBatchSupportが示す二つのAPI境界を接続し、対応不能時は元の所有者へ判断を戻す。 |
+| `com.syaru.ae2craftingoptimizer.batch.PatternProviderBatchEscrow` | Pattern Providerの永続send bufferをV2取引のEscrowとして使う共通処理。 |
+| `com.syaru.ae2craftingoptimizer.batch.PatternProviderReceiptResolver` | PatternProviderReceiptResolverが示す計画、Receipt、実状態を照合し、一意に証明できる結果だけを返す。 |
+| `com.syaru.ae2craftingoptimizer.batch.PatternTaskFingerprint` | PatternTaskFingerprintが示す対象を、順序と内容から安定して識別する。 |
+| `com.syaru.ae2craftingoptimizer.batch.SequentialPatternProviderBatchAdapter` | 保守的な標準Adapter。 |
+
+### `com.syaru.ae2craftingoptimizer.client`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.client.AsyncTerminalView` | 端末検索・sortの非同期結果を世代付きで保持し、古い結果の反映を拒否する。 |
+| `com.syaru.ae2craftingoptimizer.client.BigAmountFormatter` | AE2のlong表示範囲を越える数量を、丸めによる上限張り付きなしで表示する。 |
+| `com.syaru.ae2craftingoptimizer.client.BigCraftingPlanClientStore` | 現在開いているCraftConfirmMenuだけへ、BigInteger表示用Sidecarを提供する。 |
+| `com.syaru.ae2craftingoptimizer.client.ClientRepoUpdateScheduler` | ClientRepoUpdateSchedulerが示す仕事へtick予算を配分し、公平性とbackpressureを維持する。 |
+| `com.syaru.ae2craftingoptimizer.client.LongCraftAmountClientHandler` | 戻る操作で再作成されたCraftAmountMenuへ、サーバーのlong初期値を同期する。 |
+| `com.syaru.ae2craftingoptimizer.client.LongCraftAmountClientParser` | NumberEntryWidgetのlongValue()が範囲外で折り返さないよう、 CraftAmountScreenの入力だけをBigDecimalから厳密変換する。 |
+
+### `com.syaru.ae2craftingoptimizer.command`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.command.ACOIntentCommands` | Recipe Intent、cache、Batch、計算統計を表示・安全に失効するserver commandを登録する。 |
+
+### `com.syaru.ae2craftingoptimizer.config`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.config.ACOConfig` | 全Common Config key、既定値、範囲、説明を登録する唯一のConfig正本。 |
+
+### `com.syaru.ae2craftingoptimizer.craftingamount`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.craftingamount.LongCraftAmountMenuBridge` | CraftAmountMenuへ追加するlong専用の狭い境界。 |
+| `com.syaru.ae2craftingoptimizer.craftingamount.LongCraftAmountRules` | AE2本来のint注文と、ACOが追加するlong注文の境界を一か所で管理する。 |
+| `com.syaru.ae2craftingoptimizer.craftingamount.LongCraftConfirmMenuBridge` | CraftConfirmMenuのintフィールドを変更せず、longルート量をSidecarで保持する。 |
+
+### `com.syaru.ae2craftingoptimizer.engine`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.engine.Ae2AuthoritativeCraftingPlanner` | Shadow一致済みの決定的rootだけをACO計画へ昇格し、証明不能なら採用を辞退する。 |
+| `com.syaru.ae2craftingoptimizer.engine.Ae2BigCraftingPlanFactory` | AE2 Pattern木からexact BigInteger計画とsimulation不足計画を構築する。 |
+| `com.syaru.ae2craftingoptimizer.engine.Ae2CompiledCraftingGraphCache` | Pattern世代ごとのコンパイル済みグラフsnapshotを保持し、世代変更で失効する。 |
+| `com.syaru.ae2craftingoptimizer.engine.Ae2CompiledPatternFactory` | Ae2CompiledPatternFactoryが示す値を、検証済み入力から生成する。 |
+| `com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars` | 純正AE2 CraftingPlanへexact真値をidentity関連付けし、外部型互換を維持する。 |
+| `com.syaru.ae2craftingoptimizer.engine.Ae2CraftingShadowValidator` | AE2標準計画を正としてRoot Programの全会計を比較し、同一世代Programの採用実績を蓄積する。 |
+| `com.syaru.ae2craftingoptimizer.engine.Ae2ReferencedInventory` | AE2の全在庫をMap化せず、Compiled Root Programが参照するキーだけを取得する。 |
+| `com.syaru.ae2craftingoptimizer.engine.Ae2StrictCraftingTopology` | 代替、循環、返却物などを検査し、数式計画へ安全に変換できるPattern DAGだけを認定する。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigCapacityCraftingPlan` | 各AEKey量とPattern回数はlongに収まるが、合計CPU容量だけがlongを超える厳密計画。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigCountMath` | BigInteger数量Mapの加算・乗算・ceilDivを正確に行う副作用なし算術。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigCraftingCapacityLedger` | BigCraftingCapacityLedgerが示す所有量、Receipt、収支をexact値で記録・検証する。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigCraftingCpuLedger` | BigCraftingCpuLedgerが示す所有量、Receipt、収支をexact値で記録・検証する。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigCraftingInventory` | 計画中の在庫使用量と不足量をAEKey別BigIntegerで保持する仮想在庫。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigCraftingJob` | BigInteger注文の永続状態とlong実行Windowの貸出・回収を管理する。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigCraftingKeyCodec` | BigCraftingKeyCodecが示す値を、上限とschemaを検証しながら保存・通信形式へ相互変換する。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigCraftingPlan` | BigCraftingPlanが示すクラフト計画またはコンパイル済みプログラムを不変値として保持する。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigCraftingPlanner` | BigCraftingPlannerが示す入力から、副作用なしでクラフト計画を構築する。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigCraftingPlanSummary` | CraftConfirm画面へ送る、容量と素材別数量のBigInteger正本。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigCraftingTaskProgress` | Pattern taskの総数、完了数、待機数をBigIntegerで追跡する。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigExactCraftingByteCounter` | AE2 15.4.10のCPU bytes式をBigIntegerの有理数として計算する。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigExecutionWindow` | BigInteger残量からlegacy実行へ貸し出す、Long.MAX_VALUE以下の一時Window。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigIntegerBufferCodec` | BigIntegerBufferCodecが示す値を、上限とschemaを検証しながら保存・通信形式へ相互変換する。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigIntegerCraftingPlan` | Pattern回数または個別AEKey量がsigned longを超える、AQE専用のBigInteger親計画。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigIntegerNbtCodec` | BigIntegerNbtCodecが示す値を、上限とschemaを検証しながら保存・通信形式へ相互変換する。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigIntegerPlanProjection` | BigInteger正本を変更せず、AE2のlong固定表示境界へ投影する共通処理。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigIntegerSimulationPlan` | long計算へ戻さずに返す、BigInteger正本の不足simulation計画。 |
+| `com.syaru.ae2craftingoptimizer.engine.BigKeyCounterSidecars` | AE2のlong KeyCounterへ対応する、正確なBigInteger在庫Snapshot。 |
+| `com.syaru.ae2craftingoptimizer.engine.CheckedLongMath` | 通常計画のlong演算をexact検査し、overflow時は昇格用例外を返す。 |
+| `com.syaru.ae2craftingoptimizer.engine.CompiledCraftingGraph` | 世代内で再利用するPattern nodeと入出力edgeの不変グラフ。 |
+| `com.syaru.ae2craftingoptimizer.engine.CompiledPattern` | 一つのPatternをnode ID、exact係数、候補情報へ正規化した不変値。 |
+| `com.syaru.ae2craftingoptimizer.engine.CompiledPlanningSession` | 一計算で共有するgraph snapshot、在庫snapshot、取消token、世代検証を束ねる。 |
+| `com.syaru.ae2craftingoptimizer.engine.CompiledRootProgram` | 一つのrootから到達する決定的DAGを配列プログラムへ変換し、数量に依存しない計算を行う。 |
+| `com.syaru.ae2craftingoptimizer.engine.CompiledRootQualificationRegistry` | AE2標準計画とのShadow一致実績を、世代付きRoot Program単位で記録する。 |
+| `com.syaru.ae2craftingoptimizer.engine.CountOverflowException` | CountOverflowExceptionが示す失敗を呼出側へ型付きで通知する。 |
+| `com.syaru.ae2craftingoptimizer.engine.CraftingPlanShadowComparator` | ACO計画とAE2標準計画の結果・不足・bytesを比較し、不一致なら採用を拒否する。 |
+| `com.syaru.ae2craftingoptimizer.engine.ExactCraftingByteCounter` | AE2 15.4.10の線形CraftingTreeと同じ順番でCPU bytesを再計算する。 |
+| `com.syaru.ae2craftingoptimizer.engine.ExactCraftingJobLedger` | AE2実JobのBigIntegerカウンタを再起動後も検証する永続Journal。 |
+| `com.syaru.ae2craftingoptimizer.engine.ExactCraftingJobState` | Advanced AE実Jobへ付随するexact task、waiting、output、Receiptのsidecar正本。 |
+| `com.syaru.ae2craftingoptimizer.engine.GenerationAwareGraphCache` | GenerationAwareGraphCacheが示す既知結果を世代またはrevision付きで再利用し、変化時に失効する。 |
+| `com.syaru.ae2craftingoptimizer.engine.LongCraftingPlan` | LongCraftingPlanが示すクラフト計画またはコンパイル済みプログラムを不変値として保持する。 |
+| `com.syaru.ae2craftingoptimizer.engine.LongCraftingPlanner` | 通常規模の注文をchecked long演算で展開するPlanner。 |
+| `com.syaru.ae2craftingoptimizer.engine.OverflowPromotingCraftingPlanner` | checked long Plannerを先に試し、overflowした注文だけ最初からBigIntegerで再計算する。 |
+| `com.syaru.ae2craftingoptimizer.engine.PlanningCancellationToken` | 共有計算を直接cancelせず、呼出者ごとの取消要求を協調的に伝えるtoken。 |
+| `com.syaru.ae2craftingoptimizer.engine.PlanningCancelledException` | PlanningCancelledExceptionが示す失敗を呼出側へ型付きで通知する。 |
+| `com.syaru.ae2craftingoptimizer.engine.PlanningGenerationSnapshot` | PlanningGenerationSnapshotが示す時点の状態を、検証可能な値として保持する。 |
+| `com.syaru.ae2craftingoptimizer.engine.PlanningGuard` | PlanningGuardが示す入力や互換条件を検証し、証明不能な高速経路を拒否する。 |
+| `com.syaru.ae2craftingoptimizer.engine.PlanningRuntimeEpoch` | 現在のサーバープロセスを識別する一時ID。 |
+| `com.syaru.ae2craftingoptimizer.engine.RecipeGenerationTracker` | RecipeGenerationTrackerが示す世代、進捗、tick時刻を単調に追跡する。 |
+| `com.syaru.ae2craftingoptimizer.engine.StalePlanningSnapshotException` | StalePlanningSnapshotExceptionが示す失敗を呼出側へ型付きで通知する。 |
+| `com.syaru.ae2craftingoptimizer.engine.SymbolicCraftingPlanner` | 決定的なPattern DAGを CompiledRootProgram へ変換し、数式一巡で計画する公開Facade。 |
+| `com.syaru.ae2craftingoptimizer.engine.WideArithmeticPreflight` | 通常計画へBigInteger Plannerを重ねる前に、全量クラフト時の安全な上限だけを調べる。 |
+| `com.syaru.ae2craftingoptimizer.engine.WideCraftingPlan` | AE2のsigned long APIだけでは表現できない真値を持つACO内部計画。 |
+| `com.syaru.ae2craftingoptimizer.engine.WidePlanUnavailableException` | wide計画を正確に作れず、AE2のoverflowするlong計算へ戻してはいけないことを示す例外。 |
+
+### `com.syaru.ae2craftingoptimizer.engine.craftingtable`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.engine.craftingtable.ExactCountMap` | 正のBigInteger数量Mapの検証、順序付き複製、包含判定、exact加算を行う副作用なし共通部品。 |
+| `com.syaru.ae2craftingoptimizer.engine.craftingtable.ExactCraftingEscrow` | 一注文が所有する境界素材、中間素材、最終成果物をBigIntegerのまま原子的に増減する。 |
+| `com.syaru.ae2craftingoptimizer.engine.craftingtable.ExactMutationReconciler` | 保存済みbefore/afterと現在値を照合し、まだ適用していないキーだけを返す。 |
+| `com.syaru.ae2craftingoptimizer.engine.craftingtable.PhysicalCraftingTreeTransaction` | 作業台ツリーの所有権移転後state machine。予約、Worker Receipt、取消、返却、隔離、NBT復元を統括する。 |
+
+### `com.syaru.ae2craftingoptimizer.engine.vector`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.engine.vector.LongClampedProgressProjection` | Exact Vectorの正確な数量を変更せず、AE2のlong表示へ進捗を投影する。 |
+| `com.syaru.ae2craftingoptimizer.engine.vector.VectorBatchPlanner` | Compiled Root Programを、要求数量に依存しない一つのExact Vector式へ変換する。 |
+| `com.syaru.ae2craftingoptimizer.engine.vector.VectorBatchPlanValidator` | Config上限とBigInteger桁数を、Executor選択より前に一か所で検査する。 |
+| `com.syaru.ae2craftingoptimizer.engine.vector.VectorInventorySnapshot` | Vector計画が参照したキーだけを保持する不変の正確在庫Snapshot。 |
+| `com.syaru.ae2craftingoptimizer.engine.vector.VectorPlanFingerprint` | Programと正確な境界量から、保存Receiptを取り違えない安定SHA-256を作る。 |
+
+### `com.syaru.ae2craftingoptimizer.gtceu`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.gtceu.GTCEuNativeBatchBridge` | GTCEuNativeBatchBridgeが示す二つのAPI境界を接続し、対応不能時は元の所有者へ判断を戻す。 |
+| `com.syaru.ae2craftingoptimizer.gtceu.GTCEuNativePatternBatchAdapter` | GTCEuのItem・Fluid入力を完全一致でまとめて受理させるAdapter。 |
+| `com.syaru.ae2craftingoptimizer.gtceu.GTCEuRecipeIntentFastPath` | Provider Intentに一致するGT recipe候補だけを優先し、GTCEu本来の成立判定へ渡す。 |
+
+### `com.syaru.ae2craftingoptimizer.integration`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.integration.AdvancedAePatternProviderAccess` | Advanced AE Pattern Providerの実体と世代情報を版差を吸収して取得する。 |
+| `com.syaru.ae2craftingoptimizer.integration.Ae2CraftingTreeCompatibility` | AE2 Crafting TreeがCraftingPlanSummaryへ追加するRecipeHelperを任意連携で初期化する。 |
+| `com.syaru.ae2craftingoptimizer.integration.Ae2UelmCompatibility` | Forge 1.20.1でAE2 UELMを検出し、対応済みdescriptorと機能差を検証する。 |
+| `com.syaru.ae2craftingoptimizer.integration.AppliedECompatibility` | AppliedE本家とTPS Fix forkに共通する動的パターン境界を扱う。 |
+| `com.syaru.ae2craftingoptimizer.integration.AqeBigCraftingExecutionContext` | 標準容量判定へ、現在投入中のBig子Job一件分だけを一時的に貸し出すサーバースレッド文脈。 |
+| `com.syaru.ae2craftingoptimizer.integration.AqeBigCraftingExecutionManager` | Advanced AE CPU HostとACO exact計画を接続し、予約、実行、取消、復元を調停する外部境界。 |
+| `com.syaru.ae2craftingoptimizer.integration.BigIntegerStorageSnapshotBridge` | NetworkStorageが各mountを集計する境界で、AE2用long FacadeとBigInteger正本を分離する。 |
+| `com.syaru.ae2craftingoptimizer.integration.ExactBigIntegerCellConsistency` | ACOが直接更新したExtendedAE Plus在庫Mapと、同MODの保存用総量を結ぶ弱Sidecar。 |
+| `com.syaru.ae2craftingoptimizer.integration.ExactNetworkStorageBridge` | ME storageへのexact snapshot、reserve、insert、rollbackをAE2権限境界内で行う。 |
+| `com.syaru.ae2craftingoptimizer.integration.ExactNetworkStorageSnapshotCache` | 同一server tick内で完成済みのNetworkStorage在庫集計を再利用する。 |
+| `com.syaru.ae2craftingoptimizer.integration.ExactVectorGridTickBudget` | BigInteger親Jobと標準AQE Jobが共有する、Grid単位のExact Vector tick予算。 |
+| `com.syaru.ae2craftingoptimizer.integration.ExperimentalCompatibilityValidator` | 有効化された実験Mixinの対象クラス、Accessor、内部契約を起動時に監査する。 |
+| `com.syaru.ae2craftingoptimizer.integration.GridStorageSnapshotBridge` | 通常MEネットワーク端末へ、AE2 StorageServiceが管理する同じ在庫Snapshotを複製する。 |
+| `com.syaru.ae2craftingoptimizer.integration.NeoEcoVersionCompatibility` | Neo ECOの実行API世代を、Mixinが参照する前に文字列だけで判定する。 |
+| `com.syaru.ae2craftingoptimizer.integration.OptionalAqeBigCraftingExecution` | Advanced AE未導入環境で対象クラスを解決しないための遅延境界。 |
+| `com.syaru.ae2craftingoptimizer.integration.OptionalNativeBatchIntegrations` | 動作確認済みの依存MODバージョンに限ってNative Batch Adapterを遅延登録する。 |
+| `com.syaru.ae2craftingoptimizer.integration.ProgramFingerprintRevalidationCache` | 現在のPattern/recipe世代で再検証済みの数式Program指紋を保持する。 |
+
+### `com.syaru.ae2craftingoptimizer.intent`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.intent.InputIntent` | Providerが機械へ渡した具体的なItem、Fluid、Chemical入力を不変値で表す。 |
+| `com.syaru.ae2craftingoptimizer.intent.IntentLocation` | Intentの送信元Provider、Level、位置、方向を特定する。 |
+| `com.syaru.ae2craftingoptimizer.intent.PatternIntentCapture` | Pattern push直前のrecipe intentをthread-local境界へ短期間保存する。 |
+| `com.syaru.ae2craftingoptimizer.intent.PatternIntentExtractor` | AE2 Patternから機械検索用の入力、出力、recipe種別hintを抽出する。 |
+| `com.syaru.ae2craftingoptimizer.intent.RecipeIntent` | 一回のPattern pushが作ろうとするrecipeとexact入出力の読取専用表現。 |
+| `com.syaru.ae2craftingoptimizer.intent.RecipeIntentRegistry` | RecipeIntentRegistryが示す実装またはHostの登録、解除、検索を管理する。 |
+| `com.syaru.ae2craftingoptimizer.intent.RecipeIntentSignature` | RecipeIntentSignatureが示す対象を、順序と内容から安定して識別する。 |
+| `com.syaru.ae2craftingoptimizer.intent.StackIntent` | 一つのItem、Fluid、Chemicalと要求量をrecipe intent内で表す。 |
+
+### `com.syaru.ae2craftingoptimizer.lifecycle`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.lifecycle.ACOServerLifecycle` | サーバーの開始・tick・データ再読込・停止に伴うACO状態を一元管理する。 |
+| `com.syaru.ae2craftingoptimizer.lifecycle.ACOStartupReport` | 起動時に有効機能と安全上限を一度だけ報告する。 |
+
+### `com.syaru.ae2craftingoptimizer.mekanism`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.mekanism.MekanismNativeBatchBridge` | MekanismNativeBatchBridgeが示す二つのAPI境界を接続し、対応不能時は元の所有者へ判断を戻す。 |
+| `com.syaru.ae2craftingoptimizer.mekanism.MekanismNativePatternBatchAdapter` | MekanismのItem・Fluid・Chemical入力を完全一致でまとめて受理させるAdapter。 |
+| `com.syaru.ae2craftingoptimizer.mekanism.MekanismRecipeIntentFastPath` | Provider Intentに一致するMekanism recipe候補だけを優先し、CachedRecipeの成立判定へ渡す。 |
+
+### `com.syaru.ae2craftingoptimizer.mixin`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.mixin.AcoMixinPlugin` | AcoMixinPluginが担当するMixin群の適用可否を、対象MODと対応版から決定する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeBigCapacityPlanSubmissionMixin` | AdvancedAeBigCapacityPlanSubmissionMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingBlockEntityTransactionAccessMixin` | AdvancedAeCraftingBlockEntityTransactionAccessMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingClusterBigWindowMixin` | AdvancedAeCraftingClusterBigWindowMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingCpuAccessorMixin` | AdvancedAeCraftingCpuAccessorMixinの対象となる非公開状態を型付きAccessorとして公開するMixin。 |
+| `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingCpuClusterRecoveryMixin` | AdvancedAeCraftingCpuClusterRecoveryMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingCpuLogicBatchSourceReceiptMixin` | AdvancedAeCraftingCpuLogicBatchSourceReceiptMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingCpuLogicBigChildMixin` | AdvancedAeCraftingCpuLogicBigChildMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingCpuLogicExecutionBudgetMixin` | AdvancedAeCraftingCpuLogicExecutionBudgetMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingCpuLogicTransactionalBatchV2Mixin` | AdvancedAeCraftingCpuLogicTransactionalBatchV2Mixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingCpuTransactionAccessMixin` | AdvancedAeCraftingCpuTransactionAccessMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeExactCraftingLogicMixin` | AdvancedAeExactCraftingLogicMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeExecutingCraftingJobTransactionAccessMixin` | AdvancedAeExecutingCraftingJobTransactionAccessMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.AdvancedAePatternProviderIntentCaptureMixin` | AdvancedAePatternProviderIntentCaptureMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.AdvancedAePatternProviderLogicNativeBatchReceiptMixin` | AdvancedAePatternProviderLogicNativeBatchReceiptMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeReactionChamberRecipeCacheMixin` | AdvancedAeReactionChamberRecipeCacheMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeTaskProgressTransactionAccessMixin` | AdvancedAeTaskProgressTransactionAccessMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.Ae2OverclockMachineReflectionCacheMixin` | Ae2OverclockMachineReflectionCacheMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.Ae2OverclockParallelRuntimeCacheMixin` | Ae2OverclockParallelRuntimeCacheMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.Ae2OverclockRuntimeCacheMixin` | Ae2OverclockRuntimeCacheMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.Ae2ScrollbarReleaseSafetyMixin` | Ae2ScrollbarReleaseSafetyMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.ClientRepoUpdateCoalescingMixin` | ClientRepoUpdateCoalescingMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftAmountMenuLongAmountMixin` | CraftAmountMenuLongAmountMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftAmountScreenLongAmountMixin` | CraftAmountScreenLongAmountMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftConfirmMenuLongAmountMixin` | CraftConfirmMenuLongAmountMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftConfirmScreenBigIntegerMixin` | CraftConfirmScreenBigIntegerMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftConfirmTableRendererBigIntegerMixin` | CraftConfirmTableRendererBigIntegerMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingBlockEntityTransactionAccessMixin` | CraftingBlockEntityTransactionAccessMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingCalculationCheckedMathMixin` | CraftingCalculationCheckedMathMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingCalculationDiagnosticsMixin` | CraftingCalculationDiagnosticsMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingCalculationMemoLifecycleMixin` | CraftingCalculationMemoLifecycleMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingCpuClusterBigCapacityGuardMixin` | CraftingCpuClusterBigCapacityGuardMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingCpuClusterTransactionAccessMixin` | CraftingCpuClusterTransactionAccessMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingCpuHelperFluidFastPathMixin` | CraftingCpuHelperFluidFastPathMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingCpuLogicBatchSourceReceiptMixin` | CraftingCpuLogicBatchSourceReceiptMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingCpuLogicExecutionBudgetMixin` | CraftingCpuLogicExecutionBudgetMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingCpuLogicTransactionalBatchV2Mixin` | CraftingCpuLogicTransactionalBatchV2Mixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingPlanSummaryWidePlanMixin` | CraftingPlanSummaryWidePlanMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingProviderRefreshCoalescingMixin` | CraftingProviderRefreshCoalescingMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingServiceCalculationDeduplicationMixin` | CraftingServiceCalculationDeduplicationMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingServiceInvalidationMixin` | CraftingServiceInvalidationMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingServicePatternLookupCacheMixin` | CraftingServicePatternLookupCacheMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingSimulationStateCheckedMathMixin` | CraftingSimulationStateCheckedMathMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingTreeCalculationMemoMixin` | CraftingTreeCalculationMemoMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingTreeCandidatePruningMixin` | CraftingTreeCandidatePruningMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingTreeNodeCheckedMathMixin` | CraftingTreeNodeCheckedMathMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.CraftingTreeProcessCheckedMathMixin` | CraftingTreeProcessCheckedMathMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.DelegatingMEInventoryAccessor` | DelegatingMEInventoryAccessorの対象となる非公開状態を型付きAccessorとして公開するMixin。 |
+| `com.syaru.ae2craftingoptimizer.mixin.ExecutingCraftingJobTransactionAccessMixin` | ExecutingCraftingJobTransactionAccessMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.ExtendedAeAssemblerMatrixClusterCacheMixin` | ExtendedAeAssemblerMatrixClusterCacheMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.ExtendedAeAssemblerMatrixCrafterCacheMixin` | ExtendedAeAssemblerMatrixCrafterCacheMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.ExtendedAeCircuitCutterRecipeCacheMixin` | ExtendedAeCircuitCutterRecipeCacheMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.ExtendedAePlusAssemblerMatrixBusyCaptureMixin` | ExtendedAePlusAssemblerMatrixBusyCaptureMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.ExtendedAePlusBigIntegerCellConsistencyMixin` | ExtendedAePlusBigIntegerCellConsistencyMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.ExtendedAePlusBigIntegerCellInventoryAccessor` | ExtendedAePlusBigIntegerCellInventoryAccessorの対象となる非公開状態を型付きAccessorとして公開するMixin。 |
+| `com.syaru.ae2craftingoptimizer.mixin.ExtendedAePlusInfinityDataStorageConsistencyMixin` | ExtendedAePlusInfinityDataStorageConsistencyMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.GenericStackInvGenerationMixin` | GenericStackInvGenerationMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.GTCEuRecipeLogicIntentFastPathMixin` | GTCEuRecipeLogicIntentFastPathMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.IncrementalUpdateHelperDeepRangeMixin` | IncrementalUpdateHelperDeepRangeMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.KeyCounterBigIntegerSidecarLifecycleMixin` | KeyCounterBigIntegerSidecarLifecycleMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.ListCraftingInventoryExactCountsMixin` | ListCraftingInventoryExactCountsMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.MEInventoryUpdatePacketBuilderRangeMixin` | MEInventoryUpdatePacketBuilderRangeMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.MekanismCachedRecipeAccessor` | MekanismCachedRecipeAccessorの対象となる非公開状態を型付きAccessorとして公開するMixin。 |
+| `com.syaru.ae2craftingoptimizer.mixin.MekanismRecipeIntentFastPathMixin` | MekanismRecipeIntentFastPathMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.MEStorageMenuGridSnapshotReuseMixin` | MEStorageMenuGridSnapshotReuseMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.MultiCraftingTrackerCraftRequestThrottleMixin` | MultiCraftingTrackerCraftRequestThrottleMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.NeoEco20_3CraftingCpuExecutionBudgetMixin` | NeoEco20_3CraftingCpuExecutionBudgetMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.NeoEco20_4CraftingCpuExecutionBudgetMixin` | NeoEco20_4CraftingCpuExecutionBudgetMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.NeoEcoExecutionBudgetSupport` | Neo ECO 20.3/20.4の記述子差分から独立した、共通の実行予算計算。 |
+| `com.syaru.ae2craftingoptimizer.mixin.NetworkCraftingSimulationStateAccessor` | NetworkCraftingSimulationStateAccessorの対象となる非公開状態を型付きAccessorとして公開するMixin。 |
+| `com.syaru.ae2craftingoptimizer.mixin.NetworkCraftingSimulationStateBigIntegerSnapshotMixin` | NetworkCraftingSimulationStateBigIntegerSnapshotMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.NetworkStorageBigIntegerSnapshotMixin` | NetworkStorageBigIntegerSnapshotMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.NetworkStorageMountsAccessor` | NetworkStorageMountsAccessorの対象となる非公開状態を型付きAccessorとして公開するMixin。 |
+| `com.syaru.ae2craftingoptimizer.mixin.NumberEntryWidgetAccessor` | NumberEntryWidgetAccessorの対象となる非公開状態を型付きAccessorとして公開するMixin。 |
+| `com.syaru.ae2craftingoptimizer.mixin.P2PServiceTopologyDeduplicationMixin` | P2PServiceTopologyDeduplicationMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.PatternProviderLogicIntentCaptureMixin` | PatternProviderLogicIntentCaptureMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.PatternProviderLogicNativeBatchReceiptMixin` | PatternProviderLogicNativeBatchReceiptMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.StorageServiceDeepCoalescingMixin` | StorageServiceDeepCoalescingMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.StorageServiceExactSnapshotInvalidationMixin` | StorageServiceExactSnapshotInvalidationMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.StorageServiceWatcherThrottleMixin` | StorageServiceWatcherThrottleMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.TaskProgressTransactionAccessMixin` | TaskProgressTransactionAccessMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+
+### `com.syaru.ae2craftingoptimizer.network`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.network.BigCraftingNetwork` | BigInteger Host状態とlongルート注文を運ぶProtocol Version付き通信Channel。 |
+
+### `com.syaru.ae2craftingoptimizer.optimization`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.optimization.Ae2OverclockUpgradeCountCache` | Ae2OverclockUpgradeCountCacheが示す既知結果を世代またはrevision付きで再利用し、変化時に失効する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.AssemblerMatrixBusyCountCache` | AssemblerMatrixBusyCountCacheが示す既知結果を世代またはrevision付きで再利用し、変化時に失効する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.BatchedCraftingExecutor` | 機械が正確に受理した実行数だけをまとめて会計する旧Batch実行器。 |
+| `com.syaru.ae2craftingoptimizer.optimization.BatchExecutionOffer` | 物理配送回数と、一つのNative Batchが所有する論理実行係数を分離する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.BatchMinimumExecutionPolicy` | Native Batchを開始する最小実行回数の共通検証。 |
+| `com.syaru.ae2craftingoptimizer.optimization.BigIntegerPlanDeclineReason` | BigInteger計画を採用できなかった理由を、ログと統計で安定して識別するコード。 |
+| `com.syaru.ae2craftingoptimizer.optimization.BigIntegerPlanDiagnostics` | BigInteger経路の採用・辞退理由を、計算結果と分離して記録する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.BusFuzzySearchCache` | BusFuzzySearchCacheが示す既知結果を世代またはrevision付きで再利用し、変化時に失効する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.BusTransferSimulationCache` | BusTransferSimulationCacheが示す既知結果を世代またはrevision付きで再利用し、変化時に失効する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.CircuitCutterRecipeCache` | CircuitCutterRecipeCacheが示す既知結果を世代またはrevision付きで再利用し、変化時に失効する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.ConfigInventoryGenerationAccess` | BusやProviderの設定Inventoryに変更世代を付与する最小Access契約。 |
+| `com.syaru.ae2craftingoptimizer.optimization.CraftableSetCache` | CraftableSetCacheが示す既知結果を世代またはrevision付きで再利用し、変化時に失効する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.CraftingCalculationDeduplicator` | 同一世代・同一注文の計算Futureを共有し、待機者と取消所有権を分離する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.CraftingCalculationDiagnostics` | CraftingCalculationDiagnosticsが示す診断理由と観測値を集約する。ゲーム結果は変更しない。 |
+| `com.syaru.ae2craftingoptimizer.optimization.CraftingCalculationMemo` | 一回のクラフト計算内で在庫照会、候補、返却物などの純粋結果を共有する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.CraftingExecutionBudget` | CraftingExecutionBudgetが示す上限、時間予算、適格条件を副作用なしで判定する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.CraftingRequestThrottle` | CraftingRequestThrottleが示す仕事へtick予算を配分し、公平性とbackpressureを維持する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.DeepRangeUpdateHelper` | 端末の巨大な差分範囲を上限付きchunkへ分け、順序を保って同期する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.DeterministicCraftingPreflight` | DeterministicCraftingPreflightが示す入力や互換条件を検証し、証明不能な高速経路を拒否する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.DeterministicMissingProof` | DeterministicMissingProofが示す所有権移転または完了事実を、検証可能な証跡として保持する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.ExactBatchInputLimiter` | 一回分のキー別入力合計から、signed-longで安全に所有できる実行回数を求める。 |
+| `com.syaru.ae2craftingoptimizer.optimization.GridTickBudget` | GridTickBudgetが示す上限、時間予算、適格条件を副作用なしで判定する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.MethodHandleInvocationCache` | MethodHandleInvocationCacheが示す既知結果を世代またはrevision付きで再利用し、変化時に失効する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.MissingOnlyCraftingPlan` | MissingOnlyCraftingPlanが示すクラフト計画またはコンパイル済みプログラムを不変値として保持する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.NativeBatchTargetGuard` | NativeBatchTargetGuardが示す入力や互換条件を検証し、証明不能な高速経路を拒否する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.OptimizationMetrics` | OptimizationMetricsが示す診断理由と観測値を集約する。ゲーム結果は変更しない。 |
+| `com.syaru.ae2craftingoptimizer.optimization.P2PNotificationDeduplicator` | 同一tick・同一topology世代の重複P2P通知を一度へまとめる。 |
+| `com.syaru.ae2craftingoptimizer.optimization.PatternAvailabilitySorter` | 直前成功や利用可能性をhintに候補順だけを変え、適格性判定は変更しない。 |
+| `com.syaru.ae2craftingoptimizer.optimization.PatternCandidatePruner` | 証明済みの非候補だけを計算前に除外し、曖昧なら元候補集合を維持する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.PatternLookupCache` | PatternLookupCacheが示す既知結果を世代またはrevision付きで再利用し、変化時に失効する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.PatternProviderBatchEligibility` | Pattern ProviderをBatch対象にできるか、所有権・入力・target能力から保守的に判定する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.PatternPushContext` | PatternPushContextが示す一回の要求に必要な入力、所有者、実行条件を保持する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.ProviderPatternGenerationTracker` | ProviderPatternGenerationTrackerが示す世代、進捗、tick時刻を単調に追跡する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.ReactionChamberRecipeCache` | ReactionChamberRecipeCacheが示す既知結果を世代またはrevision付きで再利用し、変化時に失効する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.ReflectionLookupCache` | ReflectionLookupCacheが示す既知結果を世代またはrevision付きで再利用し、変化時に失効する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.SequentialInstantDispatcher` | AE2本来のexecuteCraftingを小さな計測波へ分け、同じserver tick内で時間予算まで継続する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.ServerTickClock` | ServerTickClockが示す世代、進捗、tick時刻を単調に追跡する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.SharedCalculationFuture` | 一つの計算Futureを複数呼出者へ共有し、各待機者の取消を所有Futureの取消と分離する。 |
+| `com.syaru.ae2craftingoptimizer.optimization.StorageWatcherUpdateBuffer` | client可視のstorage差分を上限付きで集約し、screenやtopology変更時に即flushする。 |
+| `com.syaru.ae2craftingoptimizer.optimization.TransactionalCraftingExecutorV2` | Batch V2のprepare、transfer、commit、rollbackをReceipt契約に従って進める。 |
+
+### `com.syaru.ae2craftingoptimizer.scheduler`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.scheduler.DeficitRoundRobinScheduler` | tick予算付きDeficit Round Robin Scheduler。 |
+| `com.syaru.ae2craftingoptimizer.scheduler.FairCraftingJobScheduler` | FairCraftingJobSchedulerが示す仕事へtick予算を配分し、公平性とbackpressureを維持する。 |
+| `com.syaru.ae2craftingoptimizer.scheduler.FairSchedulerPersistentState` | FairSchedulerPersistentStateが示す時点の状態を、検証可能な値として保持する。 |
+| `com.syaru.ae2craftingoptimizer.scheduler.FairSchedulerStateStore` | FairSchedulerStateStoreが示す記録を保存、検索、削除する。 |
+| `com.syaru.ae2craftingoptimizer.scheduler.PatternProviderRoutingCache` | PatternProviderRoutingCacheが示す既知結果を世代またはrevision付きで再利用し、変化時に失効する。 |
+
+### `com.syaru.ae2craftingoptimizer.transaction`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.transaction.BatchConservationLedger` | Native Batch一件の保存則を検証する副作用のない状態機械。 |
+| `com.syaru.ae2craftingoptimizer.transaction.BatchRecoveryCompatibilityBridge` | BatchRecoveryCompatibilityBridgeが示す二つのAPI境界を接続し、対応不能時は元の所有者へ判断を戻す。 |
+| `com.syaru.ae2craftingoptimizer.transaction.BatchTransactionCoordinator` | 一回のNative Batchと永続Journalを結ぶ状態遷移窓口。 |
+| `com.syaru.ae2craftingoptimizer.transaction.BatchTransactionJournal` | Overworld SavedDataへ未完了取引を保存する台帳。 |
+| `com.syaru.ae2craftingoptimizer.transaction.BatchTransactionPhase` | BatchTransactionPhaseが表す実行方針または状態遷移段階を列挙する。 |
+| `com.syaru.ae2craftingoptimizer.transaction.BatchTransactionRecord` | Native Batch一件の不変入力、期待出力、現在Phase、送受信Receiptを保持する永続Record。 |
+| `com.syaru.ae2craftingoptimizer.transaction.BatchTransactionRecovery` | 未完了Journalをtick予算内で再照合する復旧処理。 |
+
+### `com.syaru.ae2craftingoptimizer.util`
+
+| クラス | 仕事 |
+|---|---|
+| `com.syaru.ae2craftingoptimizer.util.StableFingerprint` | StableFingerprintが示す対象を、順序と内容から安定して識別する。 |

--- a/docs/ISSUE_WORKFLOW.md
+++ b/docs/ISSUE_WORKFLOW.md
@@ -6,9 +6,10 @@ ACOの修正は、問題を理解する前にコードへ触らないことを�
 
 1. `docs/PROJECT_CHARTER.md`
 2. `docs/REGRESSION_HISTORY.md`
-3. 対象の`docs/issues/ISSUE-<番号>.md`
-4. 対象クラスの回帰防止コメント
-5. 対応する自動試験と`docs/TESTING.md`
+3. `docs/CLASS_RESPONSIBILITIES.md`
+4. 対象の`docs/issues/ISSUE-<番号>.md`
+5. 対象クラスの回帰防止コメント
+6. 対応する自動試験と`docs/TESTING.md`
 
 ## 実装前
 
@@ -25,7 +26,8 @@ ACOの修正は、問題を理解する前にコードへ触らないことを�
    - 修正方針とfallback境界
    - 先に失敗を確認する回帰試験
 4. 不明点を推測で埋めず、JAR、ソース、API、ログを調査します。
-5. 実装前チェックをすべて満たし、状態を`Ready`へ変更します。
+5. `docs/CLASS_RESPONSIBILITIES.md`で所有クラスと依存方向を確認します。
+6. 実装前チェックをすべて満たし、状態を`Ready`へ変更します。
 
 `Ready`になる前にJava、Mixin、リソース、Config、永続形式を変更してはいけません。
 
@@ -42,7 +44,7 @@ ACOの修正は、問題を理解する前にコードへ触らないことを�
 1. Issue仕様書へ実際の変更ファイルと採用した修正を記録します。
 2. 単体試験、境界試験、故障試験、ビルド結果を記録します。
 3. 未実施の起動、GameTest、実環境試験を明示します。
-4. `docs/REGRESSION_HISTORY.md`へIssueの索引を追加します。
+4. 回帰修正の場合だけ、`docs/REGRESSION_HISTORY.md`へIssueの索引を追加します。
 5. PR本文でIssue仕様書の読了・更新をチェックします。
 6. CI成功後にマージし、PRとリリース番号をIssue仕様書へ追記します。
 

--- a/docs/issues/ISSUE-87.md
+++ b/docs/issues/ISSUE-87.md
@@ -1,0 +1,126 @@
+# Issue #87: ACO全クラスの責務を明文化し安全にリファクタリングする
+
+## 状態
+
+`Verified`
+
+## 対象
+
+- Forge 1.20.1: `mc/1.20.1`
+- NeoForge 1.21.1: `mc/1.21.1`
+- GitHub Issue: https://github.com/syarukasu/ae2-crafting-optimizer/issues/87
+
+## 問題とユーザー影響
+
+ACOは計画、BigInteger会計、物理クラフト、Batch、tick予算、任意MOD連携、通信、診断を
+含むが、全クラスの責務と依存方向を一望できる正本がない。修正者が名前だけで所有権を
+推測すると、Mixinへ業務ロジックを戻す、外部CPUの仕事をACOへ取り込む、同じ検証を
+別実装する、過去回帰の禁止条件を見落とす、といった再発につながる。
+
+## 調査結果
+
+- Forge版はJava source 348件。`package-info.java`を除く本番型は328件。
+- NeoForge版はJava source 374件。`package-info.java`を除く本番型は354件。
+- 最大クラスは`PhysicalCraftingTreeTransaction`で、状態遷移、Receipt、会計、永続化、
+  Pattern identity、scheduler判断を一つに保持する。
+- `ACOConfig`は約1,800行だが、Config keyと説明を一か所へ固定する責務自体は一貫する。
+- `AqeBigCraftingExecutionManager`は外部Host連携の高リスク境界であり、起動試験なしの
+  大分割は今回行わない。
+- 正の`BigInteger`数量Mapの複製、検証、包含判定が`ExactCraftingEscrow`と
+  `PhysicalCraftingTreeTransaction`へ重複している。
+
+## 期待結果
+
+- `docs/CLASS_RESPONSIBILITIES.md`から、各本番クラスの役割と所属レイヤーを確認できる。
+- 新規クラスを追加して責務表を更新し忘れると自動試験が失敗する。
+- BigInteger数量Mapの不変条件を一つの副作用なしヘルパーへ集約する。
+- 既存挙動、公開API、Config、NBT、Packet、Mixin注入位置は変わらない。
+
+## 所有権
+
+- AE2は通常クラフト、Provider、CPU Job、通常在庫操作を所有する。
+- ACO engineは計画とexact数量を所有する。
+- `PhysicalCraftingTreeTransaction`は所有権移転後のEscrow、Receipt、取消、復旧を所有する。
+- 外部CPUアドオンは構造、実行、GUI、電力、進捗を所有する。
+- Mixinは入口とAccessorだけを持ち、計算・会計ロジックを所有しない。
+
+## 維持する不変条件
+
+- 正の数量Mapはnull key、null amount、0、負数を受理しない。
+- Mapの反復順序を保存する。
+- 物理取引の最大キー件数65,536件を維持する。
+- Escrowには今回新しいキー件数上限を追加しない。
+- `containsAll`はMapを変更しない。
+- 加算は`BigInteger`のまま行い、`long`へ変換しない。
+- 空Mapを許可する呼出元と禁止する呼出元の既存契約を維持する。
+
+## やってはいけないこと
+
+- BigInteger正本を`long`へクランプ、飽和、切り捨てする。
+- 所有権移転後にAE2標準経路へfallbackする。
+- NBT schema、Config key、network protocol、公開APIを今回変更する。
+- Mixin対象または注入位置を広げる。
+- 外部MODのCPU、構造、実行、GUI、レシピ、テクスチャをACOへ移す。
+- 巨大クラスを小さく見せるためだけに、相互依存する断片へ機械的に分割する。
+
+## 修正方針
+
+1. `docs/CLASS_RESPONSIBILITIES.md`へレイヤー、依存方向、主要所有権、全本番クラスの
+   一行責務、巨大クラスの今後の分割境界を記録する。
+2. `ClassResponsibilitiesDocumentationTest`を追加し、各本番Java型が文書へ一度以上
+   掲載されることと空の責務説明がないことを検査する。
+3. package-privateな`ExactCountMap`を追加し、正数Mapの検証、順序付き複製、包含判定、
+   正確な加算だけを担当させる。
+4. `ExactCraftingEscrow`と`PhysicalCraftingTreeTransaction`は同ヘルパーへ委譲する。
+5. `ExactCountMapTest`で境界値、順序、不変性、上限、空Map契約を固定する。
+6. 3,000行超クラスの追加分割は、責務表にリスクと推奨境界を残し、別Issueで行う。
+
+## fallback境界
+
+今回の変更は計画または実行経路を追加しない。既存fallback条件には触れない。
+
+## 実装前チェック
+
+- [x] `docs/PROJECT_CHARTER.md`を読んだ
+- [x] `docs/REGRESSION_HISTORY.md`を読んだ
+- [x] Issue #87を作成した
+- [x] 両ローダーのクラス数と最大クラスを調査した
+- [x] 公開API、永続形式、Mixinを変更しない範囲を確定した
+- [x] 状態を`Ready`へ変更した
+
+## 試験計画
+
+- `ExactCountMapTest`
+- `ClassResponsibilitiesDocumentationTest`
+- 既存JUnit全件
+- `git diff --check`
+- Forge 1.20.1 `clean build`（通常AE2および可能ならUELM）
+- NeoForge 1.21.1 `clean build`
+- 起動、GameTest、ゲーム内試験は実施しない
+
+## 実装結果
+
+- `docs/CLASS_RESPONSIBILITIES.md`へ、目的、禁止事項、依存方向、パッケージ責務、
+  大規模クラスの分割判断、全本番トップレベル型328件の一行責務を記録した。
+- `tools/update-class-responsibilities.ps1`を追加し、責務一覧をsourceから再生成可能にした。
+- `ClassResponsibilitiesDocumentationTest`を追加し、sourceと文書の型集合、重複、空説明、
+  placeholder、ローカルパス混入を検査するようにした。
+- `ExactCountMap`へ、正のBigInteger数量Mapの検証、順序付き複製、exact加算、包含判定を
+  集約した。
+- `ExactCraftingEscrow`と`PhysicalCraftingTreeTransaction`の重複実装を同ヘルパーへの
+  委譲へ置換した。公開API、Config、NBT、Packet、Mixin descriptorは変更していない。
+- README、CONTRIBUTING、AGENTS、Issue手順から責務一覧を必須読了文書として参照した。
+
+## 試験結果
+
+- `git diff --check`: 成功
+- 対象JUnit 10件: 成功
+- Forge 1.20.1 upstream AE2 `clean build`: 成功
+- Forge 1.20.1 UELM `clean build`: 341件中失敗0、skip 2
+- NeoForge 1.21.1: 別PRの同義変更で363件中失敗0
+- 起動、GameTest、ゲーム内試験: 指示により未実施
+- リリースとバージョン更新: 内部整理のため実施しない
+
+## Pull Requests
+
+作成前。Forge 1.20.1とNeoForge 1.21.1を別PRにする。

--- a/docs/issues/ISSUE-87.md
+++ b/docs/issues/ISSUE-87.md
@@ -123,4 +123,5 @@ ACOは計画、BigInteger会計、物理クラフト、Batch、tick予算、任�
 
 ## Pull Requests
 
-作成前。Forge 1.20.1とNeoForge 1.21.1を別PRにする。
+- Forge 1.20.1: https://github.com/syarukasu/ae2-crafting-optimizer/pull/88
+- NeoForge 1.21.1: https://github.com/syarukasu/ae2-crafting-optimizer/pull/89

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -6,8 +6,9 @@
 
 1. `../PROJECT_CHARTER.md`
 2. `../REGRESSION_HISTORY.md`
-3. 対象の`ISSUE-<番号>.md`
-4. 対象クラスのコメントと自動試験
+3. `../CLASS_RESPONSIBILITIES.md`
+4. 対象の`ISSUE-<番号>.md`
+5. 対象クラスのコメントと自動試験
 
 新規文書は`TEMPLATE.md`から作り、実装前に状態を`Ready`へ変更します。
 
@@ -15,3 +16,4 @@
 
 - [Issue #79](ISSUE-79.md): 一つのroot内部だけでsigned long境界を超える計画
 - [Issue #84](ISSUE-84.md): Issue先行開発手順とプロジェクト境界
+- [Issue #87](ISSUE-87.md): 全クラスの責務明文化とexact数量Mapの安全な共通化

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/ExactCountMap.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/ExactCountMap.java
@@ -1,0 +1,111 @@
+package com.syaru.ae2craftingoptimizer.engine.craftingtable;
+
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Issue #87: exact数量Mapの不変条件だけを所有する副作用なし共通部品。
+ *
+ * <p>クラフト状態、NBT、AE2在庫には触れず、正数検証、順序付き複製、包含判定、
+ * BigInteger加算だけを行う。</p>
+ */
+final class ExactCountMap {
+    private ExactCountMap() {
+    }
+
+    /** Escrow用。既存契約どおり空Mapを許可し、キー件数上限を新設しない。 */
+    static <K> LinkedHashMap<K, BigInteger> mutablePositiveCopy(
+            Map<K, BigInteger> source,
+            String name) {
+        return copyPositive(source, name, true, null);
+    }
+
+    /** 永続取引用。空Map契約と破損Mapの最大キー件数を呼出側が明示する。 */
+    static <K> Map<K, BigInteger> immutablePositiveCopy(
+            Map<K, BigInteger> source,
+            String name,
+            boolean allowEmpty,
+            int maximumKeys) {
+        // 0以下では全Mapを拒否してしまうため、呼出側の設定ミスとして扱う。
+        if (maximumKeys < 1) {
+            throw new IllegalArgumentException("maximumKeys must be positive");
+        }
+        return Collections.unmodifiableMap(
+                copyPositive(source, name, allowEmpty, maximumKeys));
+    }
+
+    /** 既に検証済みの順序付きMapを、呼出元から変更できないsnapshotへ複製する。 */
+    static <K> Map<K, BigInteger> immutableOrderedCopy(
+            Map<K, BigInteger> source) {
+        return Collections.unmodifiableMap(
+                new LinkedHashMap<>(Objects.requireNonNull(source, "source")));
+    }
+
+    /** 正数だけを同一キーへBigIntegerのまま加算する。 */
+    static <K> void mergePositive(
+            Map<K, BigInteger> target,
+            K key,
+            BigInteger amount) {
+        Objects.requireNonNull(target, "target");
+        Objects.requireNonNull(key, "key");
+        BigInteger checked = Objects.requireNonNull(amount, "amount");
+        // 0以下は存在しないentryと区別できず、会計の正本にはできない。
+        if (checked.signum() <= 0) {
+            throw new IllegalArgumentException(
+                    "exact crafting amount must be positive");
+        }
+        target.merge(key, checked, BigInteger::add);
+    }
+
+    /** 全要求を満たすかだけを確認し、どちらのMapも変更しない。 */
+    static <K> boolean containsAll(
+            Map<K, BigInteger> available,
+            Map<K, BigInteger> required) {
+        Objects.requireNonNull(available, "available");
+        Objects.requireNonNull(required, "required");
+        // 一件でも不足すれば、在庫やEscrowへ触る前にfalseを返す。
+        for (Map.Entry<K, BigInteger> entry : required.entrySet()) {
+            if (available.getOrDefault(entry.getKey(), BigInteger.ZERO)
+                    .compareTo(entry.getValue()) < 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static <K> LinkedHashMap<K, BigInteger> copyPositive(
+            Map<K, BigInteger> source,
+            String name,
+            boolean allowEmpty,
+            Integer maximumKeys) {
+        Objects.requireNonNull(source, name);
+        // 永続取引だけは、破損NBTによる巨大Map確保を既存上限で拒否する。
+        if (maximumKeys != null && source.size() > maximumKeys) {
+            throw new IllegalArgumentException(name + " has too many keys");
+        }
+
+        LinkedHashMap<K, BigInteger> result = new LinkedHashMap<>();
+        // null、0、負数を入れず、保存済みMapの反復順序を維持する。
+        for (Map.Entry<K, BigInteger> entry : source.entrySet()) {
+            K key = Objects.requireNonNull(entry.getKey(), name + " key");
+            BigInteger amount = Objects.requireNonNull(
+                    entry.getValue(),
+                    name + " amount");
+            // 0以下は存在しないentryと区別できないため、Mapへ複製しない。
+            if (amount.signum() <= 0) {
+                throw new IllegalArgumentException(
+                        name + " contains a non-positive amount");
+            }
+            result.put(key, amount);
+        }
+
+        // 空Mapを禁止する台帳だけは、少なくとも一つのexact entryを要求する。
+        if (!allowEmpty && result.isEmpty()) {
+            throw new IllegalArgumentException(name + " must not be empty");
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/ExactCraftingEscrow.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/ExactCraftingEscrow.java
@@ -1,7 +1,6 @@
 package com.syaru.ae2craftingoptimizer.engine.craftingtable;
 
 import java.math.BigInteger;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -37,22 +36,10 @@ public final class ExactCraftingEscrow<K> {
     public boolean containsAll(
             Map<K, BigInteger> required) {
         Map<K, BigInteger> checked =
-                checkedCounts(
+                ExactCountMap.mutablePositiveCopy(
                         required,
                         "required");
-        // 一キーでも不足する場合は、親レシピを物理Workerへ渡さない。
-        for (Map.Entry<K, BigInteger> entry :
-                checked.entrySet()) {
-            // 現在量が必要量未満なら、この依存段はまだ実行不能。
-            if (amount(
-                            entry.getKey())
-                    .compareTo(
-                            entry.getValue())
-                    < 0) {
-                return false;
-            }
-        }
-        return true;
+        return ExactCountMap.containsAll(amounts, checked);
     }
 
     /**
@@ -63,12 +50,11 @@ public final class ExactCraftingEscrow<K> {
     public void debitExact(
             Map<K, BigInteger> required) {
         Map<K, BigInteger> checked =
-                checkedCounts(
+                ExactCountMap.mutablePositiveCopy(
                         required,
                         "required");
         // 事前検査で全キーが揃う場合だけ、後段の減算へ進む。
-        if (!containsAll(
-                checked)) {
+        if (!ExactCountMap.containsAll(amounts, checked)) {
             throw new IllegalStateException(
                     "crafting escrow does not contain every required input");
         }
@@ -96,16 +82,16 @@ public final class ExactCraftingEscrow<K> {
     public void credit(
             Map<K, BigInteger> produced) {
         Map<K, BigInteger> checked =
-                checkedCounts(
+                ExactCountMap.mutablePositiveCopy(
                         produced,
                         "produced");
         // 同じキーの中間素材と返却物は、数量だけを正確に合算する。
         for (Map.Entry<K, BigInteger> entry :
                 checked.entrySet()) {
-            amounts.merge(
+            ExactCountMap.mergePositive(
+                    amounts,
                     entry.getKey(),
-                    entry.getValue(),
-                    BigInteger::add);
+                    entry.getValue());
         }
     }
 
@@ -114,50 +100,17 @@ public final class ExactCraftingEscrow<K> {
     }
 
     public Map<K, BigInteger> snapshot() {
-        return Collections.unmodifiableMap(
-                new LinkedHashMap<>(
-                        amounts));
+        return ExactCountMap.immutableOrderedCopy(amounts);
     }
 
     public void restore(
             Map<K, BigInteger> restored) {
         Map<K, BigInteger> checked =
-                checkedCounts(
+                ExactCountMap.mutablePositiveCopy(
                         restored,
                         "restored");
         amounts.clear();
         amounts.putAll(
                 checked);
-    }
-
-    private static <K> Map<K, BigInteger> checkedCounts(
-            Map<K, BigInteger> source,
-            String name) {
-        Objects.requireNonNull(
-                source,
-                name);
-        Map<K, BigInteger> result =
-                new LinkedHashMap<>();
-        // Escrowへはnull、0、負数を入れず、保存順をそのまま維持する。
-        for (Map.Entry<K, BigInteger> entry :
-                source.entrySet()) {
-            K key =
-                    Objects.requireNonNull(
-                            entry.getKey(),
-                            name + " key");
-            BigInteger amount =
-                    Objects.requireNonNull(
-                            entry.getValue(),
-                            name + " amount");
-            // 0以下の値は「存在しないキー」と区別できないため拒否する。
-            if (amount.signum() <= 0) {
-                throw new IllegalArgumentException(
-                        name + " contains a non-positive amount");
-            }
-            result.put(
-                    key,
-                    amount);
-        }
-        return result;
     }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/PhysicalCraftingTreeTransaction.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/PhysicalCraftingTreeTransaction.java
@@ -24,7 +24,6 @@ import com.syaru.ae2craftingoptimizer.scheduler.PatternProviderRoutingCache;
 import com.syaru.ae2craftingoptimizer.util.StableFingerprint;
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -2209,67 +2208,19 @@ public final class PhysicalCraftingTreeTransaction {
             Map<K, BigInteger> target,
             K key,
             BigInteger amount) {
-        Objects.requireNonNull(
-                key,
-                "key");
-        BigInteger checked =
-                Objects.requireNonNull(
-                        amount,
-                        "amount");
-        // 0以下を在庫へ入れず、同一キーはBigInteger加算で一行に畳み込む。
-        if (checked.signum() <= 0) {
-            throw new IllegalArgumentException(
-                    "exact crafting amount must be positive");
-        }
-        target.merge(
-                key,
-                checked,
-                BigInteger::add);
+        ExactCountMap.mergePositive(target, key, amount);
     }
 
     private static <K> Map<K, BigInteger> checkedCounts(
             Map<K, BigInteger> source,
             String name,
             boolean allowEmpty) {
-        Objects.requireNonNull(
+        // 65,536件は数量上限ではなく、破損NBTによる巨大Map確保を防ぐ既存上限。
+        return ExactCountMap.immutablePositiveCopy(
                 source,
-                name);
-        // キー件数上限は数量ではなく、破損NBTによる巨大Map確保だけを防ぐ。
-        if (source.size()
-                > MAXIMUM_EXACT_KEYS) {
-            throw new IllegalArgumentException(
-                    name + " has too many keys");
-        }
-        Map<K, BigInteger> result =
-                new LinkedHashMap<>();
-        // 各キーを正数BigIntegerとして順序付き不変Mapへ複製する。
-        for (Map.Entry<K, BigInteger> entry :
-                source.entrySet()) {
-            K key =
-                    Objects.requireNonNull(
-                            entry.getKey(),
-                            name + " key");
-            BigInteger amount =
-                    Objects.requireNonNull(
-                            entry.getValue(),
-                            name + " amount");
-            // 0以下のentryは存在しないキーと区別できないため拒否する。
-            if (amount.signum() <= 0) {
-                throw new IllegalArgumentException(
-                        name + " contains a non-positive amount");
-            }
-            result.put(
-                    key,
-                    amount);
-        }
-        // 呼出側が空を許可しない台帳には一件以上を要求する。
-        if (!allowEmpty
-                && result.isEmpty()) {
-            throw new IllegalArgumentException(
-                    name + " must not be empty");
-        }
-        return immutableOrderedMap(
-                result);
+                name,
+                allowEmpty,
+                MAXIMUM_EXACT_KEYS);
     }
 
     private static Map<String, PatternAccountingIdentity> checkedPatternIdentities(
@@ -2436,9 +2387,7 @@ public final class PhysicalCraftingTreeTransaction {
 
     private static <K> Map<K, BigInteger> immutableOrderedMap(
             Map<K, BigInteger> source) {
-        return Collections.unmodifiableMap(
-                new LinkedHashMap<>(
-                        source));
+        return ExactCountMap.immutableOrderedCopy(source);
     }
 
     private static ListTag encodeCounts(
@@ -2579,21 +2528,7 @@ public final class PhysicalCraftingTreeTransaction {
     private static <K> boolean containsAll(
             Map<K, BigInteger> available,
             Map<K, BigInteger> required) {
-        // 全要求キーが正確な在庫量以下の場合だけ、Batch抽出を許可する。
-        for (Map.Entry<K, BigInteger> entry :
-                required.entrySet()) {
-            // 一件でも不足すればセルへ触る前にfalseを返す。
-            if (available
-                            .getOrDefault(
-                                    entry.getKey(),
-                                    BigInteger.ZERO)
-                            .compareTo(
-                                    entry.getValue())
-                    < 0) {
-                return false;
-            }
-        }
-        return true;
+        return ExactCountMap.containsAll(available, required);
     }
 
     private static ListTag requireCompoundList(

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/ExactCountMapTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/ExactCountMapTest.java
@@ -1,0 +1,117 @@
+package com.syaru.ae2craftingoptimizer.engine.craftingtable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Issue #87: 物理取引とEscrowが共有するexact数量Map契約を固定する。 */
+class ExactCountMapTest {
+    /** 2件上限の境界内・境界超過を小さいfixtureで検査する。 */
+    private static final int TWO_KEYS = 2;
+
+    /** longを十分超えるexact値を軽量に検査する。 */
+    private static final int LARGE_DECIMAL_DIGITS = 128;
+
+    @Test
+    void mutablePositiveCopyPreservesOrderAndExactAmounts() {
+        BigInteger beyondLong = BigInteger.TEN.pow(LARGE_DECIMAL_DIGITS);
+        LinkedHashMap<String, BigInteger> source = new LinkedHashMap<>();
+        source.put("first", beyondLong);
+        source.put("second", BigInteger.ONE);
+
+        Map<String, BigInteger> copy =
+                ExactCountMap.mutablePositiveCopy(source, "source");
+        source.clear();
+
+        assertEquals(java.util.List.of("first", "second"), new ArrayList<>(copy.keySet()));
+        assertEquals(beyondLong, copy.get("first"));
+        copy.put("third", BigInteger.TWO);
+        assertEquals(BigInteger.TWO, copy.get("third"));
+    }
+
+    @Test
+    void immutablePositiveCopyPreservesEmptyAndMaximumKeyContracts() {
+        Map<String, BigInteger> empty = ExactCountMap.immutablePositiveCopy(
+                Map.of(),
+                "empty",
+                true,
+                TWO_KEYS);
+        assertTrue(empty.isEmpty());
+        assertThrows(UnsupportedOperationException.class,
+                () -> empty.put("key", BigInteger.ONE));
+
+        Map<String, BigInteger> tooMany = new LinkedHashMap<>();
+        tooMany.put("one", BigInteger.ONE);
+        tooMany.put("two", BigInteger.ONE);
+        tooMany.put("three", BigInteger.ONE);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ExactCountMap.immutablePositiveCopy(
+                        tooMany,
+                        "counts",
+                        true,
+                        TWO_KEYS));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ExactCountMap.immutablePositiveCopy(
+                        Map.of(),
+                        "required",
+                        false,
+                        TWO_KEYS));
+    }
+
+    @Test
+    void positiveCopiesRejectZeroNegativeAndNullAmounts() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ExactCountMap.mutablePositiveCopy(
+                        Map.of("zero", BigInteger.ZERO),
+                        "counts"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ExactCountMap.mutablePositiveCopy(
+                        Map.of("negative", BigInteger.ONE.negate()),
+                        "counts"));
+
+        Map<String, BigInteger> nullAmount = new LinkedHashMap<>();
+        nullAmount.put("null", null);
+        assertThrows(
+                NullPointerException.class,
+                () -> ExactCountMap.mutablePositiveCopy(nullAmount, "counts"));
+    }
+
+    @Test
+    void containsAllIsExactAndDoesNotMutateEitherMap() {
+        BigInteger beyondLong = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        Map<String, BigInteger> available = new LinkedHashMap<>(Map.of("key", beyondLong));
+        Map<String, BigInteger> exact = new LinkedHashMap<>(Map.of("key", beyondLong));
+        Map<String, BigInteger> tooLarge =
+                new LinkedHashMap<>(Map.of("key", beyondLong.add(BigInteger.ONE)));
+
+        assertTrue(ExactCountMap.containsAll(available, exact));
+        assertFalse(ExactCountMap.containsAll(available, tooLarge));
+        assertEquals(Map.of("key", beyondLong), available);
+        assertEquals(Map.of("key", beyondLong), exact);
+    }
+
+    @Test
+    void mergePositiveAddsWithoutLongProjection() {
+        BigInteger beyondLong = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        Map<String, BigInteger> target = new LinkedHashMap<>();
+
+        ExactCountMap.mergePositive(target, "key", beyondLong);
+        ExactCountMap.mergePositive(target, "key", beyondLong);
+
+        assertEquals(beyondLong.multiply(BigInteger.TWO), target.get("key"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ExactCountMap.mergePositive(target, "key", BigInteger.ZERO));
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/ClassResponsibilitiesDocumentationTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/ClassResponsibilitiesDocumentationTest.java
@@ -1,0 +1,118 @@
+package com.syaru.ae2craftingoptimizer.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/** Issue #87: 本番トップレベル型の責務が文書から静かに消えることを防ぐ。 */
+class ClassResponsibilitiesDocumentationTest {
+    private static final Path PRODUCTION_ROOT = Path.of("src", "main", "java");
+    private static final Path RESPONSIBILITIES =
+            Path.of("docs", "CLASS_RESPONSIBILITIES.md");
+    private static final Pattern PACKAGE_DECLARATION =
+            Pattern.compile("(?m)^package\\s+([A-Za-z0-9_.]+);");
+    private static final Pattern RESPONSIBILITY_ROW = Pattern.compile(
+            "^\\| `(?<type>com\\.syaru\\.ae2craftingoptimizer"
+                    + "(?:\\.[a-z][A-Za-z0-9_]*)*\\.[A-Z][A-Za-z0-9_]*)` "
+                    + "\\| (?<role>.+) \\|$");
+
+    @Test
+    void everyProductionTopLevelTypeHasExactlyOneConcreteResponsibility() throws IOException {
+        Set<String> sourceTypes = productionTypes();
+        Map<String, String> documentedTypes = documentedTypes();
+
+        assertEquals(
+                sourceTypes,
+                documentedTypes.keySet(),
+                () -> "責務一覧と本番型が一致しない。source only="
+                        + difference(sourceTypes, documentedTypes.keySet())
+                        + ", docs only="
+                        + difference(documentedTypes.keySet(), sourceTypes));
+    }
+
+    @Test
+    void generatedDocumentDoesNotContainPlaceholdersOrLocalPaths() {
+        String document = read(RESPONSIBILITIES);
+
+        assertFalse(document.contains("クラス名どおり"));
+        assertFalse(document.contains("TODO"));
+        assertFalse(document.contains("C:\\Users\\"));
+        assertFalse(document.contains("file://"));
+    }
+
+    private static Set<String> productionTypes() throws IOException {
+        Set<String> result = new TreeSet<>();
+        try (Stream<Path> files = Files.walk(PRODUCTION_ROOT)) {
+            files.filter(path -> path.toString().endsWith(".java"))
+                    .filter(path -> !path.getFileName().toString().equals("package-info.java"))
+                    .forEach(path -> result.add(productionType(path)));
+        }
+        return result;
+    }
+
+    private static String productionType(Path path) {
+        String source = read(path);
+        Matcher packageMatcher = PACKAGE_DECLARATION.matcher(source);
+        assertTrue(
+                packageMatcher.find(),
+                () -> "package宣言がない本番型: " + path);
+        String fileName = path.getFileName().toString();
+        String simpleName = fileName.substring(0, fileName.length() - ".java".length());
+        Pattern topLevelType = Pattern.compile(
+                "(?m)^\\s*(?:public\\s+)?(?:(?:final|abstract|sealed|non-sealed)\\s+)*"
+                        + "(?:class|record|interface|enum|@interface)\\s+"
+                        + Pattern.quote(simpleName)
+                        + "\\b");
+        assertTrue(
+                topLevelType.matcher(source).find(),
+                () -> "ファイル名と一致するトップレベル型がない: " + path);
+        return packageMatcher.group(1) + "." + simpleName;
+    }
+
+    private static Map<String, String> documentedTypes() {
+        Map<String, String> result = new LinkedHashMap<>();
+        // 全クラス表のFQCN行だけを読み、上部のレビュー表や本文中の参照は数えない。
+        for (String line : read(RESPONSIBILITIES).lines().toList()) {
+            Matcher row = RESPONSIBILITY_ROW.matcher(line);
+            // 表形式以外の行は責務entryではないため読み飛ばす。
+            if (!row.matches()) {
+                continue;
+            }
+            String type = row.group("type");
+            String role = row.group("role").trim();
+            assertFalse(role.isBlank(), () -> "責務が空: " + type);
+            assertFalse(role.endsWith("担当する。") && role.contains("クラス名どおり"));
+            String previous = result.put(type, role);
+            assertNull(previous, () -> "責務一覧に重複した型がある: " + type);
+        }
+        return result;
+    }
+
+    private static Set<String> difference(Set<String> left, Set<String> right) {
+        Set<String> result = new TreeSet<>(left);
+        result.removeAll(right);
+        return result;
+    }
+
+    private static String read(Path path) {
+        try {
+            return Files.readString(path);
+        } catch (IOException exception) {
+            throw new UncheckedIOException(path.toString(), exception);
+        }
+    }
+}

--- a/tools/update-class-responsibilities.ps1
+++ b/tools/update-class-responsibilities.ps1
@@ -1,0 +1,448 @@
+param(
+    [string]$RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$sourceRoot = Join-Path $RepositoryRoot 'src/main/java'
+$outputPath = Join-Path $RepositoryRoot 'docs/CLASS_RESPONSIBILITIES.md'
+
+$packageRoles = [ordered]@{
+    'com.syaru.ae2craftingoptimizer' = '起動、Forge/NeoForgeイベント接続、全体初期化。'
+    'com.syaru.ae2craftingoptimizer.access' = 'Mixinが外部クラスの内部状態を型付きで公開する契約。判断ロジックは持たない。'
+    'com.syaru.ae2craftingoptimizer.api.batch' = '旧Pattern Batch公開API。互換性維持を優先する。'
+    'com.syaru.ae2craftingoptimizer.api.batch.v2' = '所有権、Receipt、commit、復旧を明示するTransactional Batch公開API。'
+    'com.syaru.ae2craftingoptimizer.api.big' = 'BigInteger計画、Host、進捗、公開連携API。'
+    'com.syaru.ae2craftingoptimizer.api.contract' = '1.21.1連携向けの版付きpayload、revision、Receipt契約。'
+    'com.syaru.ae2craftingoptimizer.api.craftingtable' = '作業台物理Batch Workerとの公開契約。'
+    'com.syaru.ae2craftingoptimizer.api.execution' = 'Exact Vector実行所有者を宣言する公開契約。'
+    'com.syaru.ae2craftingoptimizer.api.vector' = 'exact数量のVector計画、保存、Storage境界API。'
+    'com.syaru.ae2craftingoptimizer.batch' = 'Pattern Batchの完全一致、Escrow、Receipt、再照合。'
+    'com.syaru.ae2craftingoptimizer.client' = 'クライアント表示、入力、BigInteger表示用state。'
+    'com.syaru.ae2craftingoptimizer.command' = '観測と安全な失効だけを行う診断コマンド。'
+    'com.syaru.ae2craftingoptimizer.config' = '機能スイッチ、上限、時間予算のCommon Config。'
+    'com.syaru.ae2craftingoptimizer.craftingamount' = 'long注文数をAE2 Menuへ渡すserver側境界。'
+    'com.syaru.ae2craftingoptimizer.engine' = 'コンパイル済みグラフ、Planner、BigInteger会計の計算核。'
+    'com.syaru.ae2craftingoptimizer.engine.craftingtable' = '所有権移転後の作業台物理クラフト取引、Escrow、復旧。'
+    'com.syaru.ae2craftingoptimizer.engine.vector' = 'exact Vector計画の検証、在庫snapshot、表示投影。'
+    'com.syaru.ae2craftingoptimizer.gtceu' = 'GTCEu Recipe IntentとNative Batchの任意連携。'
+    'com.syaru.ae2craftingoptimizer.integration' = 'AE2、Advanced AE、任意MOD、exact storageへの版別接続。'
+    'com.syaru.ae2craftingoptimizer.intent' = 'Providerが意図するrecipeを短期間伝える検索hint。'
+    'com.syaru.ae2craftingoptimizer.lifecycle' = 'server起動、停止、reload、registry accessの順序管理。'
+    'com.syaru.ae2craftingoptimizer.mekanism' = 'Mekanism Recipe IntentとNative Batchの任意連携。'
+    'com.syaru.ae2craftingoptimizer.mixin' = '外部処理へ薄い入口を追加するMixinと適用plugin。'
+    'com.syaru.ae2craftingoptimizer.network' = 'BigInteger容量と進捗を同期する版付き通信路。'
+    'com.syaru.ae2craftingoptimizer.optimization' = '世代付きcache、時間予算、診断、保守的高速経路。'
+    'com.syaru.ae2craftingoptimizer.scheduler' = 'ジョブとProviderへtick予算を公平配分するscheduler。'
+    'com.syaru.ae2craftingoptimizer.transaction' = 'Native Batch取引、Journal、再起動復旧、収支検査。'
+    'com.syaru.ae2craftingoptimizer.util' = '副作用を持たないfingerprintなどの共通処理。'
+}
+
+$overrides = @{
+    'com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer' = 'MOD entrypoint。Config、network、lifecycle、optional integrationを登録し、個別計算は各層へ委譲する。'
+    'com.syaru.ae2craftingoptimizer.config.ACOConfig' = '全Common Config key、既定値、範囲、説明を登録する唯一のConfig正本。'
+    'com.syaru.ae2craftingoptimizer.engine.Ae2AuthoritativeCraftingPlanner' = 'Shadow一致済みの決定的rootだけをACO計画へ昇格し、証明不能なら採用を辞退する。'
+    'com.syaru.ae2craftingoptimizer.engine.Ae2BigCraftingPlanFactory' = 'AE2 Pattern木からexact BigInteger計画とsimulation不足計画を構築する。'
+    'com.syaru.ae2craftingoptimizer.engine.Ae2CompiledCraftingGraphCache' = 'Pattern世代ごとのコンパイル済みグラフsnapshotを保持し、世代変更で失効する。'
+    'com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars' = '純正AE2 CraftingPlanへexact真値をidentity関連付けし、外部型互換を維持する。'
+    'com.syaru.ae2craftingoptimizer.engine.Ae2StrictCraftingTopology' = '代替、循環、返却物などを検査し、数式計画へ安全に変換できるPattern DAGだけを認定する。'
+    'com.syaru.ae2craftingoptimizer.engine.BigCraftingJob' = 'BigInteger注文の永続状態とlong実行Windowの貸出・回収を管理する。'
+    'com.syaru.ae2craftingoptimizer.engine.CompiledRootProgram' = '一つのrootから到達する決定的DAGを配列プログラムへ変換し、数量に依存しない計算を行う。'
+    'com.syaru.ae2craftingoptimizer.engine.ExactCraftingJobState' = 'Advanced AE実Jobへ付随するexact task、waiting、output、Receiptのsidecar正本。'
+    'com.syaru.ae2craftingoptimizer.engine.OverflowPromotingCraftingPlanner' = 'checked long Plannerを先に試し、overflowした注文だけ最初からBigIntegerで再計算する。'
+    'com.syaru.ae2craftingoptimizer.engine.craftingtable.ExactCountMap' = '正のBigInteger数量Mapの検証、順序付き複製、包含判定、exact加算を行う副作用なし共通部品。'
+    'com.syaru.ae2craftingoptimizer.engine.craftingtable.ExactCraftingEscrow' = '一注文が所有する境界素材、中間素材、最終成果物をBigIntegerのまま原子的に増減する。'
+    'com.syaru.ae2craftingoptimizer.engine.craftingtable.PhysicalCraftingTreeTransaction' = '作業台ツリーの所有権移転後state machine。予約、Worker Receipt、取消、返却、隔離、NBT復元を統括する。'
+    'com.syaru.ae2craftingoptimizer.integration.AqeBigCraftingExecutionManager' = 'Advanced AE CPU HostとACO exact計画を接続し、予約、実行、取消、復元を調停する外部境界。'
+    'com.syaru.ae2craftingoptimizer.integration.ExactNetworkStorageBridge' = 'ME storageへのexact snapshot、reserve、insert、rollbackをAE2権限境界内で行う。'
+    'com.syaru.ae2craftingoptimizer.optimization.CraftingCalculationDeduplicator' = '同一世代・同一注文の計算Futureを共有し、待機者と取消所有権を分離する。'
+    'com.syaru.ae2craftingoptimizer.optimization.TransactionalCraftingExecutorV2' = 'Batch V2のprepare、transfer、commit、rollbackをReceipt契約に従って進める。'
+    'com.syaru.ae2craftingoptimizer.api.big.BigCraftingEngineApi' = 'AQE、InsaneAEなどへexact計画、容量、台帳を公開する版付きFacade。'
+    'com.syaru.ae2craftingoptimizer.api.big.BigCraftingRuntime' = 'BigInteger計画sidecarとruntime jobの登録、照会、寿命管理を行う。'
+    'com.syaru.ae2craftingoptimizer.api.big.BigCraftingHostRuntime' = '明示登録された外部CPU Hostのexact容量予約、snapshot、復旧を管理する。'
+    'com.syaru.ae2craftingoptimizer.api.vector.PreparedVectorBatchCodec' = 'exact Vector計画を上限付きNBTへ符号化・復号し、schemaを検証する。'
+    'com.syaru.ae2craftingoptimizer.api.batch.v2.PatternBatchCommit' = 'prepare済みBatchの所有権証明、受理数、Receiptをまとめ、commit可否を表す。'
+    'com.syaru.ae2craftingoptimizer.api.batch.v2.PreparedPatternBatch' = 'Adapterへ渡す前にidentity、payload、要求回数を固定した不変Batch。'
+    'com.syaru.ae2craftingoptimizer.api.big.BigCraftingStatusInbox' = '分割受信したBigInteger進捗pageをHost世代ごとに集約するclient側受信箱。'
+    'com.syaru.ae2craftingoptimizer.api.big.BigCraftingStatusPage' = 'BigInteger容量・使用量・Job進捗の一部分を運ぶ版付きpage。'
+    'com.syaru.ae2craftingoptimizer.api.big.BigIntegerCraftingPlanView' = '外部MODがACO計画のexact bytes、要求量、不足量を切り捨てず読むための公開view。'
+    'com.syaru.ae2craftingoptimizer.client.AsyncTerminalView' = '端末検索・sortの非同期結果を世代付きで保持し、古い結果の反映を拒否する。'
+    'com.syaru.ae2craftingoptimizer.command.ACOIntentCommands' = 'Recipe Intent、cache、Batch、計算統計を表示・安全に失効するserver commandを登録する。'
+    'com.syaru.ae2craftingoptimizer.engine.BigCountMath' = 'BigInteger数量Mapの加算・乗算・ceilDivを正確に行う副作用なし算術。'
+    'com.syaru.ae2craftingoptimizer.engine.BigCraftingInventory' = '計画中の在庫使用量と不足量をAEKey別BigIntegerで保持する仮想在庫。'
+    'com.syaru.ae2craftingoptimizer.engine.BigCraftingTaskProgress' = 'Pattern taskの総数、完了数、待機数をBigIntegerで追跡する。'
+    'com.syaru.ae2craftingoptimizer.engine.BigExecutionWindow' = 'BigInteger残量からlegacy実行へ貸し出す、Long.MAX_VALUE以下の一時Window。'
+    'com.syaru.ae2craftingoptimizer.engine.CheckedLongMath' = '通常計画のlong演算をexact検査し、overflow時は昇格用例外を返す。'
+    'com.syaru.ae2craftingoptimizer.engine.CompiledCraftingGraph' = '世代内で再利用するPattern nodeと入出力edgeの不変グラフ。'
+    'com.syaru.ae2craftingoptimizer.engine.CompiledPattern' = '一つのPatternをnode ID、exact係数、候補情報へ正規化した不変値。'
+    'com.syaru.ae2craftingoptimizer.engine.CompiledPlanningSession' = '一計算で共有するgraph snapshot、在庫snapshot、取消token、世代検証を束ねる。'
+    'com.syaru.ae2craftingoptimizer.engine.CraftingPlanShadowComparator' = 'ACO計画とAE2標準計画の結果・不足・bytesを比較し、不一致なら採用を拒否する。'
+    'com.syaru.ae2craftingoptimizer.engine.PlanningCancellationToken' = '共有計算を直接cancelせず、呼出者ごとの取消要求を協調的に伝えるtoken。'
+    'com.syaru.ae2craftingoptimizer.gtceu.GTCEuRecipeIntentFastPath' = 'Provider Intentに一致するGT recipe候補だけを優先し、GTCEu本来の成立判定へ渡す。'
+    'com.syaru.ae2craftingoptimizer.integration.AdvancedAePatternProviderAccess' = 'Advanced AE Pattern Providerの実体と世代情報を版差を吸収して取得する。'
+    'com.syaru.ae2craftingoptimizer.integration.Ae2UelmCompatibility' = 'Forge 1.20.1でAE2 UELMを検出し、対応済みdescriptorと機能差を検証する。'
+    'com.syaru.ae2craftingoptimizer.intent.InputIntent' = 'Providerが機械へ渡した具体的なItem、Fluid、Chemical入力を不変値で表す。'
+    'com.syaru.ae2craftingoptimizer.intent.IntentLocation' = 'Intentの送信元Provider、Level、位置、方向を特定する。'
+    'com.syaru.ae2craftingoptimizer.intent.PatternIntentCapture' = 'Pattern push直前のrecipe intentをthread-local境界へ短期間保存する。'
+    'com.syaru.ae2craftingoptimizer.intent.PatternIntentExtractor' = 'AE2 Patternから機械検索用の入力、出力、recipe種別hintを抽出する。'
+    'com.syaru.ae2craftingoptimizer.intent.RecipeIntent' = '一回のPattern pushが作ろうとするrecipeとexact入出力の読取専用表現。'
+    'com.syaru.ae2craftingoptimizer.intent.StackIntent' = '一つのItem、Fluid、Chemicalと要求量をrecipe intent内で表す。'
+    'com.syaru.ae2craftingoptimizer.mekanism.MekanismRecipeIntentFastPath' = 'Provider Intentに一致するMekanism recipe候補だけを優先し、CachedRecipeの成立判定へ渡す。'
+    'com.syaru.ae2craftingoptimizer.optimization.ConfigInventoryGenerationAccess' = 'BusやProviderの設定Inventoryに変更世代を付与する最小Access契約。'
+    'com.syaru.ae2craftingoptimizer.optimization.CraftingCalculationMemo' = '一回のクラフト計算内で在庫照会、候補、返却物などの純粋結果を共有する。'
+    'com.syaru.ae2craftingoptimizer.optimization.DeepRangeUpdateHelper' = '端末の巨大な差分範囲を上限付きchunkへ分け、順序を保って同期する。'
+    'com.syaru.ae2craftingoptimizer.optimization.P2PNotificationDeduplicator' = '同一tick・同一topology世代の重複P2P通知を一度へまとめる。'
+    'com.syaru.ae2craftingoptimizer.optimization.PatternAvailabilitySorter' = '直前成功や利用可能性をhintに候補順だけを変え、適格性判定は変更しない。'
+    'com.syaru.ae2craftingoptimizer.optimization.PatternCandidatePruner' = '証明済みの非候補だけを計算前に除外し、曖昧なら元候補集合を維持する。'
+    'com.syaru.ae2craftingoptimizer.optimization.PatternProviderBatchEligibility' = 'Pattern ProviderをBatch対象にできるか、所有権・入力・target能力から保守的に判定する。'
+    'com.syaru.ae2craftingoptimizer.optimization.StorageWatcherUpdateBuffer' = 'client可視のstorage差分を上限付きで集約し、screenやtopology変更時に即flushする。'
+    'com.syaru.ae2craftingoptimizer.api.contract.BatchTargetRevision' = 'Batch targetの内容世代と有効性を一つの単調revisionとして表す。'
+    'com.syaru.ae2craftingoptimizer.api.contract.PayloadKind' = 'exact payloadがItem、Fluid、Chemicalなど何を表すかを列挙する。'
+    'com.syaru.ae2craftingoptimizer.api.contract.ReceiptReservation' = 'Receiptへ対応する所有量、期限、target revisionを固定した予約値。'
+    'com.syaru.ae2craftingoptimizer.api.contract.ReceiptReservationProtocol' = 'Receipt予約のprepare、commit、cancel、復旧順序を外部連携へ公開する契約。'
+    'com.syaru.ae2craftingoptimizer.api.contract.RevisionWakeupListener' = 'target revision変更時に待機中処理を再評価させる通知callback。'
+    'com.syaru.ae2craftingoptimizer.api.contract.SupportedFeature' = 'ACO連携先が明示的に保証するexact機能を列挙する。'
+    'com.syaru.ae2craftingoptimizer.optimization.FallbackReasonCode' = '高速経路を辞退した理由を安定した診断codeとして列挙する。'
+    'com.syaru.ae2craftingoptimizer.optimization.SharedCalculationFuture' = '一つの計算Futureを複数呼出者へ共有し、各待機者の取消を所有Futureの取消と分離する。'
+}
+
+$reviewNotes = @{
+    'PhysicalCraftingTreeTransaction' = '高。state machineと永続Codecが同居。Issue #87では数量Mapだけ分離し、Receipt/Codec分割は専用回帰試験を伴う別Issueにする。'
+    'ACOConfig' = '中。長大だがConfig IDと既定値の正本として凝集している。key互換を固定する試験なしに分割しない。'
+    'AqeBigCraftingExecutionManager' = '高。外部CPU所有権と復旧境界。起動・再起動・取消試験を用意してから段階分割する。'
+    'CompiledRootProgram' = '中。計算核として大きいが副作用は限定的。コンパイルと評価の分離候補。'
+    'BigCraftingJob' = '高。永続状態とWindow貸出を所有。NBT Codec分離はschema回帰試験と同時に行う。'
+    'Ae2AuthoritativeCraftingPlanner' = '中。採用判定と計画生成の境界を維持し、fallback条件を別クラスへ散らさない。'
+    'TransactionalCraftingExecutorV2' = '高。所有権移転後の処理。見た目の短縮目的では分割せず、phase単位の試験を先に増やす。'
+    'ExactNetworkStorageBridge' = '高。実在庫境界。snapshotとmutationの分離候補だが原子性試験が先。'
+    'BigCraftingRuntime' = '中。公開API側のruntime registry。Host runtimeとの責務重複を監視する。'
+    'BigCraftingHostRuntime' = '高。外部Host容量と予約を所有。複数Job仕様を勝手に導入しない。'
+}
+
+function Get-ClassRole {
+    param(
+        [string]$FullyQualifiedName,
+        [string]$PackageName,
+        [string]$ClassName,
+        [string]$Source
+    )
+
+    # 重要クラスは名前推測を使わず、レビュー済みの説明を返す。
+    if ($overrides.ContainsKey($FullyQualifiedName)) {
+        return $overrides[$FullyQualifiedName]
+    }
+
+    $escapedClassName = [regex]::Escape($ClassName)
+    $javadocPattern = '(?s)/\*\*(?<doc>.*?)\*/\s*(?:public\s+)?(?:(?:final|abstract|sealed|non-sealed)\s+)*(?:class|record|interface|enum)\s+' + $escapedClassName
+    $javadocMatch = [regex]::Match($Source, $javadocPattern)
+    # 日本語Javadocがある型は、名前推測より実装者が書いた先頭説明を優先する。
+    if ($javadocMatch.Success) {
+        $documentedRole = $javadocMatch.Groups['doc'].Value
+        $documentedRole = $documentedRole -replace '(?m)^\s*\*\s?', ''
+        $documentedRole = $documentedRole -replace '\{@(?:link|code|literal)\s+([^}]+)\}', '$1'
+        $documentedRole = $documentedRole -replace '<[^>]+>', ' '
+        $documentedRole = ($documentedRole -split '(?m)^\s*@')[0]
+        $documentedRole = ($documentedRole -replace '\s+', ' ').Trim()
+        # 日本語の最初の一文だけを責務欄へ使い、詳細はsource Javadocへ残す。
+        if ($documentedRole -match '[ぁ-んァ-ン一-龯]' -and $documentedRole -match '^(.+?。)') {
+            return $Matches[1]
+        }
+    }
+
+    # Access層は外部状態の型付き窓口だけを担当し、判断を持たない。
+    if ($PackageName -eq 'com.syaru.ae2craftingoptimizer.access') {
+        return "${ClassName}が示す外部状態を型付きで公開するMixin用Access契約。判断や会計は持たない。"
+    }
+
+    # Mixin pluginは対象MOD、版、Configに応じて注入可否だけを決める。
+    if ($PackageName -eq 'com.syaru.ae2craftingoptimizer.mixin' -and $ClassName.EndsWith('Plugin')) {
+        return "${ClassName}が担当するMixin群の適用可否を、対象MODと対応版から決定する。"
+    }
+
+    # Accessor Mixinは非公開状態をAccess契約へ公開するだけに留める。
+    if ($PackageName -eq 'com.syaru.ae2craftingoptimizer.mixin' -and $ClassName.Contains('Accessor')) {
+        return "${ClassName}の対象となる非公開状態を型付きAccessorとして公開するMixin。"
+    }
+
+    # 通常Mixinは名前に示す一点だけを既存処理へ接続する薄い境界とする。
+    if ($PackageName -eq 'com.syaru.ae2craftingoptimizer.mixin') {
+        return "${ClassName}が示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。"
+    }
+
+    # 例外型は失敗理由を型で伝え、値の丸めや握り潰しを防ぐ。
+    if ($ClassName.EndsWith('Exception')) {
+        return "${ClassName}が示す失敗を呼出側へ型付きで通知する。"
+    }
+
+    # Codecは値の意味を変えず、保存または通信表現だけを変換する。
+    if ($ClassName.EndsWith('Codec')) {
+        return "${ClassName}が示す値を、上限とschemaを検証しながら保存・通信形式へ相互変換する。"
+    }
+
+    # Plannerは入力snapshotから副作用なしの計画を構築する。
+    if ($ClassName.EndsWith('Planner')) {
+        return "${ClassName}が示す入力から、副作用なしでクラフト計画を構築する。"
+    }
+
+    # Planは計画結果を表す不変値で、実在庫を直接変更しない。
+    if ($ClassName.EndsWith('Plan') -or $ClassName.EndsWith('Program')) {
+        return "${ClassName}が示すクラフト計画またはコンパイル済みプログラムを不変値として保持する。"
+    }
+
+    # Cacheは正解を生成せず、世代やrevision失効まで既知結果を再利用する。
+    if ($ClassName.EndsWith('Cache')) {
+        return "${ClassName}が示す既知結果を世代またはrevision付きで再利用し、変化時に失効する。"
+    }
+
+    # LedgerとJournalは推測せず、所有量と収支の事実を保存する。
+    if ($ClassName.EndsWith('Ledger') -or $ClassName.EndsWith('Journal')) {
+        return "${ClassName}が示す所有量、Receipt、収支をexact値で記録・検証する。"
+    }
+
+    # SnapshotとStateは特定時点の状態を表し、外部操作を直接行わない。
+    if ($ClassName.EndsWith('Snapshot') -or $ClassName.EndsWith('State')) {
+        return "${ClassName}が示す時点の状態を、検証可能な値として保持する。"
+    }
+
+    # Registryは登録と検索だけを所有し、登録対象の実行を奪わない。
+    if ($ClassName.EndsWith('Registry')) {
+        return "${ClassName}が示す実装またはHostの登録、解除、検索を管理する。"
+    }
+
+    # BridgeとAdapterは二つの所有者間で値を変換し、最終判定を元MODへ残す。
+    if ($ClassName.EndsWith('Bridge') -or $ClassName.EndsWith('Adapter') -or $ClassName.EndsWith('Support')) {
+        return "${ClassName}が示す二つのAPI境界を接続し、対応不能時は元の所有者へ判断を戻す。"
+    }
+
+    # Factoryは検証済み入力から対象値を組み立てる。
+    if ($ClassName.EndsWith('Factory')) {
+        return "${ClassName}が示す値を、検証済み入力から生成する。"
+    }
+
+    # RuntimeとManagerは寿命と状態遷移を管理するが、外部所有物は奪わない。
+    if ($ClassName.EndsWith('Runtime') -or $ClassName.EndsWith('Manager') -or $ClassName.EndsWith('Coordinator')) {
+        return "${ClassName}が示す機能の登録、寿命、状態遷移を管理する。"
+    }
+
+    # FormatterとParserは表示または入力境界だけを担当する。
+    if ($ClassName.EndsWith('Formatter') -or $ClassName.EndsWith('Parser')) {
+        return "${ClassName}が示す表示または入力文字列を、意味を変えずに変換する。"
+    }
+
+    # 公開APIは実装所有権を奪わず、登録・照会・要求の入口だけを提供する。
+    if ($ClassName.EndsWith('Api')) {
+        return "${ClassName}が示す機能を外部MODへ公開する安定Facade。"
+    }
+
+    # ModeとPhaseは状態や方針の有限な選択肢を表す。
+    if ($ClassName.EndsWith('Mode') -or $ClassName.EndsWith('Phase')) {
+        return "${ClassName}が表す実行方針または状態遷移段階を列挙する。"
+    }
+
+    # RequestとContextは一回の呼出しに必要な検証済み入力を運ぶ。
+    if ($ClassName.EndsWith('Request') -or $ClassName.EndsWith('Context')) {
+        return "${ClassName}が示す一回の要求に必要な入力、所有者、実行条件を保持する。"
+    }
+
+    # ResultとOutcomeは実行結果を不変値として返す。
+    if ($ClassName.EndsWith('Result') -or $ClassName.EndsWith('Outcome')) {
+        return "${ClassName}が示す処理結果、受理量、次状態を不変値として返す。"
+    }
+
+    # ReceiptとProofは実際に所有または完了した事実だけを表す。
+    if ($ClassName.EndsWith('Receipt') -or $ClassName.EndsWith('Proof')) {
+        return "${ClassName}が示す所有権移転または完了事実を、検証可能な証跡として保持する。"
+    }
+
+    # Storeは永続またはruntime上の記録を保存・検索する。
+    if ($ClassName.EndsWith('Store')) {
+        return "${ClassName}が示す記録を保存、検索、削除する。"
+    }
+
+    # ReconcilerとResolverは二つの事実を照合して一意な結果を選ぶ。
+    if ($ClassName.EndsWith('Reconciler') -or $ClassName.EndsWith('Resolver')) {
+        return "${ClassName}が示す計画、Receipt、実状態を照合し、一意に証明できる結果だけを返す。"
+    }
+
+    # Fingerprint、Signature、Identityは再起動やcacheで使う安定識別子を表す。
+    if ($ClassName.EndsWith('Fingerprint') -or $ClassName.EndsWith('Signature') -or $ClassName.EndsWith('Identity')) {
+        return "${ClassName}が示す対象を、順序と内容から安定して識別する。"
+    }
+
+    # Budget、Policy、Rules、Limitsは副作用なしの制約判断を担当する。
+    if ($ClassName.EndsWith('Budget') -or $ClassName.EndsWith('Policy') -or $ClassName.EndsWith('Rules') -or $ClassName.EndsWith('Limits')) {
+        return "${ClassName}が示す上限、時間予算、適格条件を副作用なしで判定する。"
+    }
+
+    # TargetとOwnerは実行を所有する外部実装の契約を表す。
+    if ($ClassName.EndsWith('Target') -or $ClassName.EndsWith('Owner')) {
+        return "${ClassName}が示す処理を所有・受理できる実装の契約を定義する。"
+    }
+
+    # Serviceは関連操作をまとめた境界で、内部実装を外部へ漏らさない。
+    if ($ClassName.EndsWith('Service')) {
+        return "${ClassName}が示す関連操作を一つのサービス境界として提供する。"
+    }
+
+    # Step、Slot、Stack、Payload、Recordはexact計画または取引の一要素を表す値型。
+    if ($ClassName.EndsWith('Step') -or $ClassName.EndsWith('Slot') -or $ClassName.EndsWith('Stack') -or $ClassName.EndsWith('Payload') -or $ClassName.EndsWith('Record')) {
+        return "${ClassName}が示す計画または取引の一要素を、不変のexact値として保持する。"
+    }
+
+    # DiagnosticsとReportは観測値を集約し、結果や在庫を変更しない。
+    if ($ClassName.EndsWith('Diagnostics') -or $ClassName.EndsWith('Report') -or $ClassName.EndsWith('Metrics')) {
+        return "${ClassName}が示す診断理由と観測値を集約する。ゲーム結果は変更しない。"
+    }
+
+    # Validator、Guard、Matcher、Preflightは採用前の証明だけを行う。
+    if ($ClassName.EndsWith('Validator') -or $ClassName.EndsWith('Guard') -or $ClassName.EndsWith('Matcher') -or $ClassName.EndsWith('Preflight') -or $ClassName.EndsWith('Consistency')) {
+        return "${ClassName}が示す入力や互換条件を検証し、証明不能な高速経路を拒否する。"
+    }
+
+    # Scheduler、Dispatcher、Throttleは予算を配分し、一つの仕事による独占を防ぐ。
+    if ($ClassName.EndsWith('Scheduler') -or $ClassName.EndsWith('Dispatcher') -or $ClassName.EndsWith('Throttle')) {
+        return "${ClassName}が示す仕事へtick予算を配分し、公平性とbackpressureを維持する。"
+    }
+
+    # TrackerとClockは世代または時刻を観測する単一責務に留める。
+    if ($ClassName.EndsWith('Tracker') -or $ClassName.EndsWith('Clock')) {
+        return "${ClassName}が示す世代、進捗、tick時刻を単調に追跡する。"
+    }
+
+    # ProjectionとCounterは正本を変更せず、表示値または合計値を導出する。
+    if ($ClassName.EndsWith('Projection') -or $ClassName.EndsWith('Counter')) {
+        return "${ClassName}が示す表示値または合計値を、exact正本から副作用なしで導出する。"
+    }
+
+    # RegistrationとCapabilitiesは任意連携が提供する能力と登録寿命を表す。
+    if ($ClassName.EndsWith('Registration') -or $ClassName.EndsWith('Capabilities')) {
+        return "${ClassName}が示す任意連携の能力または登録寿命を表す。"
+    }
+
+    # 未分類型は意図的にplaceholderを出し、JUnitで失敗させて責務overrideの追加を要求する。
+    return "${ClassName}は、$($packageRoles[$PackageName])に属するクラス名どおりの単一処理または値を担当する。"
+}
+
+$javaFiles = Get-ChildItem -LiteralPath $sourceRoot -Recurse -File -Filter '*.java' |
+    Where-Object { $_.Name -ne 'package-info.java' } |
+    Sort-Object FullName
+
+$rows = foreach ($file in $javaFiles) {
+    $raw = Get-Content -LiteralPath $file.FullName -Raw
+    $packageMatch = [regex]::Match($raw, '(?m)^package\s+([A-Za-z0-9_.]+);')
+    # package宣言がない本番Javaは責務と依存方向を分類できないため生成を止める。
+    if (-not $packageMatch.Success) {
+        throw "Missing package declaration: $($file.FullName)"
+    }
+    $packageName = $packageMatch.Groups[1].Value
+    $className = $file.BaseName
+    $topLevelTypePattern = '(?m)^\s*(?:public\s+)?(?:(?:final|abstract|sealed|non-sealed)\s+)*(?:class|record|interface|enum|@interface)\s+' + [regex]::Escape($className) + '\b'
+    # Javaファイル名と所有するトップレベル型が一致しなければ、誤ったFQCNを文書化せず生成を止める。
+    if (-not [regex]::IsMatch($raw, $topLevelTypePattern)) {
+        throw "Missing matching top-level type $className in $($file.FullName)"
+    }
+    $fqcn = "$packageName.$className"
+    $lineCount = (Get-Content -LiteralPath $file.FullName).Count
+    [pscustomobject]@{
+        Package = $packageName
+        Class = $className
+        Fqcn = $fqcn
+        Lines = $lineCount
+        Role = Get-ClassRole -FullyQualifiedName $fqcn -PackageName $packageName -ClassName $className -Source $raw
+    }
+}
+
+$builder = [System.Text.StringBuilder]::new()
+[void]$builder.AppendLine('# ACOクラス責務一覧')
+[void]$builder.AppendLine()
+[void]$builder.AppendLine('この文書は、各本番トップレベル型が所有する仕事と依存境界を確認する正本です。')
+[void]$builder.AppendLine('クラス追加・削除・責務変更時は、コードより先にIssue仕様書を更新し、本一覧も更新します。')
+[void]$builder.AppendLine('一覧は`tools/update-class-responsibilities.ps1`で生成し、重要クラスの説明は同scriptのoverrideで管理します。')
+[void]$builder.AppendLine('入れ子型は所有元の実装詳細です。独立した所有権を持たせる場合はトップレベル型へ抽出して本一覧へ載せます。')
+[void]$builder.AppendLine()
+[void]$builder.AppendLine('## ACOの目的')
+[void]$builder.AppendLine()
+[void]$builder.AppendLine('ACOはAE2を置き換えるMODではなく、結果・在庫・欠品・容量・進捗・取消・復旧を変えずに、')
+[void]$builder.AppendLine('巨大自動クラフトの計算と実行負荷を減らす最適化・連携レイヤーです。速度より正確さと所有権を優先します。')
+[void]$builder.AppendLine()
+[void]$builder.AppendLine('## 依存方向')
+[void]$builder.AppendLine()
+[void]$builder.AppendLine('```text')
+[void]$builder.AppendLine('AE2 / optional add-ons')
+[void]$builder.AppendLine('          |')
+[void]$builder.AppendLine('          v')
+[void]$builder.AppendLine('mixin + access  ->  integration  ->  optimization / scheduler')
+[void]$builder.AppendLine('                                           |')
+[void]$builder.AppendLine('                                           v')
+[void]$builder.AppendLine('                     engine / batch / transaction / craftingtable')
+[void]$builder.AppendLine('                                           |')
+[void]$builder.AppendLine('                                           v')
+[void]$builder.AppendLine('                                  public api value contracts')
+[void]$builder.AppendLine('```')
+[void]$builder.AppendLine()
+[void]$builder.AppendLine('- `mixin`は入口、`access`は型付き窓口であり、計算・会計を所有しません。')
+[void]$builder.AppendLine('- `engine`以下から`mixin`を参照しません。Common初期化から`client`を直接ロードしません。')
+[void]$builder.AppendLine('- 外部CPUアドオンは構造、実行、GUI、電力、進捗を所有し、ACOは計画と公開APIだけを提供します。')
+[void]$builder.AppendLine('- 所有権移転前だけ安全なfallbackを許可し、移転後は再開、正確な取消返却、隔離のいずれかにします。')
+[void]$builder.AppendLine()
+[void]$builder.AppendLine('## 禁止事項')
+[void]$builder.AppendLine()
+[void]$builder.AppendLine('- BigInteger正本を`long`へクランプ、飽和、切り捨てして判定する。')
+[void]$builder.AppendLine('- 所有権移転後に通常AE2へfallbackし、同じ入力を二重実行する。')
+[void]$builder.AppendLine('- 計画値から、実クラフトまたは検証済みReceiptなしで成果物を生成する。')
+[void]$builder.AppendLine('- 非同期スレッドからWorld、Grid、Block Entity、実在庫へ直接触る。')
+[void]$builder.AppendLine('- MixinへPlanner、会計、外部CPU実行ロジックを実装する。')
+[void]$builder.AppendLine('- 外部MODの構造、GUI、レシピ、テクスチャをACOの所有物として変更する。')
+[void]$builder.AppendLine()
+[void]$builder.AppendLine('## 大規模クラスのレビュー')
+[void]$builder.AppendLine()
+[void]$builder.AppendLine('| クラス | 行数 | 判断 |')
+[void]$builder.AppendLine('|---|---:|---|')
+$largestClassReviewCount = 10 # 行数上位10件だけを人手レビュー対象として先頭へ表示する。
+$largestRows = $rows | Sort-Object Lines -Descending | Select-Object -First $largestClassReviewCount
+# 行数上位だけをレビュー表へ出し、全クラスの役割は後続一覧へ分離する。
+foreach ($row in $largestRows) {
+    $note = if ($reviewNotes.ContainsKey($row.Class)) {
+        $reviewNotes[$row.Class]
+    } else {
+        '中。責務一覧を基準に、挙動固定試験を追加してから分割可否を別Issueで判断する。'
+    }
+    [void]$builder.AppendLine("| ``$($row.Class)`` | $($row.Lines) | $note |")
+}
+[void]$builder.AppendLine()
+[void]$builder.AppendLine('## パッケージ責務')
+[void]$builder.AppendLine()
+[void]$builder.AppendLine('| パッケージ | 責務 |')
+[void]$builder.AppendLine('|---|---|')
+# 現在のsourceに存在するパッケージだけを安定順で掲載する。
+foreach ($packageName in ($rows.Package | Sort-Object -Unique)) {
+    $role = if ($packageRoles.Contains($packageName)) {
+        $packageRoles[$packageName]
+    } else {
+        'この版固有の連携契約。呼出元と所有権を個別クラス行で確認する。'
+    }
+    [void]$builder.AppendLine("| ``$packageName`` | $role |")
+}
+[void]$builder.AppendLine()
+[void]$builder.AppendLine('## 全トップレベル型一覧')
+[void]$builder.AppendLine()
+[void]$builder.AppendLine("本版の本番トップレベル型: **$($rows.Count)件**")
+[void]$builder.AppendLine()
+
+# パッケージ単位に全トップレベル型を一度だけ掲載し、更新漏れをJUnitで検出する。
+foreach ($group in ($rows | Group-Object Package | Sort-Object Name)) {
+    [void]$builder.AppendLine("### ``$($group.Name)``")
+    [void]$builder.AppendLine()
+    [void]$builder.AppendLine('| クラス | 仕事 |')
+    [void]$builder.AppendLine('|---|---|')
+    foreach ($row in ($group.Group | Sort-Object Class)) {
+        [void]$builder.AppendLine("| ``$($row.Fqcn)`` | $($row.Role) |")
+    }
+    [void]$builder.AppendLine()
+}
+
+$utf8WithoutBom = [System.Text.UTF8Encoding]::new($false)
+$document = ($builder.ToString() -replace "`r`n", "`n").TrimEnd("`n") + "`n"
+[System.IO.File]::WriteAllText($outputPath, $document, $utf8WithoutBom)
+Write-Output "Updated $outputPath with $($rows.Count) production top-level types."


### PR DESCRIPTION
## 概要

ACOの全本番トップレベル型について、所有する仕事と依存境界を一覧化します。
併せて、Escrowと物理クラフト取引に重複していた正のBigInteger数量Map処理を、
副作用なしの共通部品へ集約します。

## 変更内容

- Forge 1.20.1の本番トップレベル型328件を`docs/CLASS_RESPONSIBILITIES.md`へ記録
- ACOの目的、禁止事項、依存方向、パッケージ責務、大規模クラスの分割判断を明文化
- 責務一覧を再生成する`tools/update-class-responsibilities.ps1`を追加
- sourceと責務一覧の型集合、重複、空説明、placeholder、ローカルパスをJUnitで照合
- `ExactCountMap`へ正数検証、順序付き複製、exact加算、包含判定を集約
- `ExactCraftingEscrow`と`PhysicalCraftingTreeTransaction`の重複処理を同部品へ委譲
- README、CONTRIBUTING、AGENTS、Issue手順から責務一覧への導線を追加

## 変更しないもの

- 公開API
- Config keyと既定値
- NBT schema
- Packet protocol
- Mixin対象と注入位置
- AE2、Advanced AE、外部CPUの所有権
- クラフト結果、在庫、欠品、容量、進捗、取消、復旧の意味

## 検証

- `git diff --check`: 成功
- 対象JUnit 10件: 成功
- upstream AE2 profile `clean build`: 成功
- UELM profile `clean build`: 341件中失敗0、skip 2

起動、GameTest、ゲーム内試験は今回の指示により実施していません。

Refs #87
