### PR TITLE
[1.20.1] Java 25のBigInteger Sidecarネイティブクラッシュを修正

### DIFF
--- a/docs/REGRESSION_HISTORY.md
+++ b/docs/REGRESSION_HISTORY.md
@@ -6,6 +6,7 @@
 | Issue | 症状 | 影響版 | 修正版 | 仕様書 |
 |---|---|---:|---:|---|
 | [#79](https://github.com/syarukasu/ae2-crafting-optimizer/issues/79) | 一つのroot内部だけでsigned long境界を超えるexact計画が失われる | 1.5.17 | 1.5.18 | [ISSUE-79.md](issues/ISSUE-79.md) |
+| [#93](https://github.com/syarukasu/ae2-crafting-optimizer/issues/93) | Java 25でBigInteger在庫Sidecarの可視コピー中にJVMが終了する | 1.5.18 | 未定 | [ISSUE-93.md](issues/ISSUE-93.md) |
 
 ## 運用
 

--- a/docs/issues/ISSUE-93.md
+++ b/docs/issues/ISSUE-93.md
@@ -1,0 +1,110 @@
+# Issue #93: Java 25でBigInteger在庫Sidecarの可視コピー中にJVMが終了する
+
+- GitHub Issue: https://github.com/syarukasu/ae2-crafting-optimizer/issues/93
+- 状態: Verified
+- 対象版: ACO 1.5.18
+- 対象ローダー: Forge 1.20.1 / NeoForge 1.21.1
+- 関連Issue・PR: PR未作成
+
+## 問題
+
+正確なBigInteger在庫SnapshotをAE2のクラフト計算用`KeyCounter`へ伝播中、
+Java例外ではなくJVMが`EXCEPTION_ACCESS_VIOLATION`で終了しました。Minecraftの
+クラッシュレポートや正常停止処理は残らず、接続中クライアントも切断されます。
+
+## 再現と証拠
+
+- Minecraft 1.20.1、ACO 1.5.18、Temurin 25.0.4+7、G1 GC
+- Arclight Forge 1.20.1のServer threadで発生
+- `hs_err_pid5116.log`のproblematic frameはC2コンパイル済み
+  `BigKeyCounterSidecars.copyVisible(KeyCounter, KeyCounter)`
+- 読み取り先は`0x000000007f7c8de0`
+- compiled methodは`ImmutableCollections$MapN`を反復しながら、AE2の
+  `KeyCounter.get`が持つfastutil木を同じループ内で検索していた
+- サーバー消失後のクライアントNPEはTooManyRecipeViewersのlogout処理で発生した
+  二次障害であり、このIssueの変更対象ではない
+
+## 期待結果
+
+- 正確なBigInteger在庫値を丸めずに別`KeyCounter`へ伝播できる。
+- Java 25で対象処理が高頻度にC2コンパイルされてもJVMが終了しない。
+- AE2側で除外済みのキーをSidecarだけで復活させない。
+- source/targetが同一でも別インスタンスでも既存の可視性契約を維持する。
+
+## 現在結果
+
+不変Snapshotの`MapN`反復と可変`KeyCounter`検索が一つの大きなC2 methodへ融合し、
+Java 25上でネイティブアクセス違反を起こしました。
+
+## 所有権
+
+- AE2が所有する状態: long facadeの`KeyCounter`と可視キー集合
+- ACOが所有する状態: `KeyCounter`へ関連付ける不変BigInteger Snapshot
+- 任意アドオンが所有する状態: 一基ごとの正確なBigInteger在庫値
+- fallback可能な境界: Sidecarが存在しない場合だけlong facadeを正本にする
+
+## 維持する不変条件
+
+- BigInteger正本を`long`へクランプ、飽和、切り捨てしない。
+- targetのlong facadeに正量で存在するキーだけを伝播する。
+- Snapshot公開後に呼出側からMap/Setを変更できない。
+- source Snapshotとtarget可視キーを独立した一時点Snapshotとして扱う。
+- SidecarのIdentity弱参照による寿命管理を維持する。
+
+## やってはいけないこと
+
+- ACOのBigInteger在庫機能を無効化して回避する。
+- JVM起動引数へACO固有の`CompileCommand`を必須化する。
+- Java 25だけを一律非対応にして原因を隠す。
+- 可視性判定を省略して、抽出済みキーを復活させる。
+- クライアント側TooManyRecipeViewersをACOから改変する。
+
+## 修正方針
+
+`Snapshot`のMap/SetをACO所有の順序保持コレクションへ複製し、その読み取り専用viewを
+公開します。`copyVisible`はtargetの正量キー取得とsourceの正確値抽出を別工程へ分け、
+JDKの`MapN`反復とfastutil検索を一つのC2ループへ融合させません。
+
+## 実装前チェック
+
+- [x] `docs/PROJECT_CHARTER.md`を読んだ
+- [x] `docs/REGRESSION_HISTORY.md`を読んだ
+- [x] 関連クラスと既存試験を読んだ
+- [x] 再現条件を試験へ変換した
+- [x] 所有権とfallback境界を確定した
+- [x] 禁止事項を明記した
+- [x] Forge/NeoForgeの適用範囲を確定した
+
+## 試験計画
+
+- 単体試験: 可視キーだけのexact値・exact key・complete flag伝播
+- 境界試験: `Long.MAX_VALUE + 1`を丸めず維持
+- 故障試験: 元Map/Set変更後もSnapshotが変わらない
+- ストレス試験: 同一targetへの高頻度コピーで値と正確性が変化しない
+- ビルド: 両版のJUnit、静的検査、`clean build`
+- GameTestまたはユーザー側確認: Minecraft起動はユーザー側確認
+
+## 実装結果
+
+- `BigKeyCounterSidecars.copyVisible`から`KeyCounter.get`を使う複合ループを除去した。
+- targetの正量キー取得とsource BigInteger値の抽出を別メソッドへ分離した。
+- SnapshotのMap/SetをACO所有の`LinkedHashMap`/`LinkedHashSet`へ複製し、
+  `Collections.unmodifiableMap`/`unmodifiableSet`で公開するよう変更した。
+- 12,000キーを8回コピーするJava 25向け回帰試験を追加した。
+- BigInteger値、可視キー、キー単位exactness、complete flag、弱参照管理を維持した。
+
+## 検証結果
+
+- Forge 1.20.1: JUnit 344件、失敗0、エラー0、スキップ2
+- NeoForge 1.21.1: JUnit 366件、失敗0、エラー0、スキップ0
+- Temurin 25.0.4+7: 両版の12,000キー回帰試験成功
+- Forge 1.20.1 `clean build`: 成功
+- NeoForge 1.21.1 `clean build`: 成功
+- Minecraftクライアント・専用サーバー起動: 指示により未実施
+
+## 完了
+
+- PR: 未作成
+- マージコミット: 未定
+- 修正版: 未定
+- リリース: 未定

--- a/docs/issues/ISSUE-93.md
+++ b/docs/issues/ISSUE-93.md
@@ -4,7 +4,7 @@
 - 状態: Verified
 - 対象版: ACO 1.5.18
 - 対象ローダー: Forge 1.20.1 / NeoForge 1.21.1
-- 関連Issue・PR: PR未作成
+- 関連Issue・PR: PR #94、PR #95
 
 ## 問題
 
@@ -104,7 +104,7 @@ JDKの`MapN`反復とfastutil検索を一つのC2ループへ融合させませ�
 
 ## 完了
 
-- PR: 未作成
+- PR: Forge #94、NeoForge #95
 - マージコミット: 未定
 - 修正版: 未定
 - リリース: 未定

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -17,3 +17,4 @@
 - [Issue #79](ISSUE-79.md): 一つのroot内部だけでsigned long境界を超える計画
 - [Issue #84](ISSUE-84.md): Issue先行開発手順とプロジェクト境界
 - [Issue #87](ISSUE-87.md): 全クラスの責務明文化とexact数量Mapの安全な共通化
+- [Issue #93](ISSUE-93.md): Java 25でBigInteger在庫Sidecarの可視コピー中にJVMが終了する

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigKeyCounterSidecars.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigKeyCounterSidecars.java
@@ -5,6 +5,7 @@ import appeng.api.stacks.KeyCounter;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -74,22 +75,45 @@ public final class BigKeyCounterSidecars {
             return;
         }
 
-        Map<AEKey, BigInteger> visible = new LinkedHashMap<>();
-        // AE2の抽出Simulationで除外されたキーをBigInteger側だけ復活させない。
-        for (Map.Entry<AEKey, BigInteger> entry : sourceSnapshot.amounts().entrySet()) {
-            // long側に正の在庫として残ったキーだけを計画用Sidecarへ伝播する。
-            if (target.get(entry.getKey()) > 0L) {
-                visible.put(entry.getKey(), entry.getValue());
+        // Issue #93: KeyCounter検索とJDK MapN反復を同じC2ループへ融合させない。
+        Set<AEKey> visibleKeys = capturePositiveKeys(target);
+        put(target, retainVisibleAmounts(sourceSnapshot, visibleKeys));
+    }
+
+    /** AE2のlong Facadeから、現在正量として見えているキーだけを独立Snapshotへ取り出す。 */
+    private static Set<AEKey> capturePositiveKeys(KeyCounter target) {
+        Set<AEKey> visibleKeys = new LinkedHashSet<>();
+        // 可変KeyCounterの走査をBigInteger Mapの走査から分離し、二種類の実装を同時に触らない。
+        for (var entry : target) {
+            // 0以下はAE2側で在庫として見えていないため、Sidecarにも伝播しない。
+            if (entry.getLongValue() <= 0L) {
+                continue;
             }
+            visibleKeys.add(entry.getKey());
         }
+        return Collections.unmodifiableSet(visibleKeys);
+    }
+
+    /** 不変source Snapshotから、AE2のlong Facadeに残ったキーだけを抽出する。 */
+    private static Snapshot retainVisibleAmounts(
+            Snapshot sourceSnapshot,
+            Set<AEKey> visibleKeys) {
+        Map<AEKey, BigInteger> visible = new LinkedHashMap<>();
         Set<AEKey> exactVisible = new LinkedHashSet<>();
-        for (AEKey key : sourceSnapshot.exactKeys()) {
-            // 画面側Counterに存在しないキーを正確在庫として復活させない。
-            if (visible.containsKey(key)) {
+        // 可視キーSnapshotに存在する正確値だけを伝播し、AE2が除外したキーを復活させない。
+        for (Map.Entry<AEKey, BigInteger> entry : sourceSnapshot.amounts().entrySet()) {
+            AEKey key = entry.getKey();
+            // targetに存在しないキーは、BigInteger側だけで再追加しない。
+            if (!visibleKeys.contains(key)) {
+                continue;
+            }
+            visible.put(key, entry.getValue());
+            // sourceで値が証明済みのキーだけ、コピー先でもexactとして扱う。
+            if (sourceSnapshot.isExact(key)) {
                 exactVisible.add(key);
             }
         }
-        put(target, new Snapshot(visible, sourceSnapshot.complete(), exactVisible));
+        return new Snapshot(visible, sourceSnapshot.complete(), exactVisible);
     }
 
     /** long FacadeとBigInteger Sidecarを一つの独立したKeyCounterへ複製する。 */
@@ -194,7 +218,8 @@ public final class BigKeyCounterSidecars {
                     checked.put(key, amount);
                 }
             }
-            amounts = Map.copyOf(checked);
+            // Issue #93: MapNとfastutil検索のC2融合を避けるため、所有Mapを読み取り専用化する。
+            amounts = Collections.unmodifiableMap(checked);
 
             Set<AEKey> checkedExactKeys = new LinkedHashSet<>();
             for (AEKey key : exactKeys) {
@@ -204,7 +229,7 @@ public final class BigKeyCounterSidecars {
                     checkedExactKeys.add(key);
                 }
             }
-            exactKeys = Set.copyOf(checkedExactKeys);
+            exactKeys = Collections.unmodifiableSet(checkedExactKeys);
         }
 
         public BigInteger amount(AEKey key) {

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/BigKeyCounterSidecarsTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/BigKeyCounterSidecarsTest.java
@@ -1,0 +1,183 @@
+package com.syaru.ae2craftingoptimizer.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.AEKeyType;
+import appeng.api.stacks.KeyCounter;
+import java.math.BigInteger;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/** Issue #93のJava 25 C2クラッシュとSidecar可視性契約を固定する試験。 */
+class BigKeyCounterSidecarsTest {
+    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
+    /** 実際のfatal errorで処理中だった約11,892キーを上回るストレス試験件数。 */
+    private static final int STRESS_KEY_COUNT = 12_000;
+    /** C2のloop最適化を促しつつ、単体試験時間を抑える反復回数。 */
+    private static final int STRESS_COPY_ROUNDS = 8;
+
+    @AfterEach
+    void clearSidecars() {
+        BigKeyCounterSidecars.clearForTests();
+    }
+
+    @Test
+    void copiesOnlyPositiveVisibleKeysWithoutTruncatingExactAmounts() {
+        TestKey visibleKey = new TestKey("visible");
+        TestKey hiddenKey = new TestKey("hidden");
+        BigInteger exactAmount = LONG_MAX.add(BigInteger.ONE);
+        KeyCounter source = new KeyCounter();
+        BigKeyCounterSidecars.merge(
+                source,
+                new BigKeyCounterSidecars.Snapshot(
+                        Map.of(visibleKey, exactAmount, hiddenKey, BigInteger.TEN),
+                        true));
+
+        KeyCounter target = new KeyCounter();
+        target.set(visibleKey, Long.MAX_VALUE);
+        BigKeyCounterSidecars.copyVisible(source, target);
+
+        BigKeyCounterSidecars.Snapshot copied =
+                BigKeyCounterSidecars.snapshot(target).orElseThrow();
+        assertEquals(exactAmount, copied.amount(visibleKey));
+        assertEquals(BigInteger.ZERO, copied.amount(hiddenKey));
+        assertTrue(copied.isExact(visibleKey));
+        assertTrue(copied.complete());
+    }
+
+    @Test
+    void snapshotOwnsItsCollectionsAndExposesReadOnlyViews() {
+        TestKey key = new TestKey("owned");
+        Map<AEKey, BigInteger> mutableAmounts = new LinkedHashMap<>();
+        Set<AEKey> mutableExactKeys = new LinkedHashSet<>();
+        mutableAmounts.put(key, BigInteger.TEN);
+        mutableExactKeys.add(key);
+
+        BigKeyCounterSidecars.Snapshot snapshot =
+                new BigKeyCounterSidecars.Snapshot(
+                        mutableAmounts,
+                        false,
+                        mutableExactKeys);
+        mutableAmounts.clear();
+        mutableExactKeys.clear();
+
+        assertEquals(BigInteger.TEN, snapshot.amount(key));
+        assertTrue(snapshot.isExact(key));
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> snapshot.amounts().put(key, BigInteger.ONE));
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> snapshot.exactKeys().clear());
+    }
+
+    @Test
+    void repeatedlyCopiesAProductionSizedVisibleSnapshot() {
+        Map<AEKey, BigInteger> exactAmounts = new LinkedHashMap<>();
+        KeyCounter source = new KeyCounter();
+        KeyCounter target = new KeyCounter();
+        TestKey first = null;
+        TestKey last = null;
+
+        // fatal error時より多いキーを用意し、同じ可視コピー経路をloop最適化対象にする。
+        for (int index = 0; index < STRESS_KEY_COUNT; index++) {
+            TestKey key = new TestKey("stress_" + index);
+            // 境界キーを後段の正確値検証へ残す。
+            if (index == 0) {
+                first = key;
+            }
+            last = key;
+            BigInteger amount = LONG_MAX.add(BigInteger.valueOf(index + 1L));
+            exactAmounts.put(key, amount);
+            target.set(key, Long.MAX_VALUE);
+        }
+        BigKeyCounterSidecars.merge(
+                source,
+                new BigKeyCounterSidecars.Snapshot(exactAmounts, true));
+
+        // 同一targetのSidecarを繰り返し置換し、値・exactness・寿命管理を同時に検証する。
+        for (int round = 0; round < STRESS_COPY_ROUNDS; round++) {
+            BigKeyCounterSidecars.copyVisible(source, target);
+        }
+
+        BigKeyCounterSidecars.Snapshot copied =
+                BigKeyCounterSidecars.snapshot(target).orElseThrow();
+        assertEquals(STRESS_KEY_COUNT, copied.amounts().size());
+        assertEquals(LONG_MAX.add(BigInteger.ONE), copied.amount(first));
+        assertEquals(
+                LONG_MAX.add(BigInteger.valueOf(STRESS_KEY_COUNT)),
+                copied.amount(last));
+        assertTrue(copied.isExact(first));
+        assertTrue(copied.isExact(last));
+        assertFalse(copied.amounts().isEmpty());
+    }
+
+    /** Minecraft Registry初期化なしで多数の異なるAEKeyを作る最小実装。 */
+    private static final class TestKey extends AEKey {
+        private final ResourceLocation id;
+
+        private TestKey(String path) {
+            this.id = new ResourceLocation("ae2_crafting_optimizer", path);
+        }
+
+        @Override
+        public AEKeyType getType() {
+            return null;
+        }
+
+        @Override
+        public AEKey dropSecondary() {
+            return this;
+        }
+
+        @Override
+        public CompoundTag toTag() {
+            return new CompoundTag();
+        }
+
+        @Override
+        public Object getPrimaryKey() {
+            return id;
+        }
+
+        @Override
+        public ResourceLocation getId() {
+            return id;
+        }
+
+        @Override
+        public void writeToPacket(FriendlyByteBuf buffer) {
+            // Packet同期を行わない単体試験なので書き込みは不要。
+        }
+
+        @Override
+        protected Component computeDisplayName() {
+            return Component.literal(id.toString());
+        }
+
+        @Override
+        public void addDrops(
+                long amount,
+                List<ItemStack> drops,
+                Level level,
+                BlockPos pos) {
+            // ワールド内ドロップを扱わない単体試験なので処理は不要。
+        }
+    }
+}


### PR DESCRIPTION
## 概要

Java 25で`BigKeyCounterSidecars.copyVisible`がC2コンパイルされた際に発生した、サーバーJVMの`EXCEPTION_ACCESS_VIOLATION`を回避します。

Issue #93に対応するForge 1.20.1版です。

## 原因

不変Snapshotの`ImmutableCollections$MapN`を反復しながら、AE2 `KeyCounter.get`のfastutil木を同じループで検索していました。fatal errorのproblematic frameは、この複合ループを巨大にインライン化したC2 compiled methodでした。

## 変更

- targetの正量キー取得とsource BigInteger値の抽出を別工程へ分離
- SnapshotをACO所有の`LinkedHashMap`/`LinkedHashSet`へ複製して読み取り専用化
- BigInteger値、可視キー、キー単位exactness、complete flagを維持
- 12,000キーを8回コピーする回帰試験を追加
- Issue仕様書と回帰履歴を追加

## 検証

- Temurin 25.0.4+7で12,000キー回帰試験成功
- JUnit 344件: 失敗0、エラー0、スキップ2
- `gradlew clean build --no-daemon`: 成功
- Minecraft起動試験: 指示により未実施

## 境界

クラフト計画、CPU実行、外部MOD、在庫値の丸めには変更を加えていません。クライアント側TooManyRecipeViewersのlogout NPEは、サーバー消失後に発生した別MODの二次障害です。

Relates #93
