### PR TITLE
[1.20.1] 無関係なProvider更新によるBigInteger計画失効を修正

### DIFF
--- a/docs/CLASS_RESPONSIBILITIES.md
+++ b/docs/CLASS_RESPONSIBILITIES.md
@@ -293,6 +293,7 @@ mixin + access  ->  integration  ->  optimization / scheduler
 | `com.syaru.ae2craftingoptimizer.engine.CountOverflowException` | CountOverflowExceptionが示す失敗を呼出側へ型付きで通知する。 |
 | `com.syaru.ae2craftingoptimizer.engine.CraftingPlanShadowComparator` | ACO計画とAE2標準計画の結果・不足・bytesを比較し、不一致なら採用を拒否する。 |
 | `com.syaru.ae2craftingoptimizer.engine.ExactCraftingByteCounter` | AE2 15.4.10の線形CraftingTreeと同じ順番でCPU bytesを再計算する。 |
+| `com.syaru.ae2craftingoptimizer.engine.ExactPlanPatternRevalidator` | exact計画の提出時に参照Patternだけを現行CraftingService索引へ再照合し、無関係なProvider世代更新を区別する。 |
 | `com.syaru.ae2craftingoptimizer.engine.ExactCraftingJobLedger` | AE2実JobのBigIntegerカウンタを再起動後も検証する永続Journal。 |
 | `com.syaru.ae2craftingoptimizer.engine.ExactCraftingJobState` | Advanced AE実Jobへ付随するexact task、waiting、output、Receiptのsidecar正本。 |
 | `com.syaru.ae2craftingoptimizer.engine.GenerationAwareGraphCache` | GenerationAwareGraphCacheが示す既知結果を世代またはrevision付きで再利用し、変化時に失効する。 |

--- a/docs/REGRESSION_HISTORY.md
+++ b/docs/REGRESSION_HISTORY.md
@@ -6,6 +6,7 @@
 | Issue | 症状 | 影響版 | 修正版 | 仕様書 |
 |---|---|---:|---:|---|
 | [#79](https://github.com/syarukasu/ae2-crafting-optimizer/issues/79) | 一つのroot内部だけでsigned long境界を超えるexact計画が失われる | 1.5.17 | 1.5.18 | [ISSUE-79.md](issues/ISSUE-79.md) |
+| [#90](https://github.com/syarukasu/ae2-crafting-optimizer/issues/90) | 無関係なProvider世代更新でBigInteger計画が提出時に失効する | 1.5.18 | 未リリース | [ISSUE-90.md](issues/ISSUE-90.md) |
 
 ## 運用
 

--- a/docs/issues/ISSUE-90.md
+++ b/docs/issues/ISSUE-90.md
@@ -1,0 +1,115 @@
+# Issue #90: 無関係なProvider更新で全BigInteger計画が提出時に失効する
+
+- GitHub Issue: https://github.com/syarukasu/ae2-crafting-optimizer/issues/90
+- 状態: In Progress
+- 影響版: ACO 1.5.18
+- 対象ローダー: Forge 1.20.1 / NeoForge 1.21.1
+- 関連Issue: #44、#64、#79
+
+## 問題
+
+正確なBigInteger計画を作成できても、計算後からCPU提出までにネットワーク内の
+無関係なPattern Providerが一件更新されると、全Provider共通の世代番号が変わります。
+`BigIntegerCraftingPlan`と`BigCapacityCraftingPlan`はこの全体世代だけを比較するため、
+注文が実際に使うPatternが一つも変わっていなくても`INCOMPLETE_PLAN`で拒否されます。
+
+## 再現と証拠
+
+- ACO 1.5.18、AQE BigInteger CPU、BigInteger在庫セルを使用
+- 20段の決定的な3x3圧縮計画を計算
+- 確認画面を開いている間に別Providerの内容または接続状態が更新される
+- 開始時に`Couldn't submit crafting job ... INCOMPLETE_PLAN`となる
+- 実ログでは同じ注文が4回連続で`INCOMPLETE_PLAN`になった
+- BigInteger backend、AQE/InsaneAE profile、compiled graph、atomic plan、gameplay executionは全て有効
+
+## 期待結果
+
+- 注文が参照する全Patternが現在のCraftingServiceに同じ実体として残る場合は提出できる
+- 注文が参照するPattern自身、レシピ、在庫、CPU容量が変わった場合は提出前に拒否する
+- 通常long計画とBigInteger計画で、無関係なProvider更新に対する扱いを不必要に変えない
+- BigInteger正本、在庫、欠品、容量、進捗をlongへ丸めない
+
+## 現在結果
+
+`generationsAreCurrent()`が全Provider共通世代の完全一致だけを要求します。大規模ネットワークでは
+確認画面を開いている短時間にも世代が進み、BigInteger計画だけが恒常的に提出不能になります。
+
+## 所有権
+
+- AE2: 現在のCraftingService索引、通常long計画、通常CPU提出
+- ACO: exact計画、参照Pattern集合、BigInteger sidecar、提出前のexact計画検証
+- AQE・InsaneAE: CPU構造と実行
+- fallback境界: exact計画の所有権移転前。wide計画を標準long計算へ落とさない
+
+## 維持する不変条件
+
+- レシピ世代が変わった計画は拒否する
+- 参照Patternが一件でも現在のCraftingServiceから消えた計画は拒否する
+- 無関係なProvider更新だけではexact計画を拒否しない
+- Provider再検証は計画に含まれる固有Pattern数にだけ比例させる
+- 提出後の取消、保存、進捗会計は変更しない
+
+## やってはいけないこと
+
+- 世代検査を無条件に削除する
+- Patternの内容が変わった計画を許可する
+- BigInteger計画をAE2標準long計画へフォールバックする
+- AQEまたはInsaneAEのCPU実行ロジックへ新しい介入を追加する
+- 全Providerを再走査して提出処理を重くする
+
+## 修正方針
+
+1. 同一の全体世代なら従来どおり即時に有効と判定する。
+2. 全体世代だけが変わった場合、計画が使う各`IPatternDetails`について、主出力の
+   `ICraftingService#getCraftingFor`に同一参照が残るかを再検証する。
+3. レシピ世代が変わった場合は再検証で救済せず拒否する。
+4. BigInteger計画とBigCapacity計画で同じ検証器を共有する。
+5. 拒否理由を診断へ記録し、`INCOMPLETE_PLAN`の原因を区別できるようにする。
+
+## 実装前チェック
+
+- [x] `docs/PROJECT_CHARTER.md`を読んだ
+- [x] `docs/REGRESSION_HISTORY.md`を読んだ
+- [x] 関連クラスと既存試験を読んだ
+- [x] 再現条件を試験へ変換した
+- [x] 所有権とfallback境界を確定した
+- [x] 禁止事項を明記した
+- [x] Forge/NeoForgeの適用範囲を確定した
+
+## 試験計画
+
+- 同一世代は再走査なしで成功
+- 無関係なProvider世代更新後も、全参照Patternが残れば成功
+- 参照Pattern削除後は失敗
+- 参照Pattern置換後は、内容が同じでも古い実体を実行せず失敗
+- レシピ世代更新後は失敗
+- Forge 1.20.1 / NeoForge 1.21.1の全JUnitと`clean build`
+
+## 実装結果
+
+- `ExactPlanPatternRevalidator`を追加した。
+- 計画時と現在のレシピ世代が異なる場合は従来どおり拒否する。
+- Provider世代が一致する場合は索引を再走査しない。
+- Provider世代だけが異なる場合は、計画に含まれるPatternを主出力ごとにまとめ、
+  現在の`CraftingService`索引へ同一参照で残るか再検証する。
+- Patternを参照しない在庫完結計画は、無関係なProvider世代更新だけでは拒否しない。
+- `BigIntegerCraftingPlan`と`BigCapacityCraftingPlan`の提出判定を共通検証器へ接続した。
+- 再検証に失敗した場合は`GENERATION_CHANGED`診断へ具体的理由を記録する。
+- 容量比較、在庫会計、Pattern回数、実行Job、取消・保存処理は変更していない。
+
+## 検証結果
+
+- Forge 1.20.1 targeted JUnit: 6件成功
+- Forge 1.20.1 full JUnit: 347件中345件成功、2件skip
+- Forge 1.20.1 `clean build`: 成功
+- NeoForge 1.21.1 targeted JUnit: 6件成功
+- NeoForge 1.21.1 full JUnit: 369件成功、失敗・skipなし
+- NeoForge 1.21.1 `clean build`: 成功
+- Minecraft起動試験: 指示により未実施
+
+## 完了
+
+- Forge PR:
+- NeoForge PR:
+- 修正版:
+- リリース:

--- a/docs/issues/ISSUE-90.md
+++ b/docs/issues/ISSUE-90.md
@@ -109,7 +109,7 @@
 
 ## 完了
 
-- Forge PR:
-- NeoForge PR:
+- Forge PR: https://github.com/syarukasu/ae2-crafting-optimizer/pull/91
+- NeoForge PR: https://github.com/syarukasu/ae2-crafting-optimizer/pull/92
 - 修正版:
 - リリース:

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigCapacityCraftingPlan.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigCapacityCraftingPlan.java
@@ -1,6 +1,7 @@
 package com.syaru.ae2craftingoptimizer.engine;
 
 import appeng.api.crafting.IPatternDetails;
+import appeng.api.networking.IGrid;
 import appeng.api.stacks.GenericStack;
 import appeng.api.stacks.KeyCounter;
 import com.syaru.ae2craftingoptimizer.optimization.ProviderPatternGenerationTracker;
@@ -105,7 +106,30 @@ public final class BigCapacityCraftingPlan implements WideCraftingPlan {
         return exactBytes;
     }
 
-    /** 計算後にPatternまたはレシピが変わった計画を送信しない。 */
+    /** CPU提出時に、この計画が実際に参照するPatternだけを現在索引へ再照合する。 */
+    public ExactPlanPatternRevalidator.Result validateForSubmission(IGrid grid) {
+        return ExactPlanPatternRevalidator.validate(
+                grid,
+                patternGeneration,
+                recipeGeneration,
+                patternTimes.keySet());
+    }
+
+    public long patternGeneration() {
+        return patternGeneration;
+    }
+
+    public long recipeGeneration() {
+        return recipeGeneration;
+    }
+
+    /**
+     * 全体世代だけを確認する旧互換API。
+     *
+     * @deprecated CPU提出時は、無関係なProvider更新を区別できる
+     *     {@link #validateForSubmission(IGrid)}を使用する。
+     */
+    @Deprecated(forRemoval = false)
     public boolean generationsAreCurrent() {
         return patternGeneration == ProviderPatternGenerationTracker.generation()
                 && recipeGeneration == RecipeGenerationTracker.generation();

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerCraftingPlan.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerCraftingPlan.java
@@ -1,6 +1,7 @@
 package com.syaru.ae2craftingoptimizer.engine;
 
 import appeng.api.crafting.IPatternDetails;
+import appeng.api.networking.IGrid;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.GenericStack;
 import appeng.api.stacks.KeyCounter;
@@ -135,7 +136,30 @@ public final class BigIntegerCraftingPlan implements WideCraftingPlan {
         submissionClaimed.set(false);
     }
 
-    /** 計算後にPatternまたはrecipeが変わった親Jobを実行しない。 */
+    /** CPU提出時に、この親Jobが実際に参照するPatternだけを現在索引へ再照合する。 */
+    public ExactPlanPatternRevalidator.Result validateForSubmission(IGrid grid) {
+        return ExactPlanPatternRevalidator.validate(
+                grid,
+                preparedRoot.patternGeneration(),
+                preparedRoot.recipeGeneration(),
+                exactPatternTimes.keySet());
+    }
+
+    public long patternGeneration() {
+        return preparedRoot.patternGeneration();
+    }
+
+    public long recipeGeneration() {
+        return preparedRoot.recipeGeneration();
+    }
+
+    /**
+     * 全体世代だけを確認する旧互換API。
+     *
+     * @deprecated CPU提出時は、無関係なProvider更新を区別できる
+     *     {@link #validateForSubmission(IGrid)}を使用する。
+     */
+    @Deprecated(forRemoval = false)
     public boolean generationsAreCurrent() {
         return preparedRoot.patternGeneration() == ProviderPatternGenerationTracker.generation()
                 && preparedRoot.recipeGeneration() == RecipeGenerationTracker.generation();

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/ExactPlanPatternRevalidator.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/ExactPlanPatternRevalidator.java
@@ -1,0 +1,130 @@
+package com.syaru.ae2craftingoptimizer.engine;
+
+import appeng.api.crafting.IPatternDetails;
+import appeng.api.networking.IGrid;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.GenericStack;
+import com.syaru.ae2craftingoptimizer.optimization.ProviderPatternGenerationTracker;
+import java.util.Collection;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Exact計画が参照するPatternだけを、CPU提出直前のCraftingServiceへ再照合する。
+ *
+ * <p>Issue #90: 全Provider共通世代だけを比較すると、無関係なProvider更新でも
+ * BigInteger計画がすべて失効する。全体世代が変わった場合だけ、計画内のPatternが
+ * 現在の索引に同一参照で残ることを確認する。</p>
+ */
+public final class ExactPlanPatternRevalidator {
+    private ExactPlanPatternRevalidator() {
+    }
+
+    public static Result validate(
+            IGrid grid,
+            long plannedPatternGeneration,
+            long plannedRecipeGeneration,
+            Collection<IPatternDetails> plannedPatterns) {
+        Objects.requireNonNull(grid, "grid");
+        return validate(
+                plannedPatternGeneration,
+                plannedRecipeGeneration,
+                ProviderPatternGenerationTracker.generation(),
+                RecipeGenerationTracker.generation(),
+                plannedPatterns,
+                key -> grid.getCraftingService().getCraftingFor(key));
+    }
+
+    static Result validate(
+            long plannedPatternGeneration,
+            long plannedRecipeGeneration,
+            long currentPatternGeneration,
+            long currentRecipeGeneration,
+            Collection<IPatternDetails> plannedPatterns,
+            Function<AEKey, Collection<IPatternDetails>> currentPatterns) {
+        Objects.requireNonNull(plannedPatterns, "plannedPatterns");
+        Objects.requireNonNull(currentPatterns, "currentPatterns");
+
+        // Recipe reload後は同じPattern参照でも意味が変わり得るため、再利用しない。
+        if (plannedRecipeGeneration != currentRecipeGeneration) {
+            return Result.RECIPE_GENERATION_CHANGED;
+        }
+        // 同じ全体世代なら、計画時の厳密Topology検証をそのまま利用できる。
+        if (plannedPatternGeneration == currentPatternGeneration) {
+            return Result.CURRENT_GENERATION;
+        }
+        // Patternを持たない在庫完結計画には、Provider世代で失効する参照が存在しない。
+        if (plannedPatterns.isEmpty()) {
+            return Result.REFERENCED_PATTERNS_REVALIDATED;
+        }
+
+        Map<AEKey, Set<IPatternDetails>> requiredByOutput = new LinkedHashMap<>();
+        // 主出力ごとに必要Patternをまとめ、CraftingService索引の取得を一回へ抑える。
+        for (IPatternDetails pattern : plannedPatterns) {
+            IPatternDetails checkedPattern = Objects.requireNonNull(pattern, "planned pattern");
+            GenericStack primaryOutput = checkedPattern.getPrimaryOutput();
+            // 主出力なしのPatternは現在索引から安全に引き直せないため拒否する。
+            if (primaryOutput == null) {
+                return Result.REFERENCED_PATTERN_CHANGED;
+            }
+            requiredByOutput
+                    .computeIfAbsent(
+                            primaryOutput.what(),
+                            ignored -> java.util.Collections.newSetFromMap(
+                                    new IdentityHashMap<>()))
+                    .add(checkedPattern);
+        }
+
+        // 無関係なProvider更新は許容し、計画が実際に使うPatternだけを再照合する。
+        for (Map.Entry<AEKey, Set<IPatternDetails>> entry : requiredByOutput.entrySet()) {
+            Collection<IPatternDetails> indexed = currentPatterns.apply(entry.getKey());
+            // 出力索引自体が消えた場合は、古いPatternを実行対象へ残さない。
+            if (indexed == null || indexed.isEmpty()) {
+                return Result.REFERENCED_PATTERN_CHANGED;
+            }
+            Set<IPatternDetails> missing = java.util.Collections.newSetFromMap(
+                    new IdentityHashMap<>());
+            missing.addAll(entry.getValue());
+            // equalsではなく同一参照を照合し、同内容に見える差し替えを誤採用しない。
+            for (IPatternDetails current : indexed) {
+                missing.remove(current);
+                // この出力に必要な全Patternが見つかれば残りの索引走査を省略する。
+                if (missing.isEmpty()) {
+                    break;
+                }
+            }
+            // 一件でも参照Patternが消えていれば、計画全体を提出前に拒否する。
+            if (!missing.isEmpty()) {
+                return Result.REFERENCED_PATTERN_CHANGED;
+            }
+        }
+        return Result.REFERENCED_PATTERNS_REVALIDATED;
+    }
+
+    public enum Result {
+        CURRENT_GENERATION(true, "planning generations are current"),
+        REFERENCED_PATTERNS_REVALIDATED(true, "referenced patterns remain current"),
+        RECIPE_GENERATION_CHANGED(false, "recipe generation changed after planning"),
+        REFERENCED_PATTERN_CHANGED(false, "a referenced pattern changed after planning");
+
+        private final boolean valid;
+        private final String detail;
+
+        Result(boolean valid, String detail) {
+            this.valid = valid;
+            this.detail = detail;
+        }
+
+        public boolean valid() {
+            return valid;
+        }
+
+        public String detail() {
+            return detail;
+        }
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeBigCapacityPlanSubmissionMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeBigCapacityPlanSubmissionMixin.java
@@ -5,6 +5,7 @@ import appeng.api.networking.crafting.ICraftingPlan;
 import appeng.api.networking.crafting.ICraftingRequester;
 import appeng.api.networking.crafting.ICraftingSubmitResult;
 import appeng.api.networking.security.IActionSource;
+import appeng.api.stacks.GenericStack;
 import appeng.api.stacks.KeyCounter;
 import appeng.crafting.CraftingPlan;
 import appeng.crafting.execution.CraftingSubmitResult;
@@ -17,7 +18,10 @@ import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
 import com.syaru.ae2craftingoptimizer.engine.BigCapacityCraftingPlan;
 import com.syaru.ae2craftingoptimizer.engine.BigIntegerCraftingPlan;
+import com.syaru.ae2craftingoptimizer.engine.ExactPlanPatternRevalidator;
 import com.syaru.ae2craftingoptimizer.integration.AqeBigCraftingExecutionContext;
+import com.syaru.ae2craftingoptimizer.optimization.BigIntegerPlanDeclineReason;
+import com.syaru.ae2craftingoptimizer.optimization.BigIntegerPlanDiagnostics;
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -75,8 +79,20 @@ public abstract class AdvancedAeBigCapacityPlanSubmissionMixin
             // 自動要求は最終出力をCraftingLinkへ戻すExact転送が未対応なので、手動注文だけを受理する。
             if (requester != null
                     || !ACOConfig.enableBigIntegerGameplayExecution()
-                    || bigIntegerPlan.simulation()
-                    || !bigIntegerPlan.generationsAreCurrent()) {
+                    || bigIntegerPlan.simulation()) {
+                cir.setReturnValue(CraftingSubmitResult.INCOMPLETE_PLAN);
+                return;
+            }
+            ExactPlanPatternRevalidator.Result validation =
+                    bigIntegerPlan.validateForSubmission(grid);
+            // Issue #90: 無関係なProvider更新は通し、参照Patternの変更だけを拒否する。
+            if (!validation.valid()) {
+                aco$recordGenerationDecline(
+                        bigIntegerPlan.finalOutput(),
+                        bigIntegerPlan.exactPlan().requestedAmount(),
+                        bigIntegerPlan.patternGeneration(),
+                        bigIntegerPlan.recipeGeneration(),
+                        validation);
                 cir.setReturnValue(CraftingSubmitResult.INCOMPLETE_PLAN);
                 return;
             }
@@ -108,8 +124,19 @@ public abstract class AdvancedAeBigCapacityPlanSubmissionMixin
         // 実験機能OFF、Missing計画、古いPattern世代は入力を抜く前に拒否する。
         if (!ACOConfig.enableAtomicBigCapacityPlans()
                 || bigPlan.simulation()
-                || !bigPlan.missingItems().isEmpty()
-                || !bigPlan.generationsAreCurrent()) {
+                || !bigPlan.missingItems().isEmpty()) {
+            cir.setReturnValue(CraftingSubmitResult.INCOMPLETE_PLAN);
+            return;
+        }
+        ExactPlanPatternRevalidator.Result validation = bigPlan.validateForSubmission(grid);
+        // Issue #90: 合計容量だけがwideな計画にも、同じ対象限定の再検証を適用する。
+        if (!validation.valid()) {
+            aco$recordGenerationDecline(
+                    bigPlan.finalOutput(),
+                    BigInteger.valueOf(bigPlan.finalOutput().amount()),
+                    bigPlan.patternGeneration(),
+                    bigPlan.recipeGeneration(),
+                    validation);
             cir.setReturnValue(CraftingSubmitResult.INCOMPLETE_PLAN);
             return;
         }
@@ -347,6 +374,23 @@ public abstract class AdvancedAeBigCapacityPlanSubmissionMixin
                 new KeyCounter(),
                 new KeyCounter(),
                 Map.copyOf(oneExecution));
+    }
+
+    /** 世代再検証の拒否理由を、設定可能なBigInteger診断へ集約する。 */
+    @Unique
+    private static void aco$recordGenerationDecline(
+            GenericStack output,
+            BigInteger requestedAmount,
+            long patternGeneration,
+            long recipeGeneration,
+            ExactPlanPatternRevalidator.Result validation) {
+        BigIntegerPlanDiagnostics.record(
+                BigIntegerPlanDeclineReason.GENERATION_CHANGED,
+                output.what().getId().toString(),
+                requestedAmount,
+                patternGeneration,
+                recipeGeneration,
+                validation.detail());
     }
 
     private record SubmissionAttempt(

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/ExactPlanPatternRevalidatorTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/ExactPlanPatternRevalidatorTest.java
@@ -1,0 +1,213 @@
+package com.syaru.ae2craftingoptimizer.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import appeng.api.crafting.IPatternDetails;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.AEKeyType;
+import appeng.api.stacks.GenericStack;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import org.junit.jupiter.api.Test;
+
+class ExactPlanPatternRevalidatorTest {
+    private static final long PLANNED_PATTERN_GENERATION = 10L;
+    private static final long UPDATED_PATTERN_GENERATION = 11L;
+    private static final long RECIPE_GENERATION = 20L;
+
+    @Test
+    void acceptsMatchingGenerationWithoutIndexScan() {
+        StubPattern pattern = new StubPattern(new TestKey("iron_block"));
+        AtomicInteger lookups = new AtomicInteger();
+
+        var result = ExactPlanPatternRevalidator.validate(
+                PLANNED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                PLANNED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                List.of(pattern),
+                ignored -> {
+                    lookups.incrementAndGet();
+                    return List.of();
+                });
+
+        assertEquals(ExactPlanPatternRevalidator.Result.CURRENT_GENERATION, result);
+        assertEquals(0, lookups.get());
+    }
+
+    @Test
+    void acceptsUnrelatedProviderGenerationWhenReferencedPatternRemains() {
+        StubPattern pattern = new StubPattern(new TestKey("iron_block"));
+
+        var result = ExactPlanPatternRevalidator.validate(
+                PLANNED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                UPDATED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                List.of(pattern),
+                ignored -> List.of(pattern));
+
+        assertEquals(
+                ExactPlanPatternRevalidator.Result.REFERENCED_PATTERNS_REVALIDATED,
+                result);
+    }
+
+    @Test
+    void acceptsProviderGenerationChangeForInventoryOnlyPlan() {
+        AtomicInteger lookups = new AtomicInteger();
+
+        var result = ExactPlanPatternRevalidator.validate(
+                PLANNED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                UPDATED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                List.of(),
+                ignored -> {
+                    lookups.incrementAndGet();
+                    return List.of();
+                });
+
+        assertEquals(
+                ExactPlanPatternRevalidator.Result.REFERENCED_PATTERNS_REVALIDATED,
+                result);
+        assertEquals(0, lookups.get());
+    }
+
+    @Test
+    void rejectsEqualLookingReplacementPattern() {
+        TestKey output = new TestKey("iron_block");
+        StubPattern planned = new StubPattern(output);
+        StubPattern replacement = new StubPattern(output);
+
+        var result = ExactPlanPatternRevalidator.validate(
+                PLANNED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                UPDATED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                List.of(planned),
+                ignored -> List.of(replacement));
+
+        assertEquals(
+                ExactPlanPatternRevalidator.Result.REFERENCED_PATTERN_CHANGED,
+                result);
+    }
+
+    @Test
+    void rejectsMissingReferencedPattern() {
+        StubPattern pattern = new StubPattern(new TestKey("iron_block"));
+
+        var result = ExactPlanPatternRevalidator.validate(
+                PLANNED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                UPDATED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                List.of(pattern),
+                ignored -> List.of());
+
+        assertEquals(
+                ExactPlanPatternRevalidator.Result.REFERENCED_PATTERN_CHANGED,
+                result);
+    }
+
+    @Test
+    void rejectsRecipeGenerationChangeWithoutIndexScan() {
+        StubPattern pattern = new StubPattern(new TestKey("iron_block"));
+        AtomicInteger lookups = new AtomicInteger();
+
+        var result = ExactPlanPatternRevalidator.validate(
+                PLANNED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                UPDATED_PATTERN_GENERATION,
+                RECIPE_GENERATION + 1L,
+                List.of(pattern),
+                ignored -> {
+                    lookups.incrementAndGet();
+                    return List.of(pattern);
+                });
+
+        assertEquals(
+                ExactPlanPatternRevalidator.Result.RECIPE_GENERATION_CHANGED,
+                result);
+        assertEquals(0, lookups.get());
+    }
+
+    private static final class StubPattern implements IPatternDetails {
+        private final GenericStack[] outputs;
+
+        private StubPattern(AEKey output) {
+            this.outputs = new GenericStack[] {new GenericStack(output, 1L)};
+        }
+
+        @Override
+        public appeng.api.stacks.AEItemKey getDefinition() {
+            return null;
+        }
+
+        @Override
+        public IInput[] getInputs() {
+            return new IInput[0];
+        }
+
+        @Override
+        public GenericStack[] getOutputs() {
+            return outputs.clone();
+        }
+    }
+
+    /** Minecraftレジストリを起動せず、Pattern主出力の識別だけを行う最小AEKey。 */
+    private static final class TestKey extends AEKey {
+        private final String path;
+
+        private TestKey(String path) {
+            this.path = path;
+        }
+
+        @Override
+        public AEKeyType getType() {
+            return null;
+        }
+
+        @Override
+        public AEKey dropSecondary() {
+            return this;
+        }
+
+        @Override
+        public CompoundTag toTag() {
+            return new CompoundTag();
+        }
+
+        @Override
+        public Object getPrimaryKey() {
+            return this;
+        }
+
+        @Override
+        public ResourceLocation getId() {
+            return new ResourceLocation("ae2_crafting_optimizer", path);
+        }
+
+        @Override
+        public void writeToPacket(FriendlyByteBuf buffer) {
+            // この試験はネットワーク同期を行わない。
+        }
+
+        @Override
+        protected Component computeDisplayName() {
+            return Component.literal(path);
+        }
+
+        @Override
+        public void addDrops(long amount, List<ItemStack> drops, Level level, BlockPos pos) {
+            // この試験はワールド内ドロップを作らない。
+        }
+    }
+}


### PR DESCRIPTION
## 概要

BigInteger / BigCapacity 計画が、注文と無関係な Pattern Provider 更新だけで提出不能になる問題を修正します。

Relates to #90

## 原因

提出境界が、計画で参照した Pattern ではなく Grid 全体の Provider 世代番号だけを比較していました。確認画面を開いてから開始するまでに別 Provider が更新されると、計画内容が不変でも `INCOMPLETE_PLAN` になっていました。

## 変更

- exact 計画が参照する Pattern だけを現在の CraftingService 索引へ再照合
- Provider 世代が同じ場合は従来どおり再走査なし
- 無関係な Provider 更新後も、参照 Pattern が同一なら提出を許可
- 参照 Pattern の削除・置換、またはレシピ世代変更は提出前に拒否
- Pattern を参照しない在庫完結計画は Provider 更新だけで失効させない
- 拒否理由を BigInteger 診断統計へ記録
- BigIntegerCraftingPlan と BigCapacityCraftingPlan で検証器を共有

容量比較、在庫会計、Pattern 回数、実行 Job、取消・保存処理は変更していません。

## 検証

- targeted JUnit: 6件成功
- full JUnit: 347件中345件成功、2件skip、失敗0
- `gradlew.bat clean build --no-daemon`: 成功
- Minecraft 起動試験: 指示により未実施

## 対象

- Minecraft 1.20.1
- Forge 47.4.x
- AE2 15.4.x
