### PR TITLE
[1.20.1] Preserve exact BigInteger plans for external CPU consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.19] - 2026-08-15
+
+### Added
+
+- Added a public registration boundary for add-ons that consume exact
+  BigInteger crafting plans without transferring CPU execution ownership to ACO.
+
+### Fixed
+
+- Reattached exact BigInteger sidecars when AE2 rebuilds a crafting-plan facade.
+- Prevented wide plans from silently falling back to an overflowing standard
+  `long` CPU path when no compatible external consumer is registered.
+- Removed ACO-owned execution assumptions for InsaneAE; add-ons continue to own
+  their structures, dispatch, progress, cancellation, and completion.
+
 ## [1.5.18] - 2026-08-14
 
 ### Fixed

--- a/docs/CLASS_RESPONSIBILITIES.md
+++ b/docs/CLASS_RESPONSIBILITIES.md
@@ -293,6 +293,7 @@ mixin + access  ->  integration  ->  optimization / scheduler
 | `com.syaru.ae2craftingoptimizer.engine.CountOverflowException` | CountOverflowExceptionが示す失敗を呼出側へ型付きで通知する。 |
 | `com.syaru.ae2craftingoptimizer.engine.CraftingPlanShadowComparator` | ACO計画とAE2標準計画の結果・不足・bytesを比較し、不一致なら採用を拒否する。 |
 | `com.syaru.ae2craftingoptimizer.engine.ExactCraftingByteCounter` | AE2 15.4.10の線形CraftingTreeと同じ順番でCPU bytesを再計算する。 |
+| `com.syaru.ae2craftingoptimizer.engine.ExactPlanPatternRevalidator` | exact計画の提出時に参照Patternだけを現行CraftingService索引へ再照合し、無関係なProvider世代更新を区別する。 |
 | `com.syaru.ae2craftingoptimizer.engine.ExactCraftingJobLedger` | AE2実JobのBigIntegerカウンタを再起動後も検証する永続Journal。 |
 | `com.syaru.ae2craftingoptimizer.engine.ExactCraftingJobState` | Advanced AE実Jobへ付随するexact task、waiting、output、Receiptのsidecar正本。 |
 | `com.syaru.ae2craftingoptimizer.engine.GenerationAwareGraphCache` | GenerationAwareGraphCacheが示す既知結果を世代またはrevision付きで再利用し、変化時に失効する。 |

--- a/docs/CLASS_RESPONSIBILITIES.md
+++ b/docs/CLASS_RESPONSIBILITIES.md
@@ -553,3 +553,15 @@ mixin + access  ->  integration  ->  optimization / scheduler
 | クラス | 仕事 |
 |---|---|
 | `com.syaru.ae2craftingoptimizer.util.StableFingerprint` | StableFingerprintが示す対象を、順序と内容から安定して識別する。 |
+
+## BigInteger external-consumer boundary
+
+| クラス | 仕事 |
+|---|---|
+| `api.big.BigCraftingEngineApi` | 外部CPUコンシューマ登録と公開BigInteger計画APIの入口。外部CPUを実行しない。 |
+| `engine.Ae2CraftingPlanSidecars` | AE2のlong表示用`CraftingPlan`へ、正確なBigInteger計画をidentityで関連付ける。 |
+| `mixin.CraftingCalculationDiagnosticsMixin` | `CraftingCalculation`の実経路で返された計画へ、再構築後もsidecarを再接続する。 |
+| `mixin.CraftingCpuClusterBigCapacityGuardMixin` | 外部コンシューマ登録の有無と正確なsidecarを提出境界で確認する。実行・進捗は持たない。 |
+
+ACOの外部連携は上記の計画/API境界に限定する。InsaneAEのQuantum CPU実行、Bulk投入、
+進捗、完了会計、キャンセル、AQEのCPUホスト処理をACOへ戻してはいけない。

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -24,7 +24,7 @@ Important calculation options include:
 | Key | Default | Purpose |
 | --- | ---: | --- |
 | `enableAqeBigCraftingProfile` | `true` | Activates the narrow AQE compiled/checked profile only when Advanced AE and AQE are installed. |
-| `enableInsaneAeBigCraftingProfile` | `true` | Activates the same strict calculation profile when InsaneAE is installed, so InsaneAE does not apply a competing calculation batch. |
+| `enableExternalBigCraftingProfile` | `true` | Allows a registered external CPU consumer to accept an exact BigInteger plan. Registration is performed by the consumer through the public API. |
 | `enableLongRootCraftAmounts` | `true` | Adds the signed-long root-order path while preserving AE2's original int path. |
 | `enableCompiledCraftingGraph` | `true` | Reuses a generation-keyed deterministic graph where the active profile allows it. |
 | `enableShadowMode` | `true` | Compares eligible compiled results against AE2 without changing normal results. |

--- a/docs/EXPERIMENTAL_ENGINE.md
+++ b/docs/EXPERIMENTAL_ENGINE.md
@@ -11,8 +11,8 @@ runtime qualification is P9 and is intentionally left to the pack operator.
 
 General deep behavior-changing paths are deliberately **disabled by default**.
 The narrow AQE profile is enabled only when Advanced AE and Advanced Quantum
-Engineering are both loaded. The optional InsaneAE profile provides the same
-calculation boundary when InsaneAE is loaded. It activates compiled observation, checked
+Engineering are both loaded. A registered external consumer such as InsaneAE
+provides the external calculation boundary through the public API. It activates compiled observation, checked
 arithmetic, exact wide-capacity planning, BigInteger execution windows, and
 ordinary-long replacement only for roots whose current AE2 Pattern API,
 candidate set, inventory, and generations pass the strict proof. It does not
@@ -51,7 +51,7 @@ condition for the checked BigInteger path:
 ```toml
 [experimentalCraftingEngine]
 enableAqeBigCraftingProfile = true
-enableInsaneAeBigCraftingProfile = true
+enableExternalBigCraftingProfile = true
 enableLongRootCraftAmounts = true
 enableExperimentalCraftingEngine = false
 enableShadowMode = true

--- a/docs/FEATURE_OWNERSHIP.md
+++ b/docs/FEATURE_OWNERSHIP.md
@@ -1,70 +1,76 @@
 # Feature Ownership
 
+This document is the ownership boundary for the BigInteger integration. It is
+also a guard against reintroducing the execution ownership bugs recorded in
+`ISSUE-BIGINT-EXTERNAL-CONSUMER.md`.
+
 ## ACO Owns
 
-- Provider/recipe generation tracking
-- Compiled deterministic Pattern graphs
-- `long` and `BigInteger` planning
-- Exact boundary-input and final-output formulas
-- Parent CPU capacity reservation and job progress
-- Transaction-local crafting escrow
-- Exact ME storage before/after reconciliation
-- Cancellation, recovery, quarantine, and fallback decisions
-- Per-CPU and per-grid TPS budgets
-- BigInteger NBT and status protocol
+- AE2 recipe/provider generation tracking and deterministic planning.
+- The exact `long`/`BigInteger` calculation result, including missing amounts.
+- The public BigInteger plan API and plan sidecar association.
+- Exact plan inspection and diagnostics for a plan that AE2 represents with a
+  saturated `long` facade.
+- Lossless conversion of a BigInteger remainder into one bounded physical
+  execution window.
+- Its own generic AE2 optimization paths and their fallback rules.
 
-ACO never asks AAC to decide whether a parent job is complete.
-
-## AAC Owns
-
-- AAC block and multiblock registration
-- Neo ECO structure integration
-- Pattern Bus to Worker routing
-- One real `assemble` proof for each accepted crafting-table step
-- Neo ECO Thread progress and power
-- Worker-local live ownership
-- Durable terminal output receipts
-- Physical Thread cancellation before output is complete
-
-AAC does not compile the crafting tree, reserve ME storage, complete the AQE
-parent job, or generate the tree's final output.
+ACO does **not** own an external CPU's crafting loop, Pattern dispatch,
+`waitingFor`, progress, cancellation, output receipt, power accounting, or
+job completion. ACO never creates a second execution ledger for an external
+CPU and never treats a saturated AE2 value as an exact amount.
 
 ## AE2 Owns
 
-- Encoded Pattern identity
-- Normal crafting jobs and recipe eligibility
-- Standard CPU inventories and links
-- Normal Provider routing and machine work
-- Standard insertion/extraction when no exact sidecar path is active
+- Encoded Pattern identity and recipe eligibility.
+- The standard calculation service and normal `CraftingPlan` lifecycle.
+- Standard CPU selection, job submission, inventories, links, and normal
+  provider routing.
+- Standard insertion/extraction when no external exact consumer accepts the
+  plan.
 
-## Neo ECO Owns
+## InsaneAE Owns
 
-- Pattern Bus, Worker, and Thread lifecycle
-- Structure formation and cluster lists
-- Physical progress and power consumption
-- Physical Thread NBT
+- Quantum CPU structure, CPU selection, and one-CPU/one-job rules.
+- Quantum CPU execution, Bulk/Task Fusion dispatch, provider backpressure,
+  power use, progress, `waitingFor`, receipts, persistence, cancellation, and
+  completion.
+- Registration as an external ACO BigInteger plan consumer.
+- Its own bounded `long` execution windows and exact BigInteger remainder.
 
-AAC subclasses and narrowly extends these components. It does not replace the
-Neo ECO cluster implementation.
+ACO may expose the plan and API to InsaneAE, but must not add an InsaneAE
+execution Mixin, inspect InsaneAE internals, or submit work on its behalf.
 
-## AQE and Advanced AE
+## AQE Owns
 
-AQE is an optional BigInteger host integration for ACO. Advanced AE continues
-to own its Quantum Computer structure and active CPU implementation.
+- Advanced Quantum Engineering CPU structures, hosts, capacity calculation,
+  CPU selection, active jobs, progress, persistence, and completion.
+- Its optional reflective ACO adapter. The adapter only registers AQE as an
+  external plan consumer and reads the public ACO contract.
 
-AAC does not require AQE at runtime for its execution code. AQE-dependent AAC
-progression recipes are Forge-conditional and load only when AQE is installed.
+AQE and ACO remain optional dependencies. ACO must still load without AQE;
+AQE must still load without ACO and use its native exact backend.
 
-## Fallback Boundary
+## External Consumer Contract
 
-Before boundary input ownership moves, an unsupported or unavailable physical
-path may return to AE2's normal execution.
+An external consumer must:
 
-After ownership moves, fallback is forbidden. The transaction must:
+1. register through `BigCraftingEngineApi`;
+2. read the exact plan/sidecar rather than the saturated AE2 `long` field;
+3. compare the exact requested capacity with its own exact CPU capacity;
+4. execute only bounded physical windows;
+5. retain the BigInteger remainder and reconcile the actual accepted amount.
 
-1. resume from its receipts;
-2. cancel and return exact escrow; or
-3. quarantine when ownership cannot be proven.
+If any of these proofs is unavailable, the consumer declines the plan and AE2
+handles the normal path. Declining must not throw from the AE2 calculation
+thread and must not create a `+1` fallback, duplicate output, or lost input.
 
-This boundary prevents a normal fallback from executing the same work a second
-time.
+## Forbidden Changes
+
+- ACO-side Quantum CPU execution, Task Fusion, or progress replacement.
+- ACO-side InsaneAE/AQE structure, GUI, texture, recipe, power, or NBT
+  ownership.
+- Converting the exact plan to `long` before choosing a physical window.
+- Returning a saturated plan without preserving its exact sidecar.
+- Running the same plan once through an external consumer and again through
+  AE2 because the external consumer declined it.

--- a/docs/ISSUE-BIGINT-EXTERNAL-CONSUMER.md
+++ b/docs/ISSUE-BIGINT-EXTERNAL-CONSUMER.md
@@ -1,0 +1,61 @@
+# BigInteger external-consumer regression record
+
+## Symptom
+
+An order above `Long.MAX_VALUE` could be calculated through the direct ACO
+API, but the real AE2 `CraftingService.beginCraftingCalculation` path could
+return a saturated `CraftingPlan` with no exact sidecar. An external CPU then
+saw `Long.MAX_VALUE`, rejected a valid order as `CPU_TOO_SMALL`, or lost the
+exact remainder. A second symptom was a Quantum CPU receiving
+`maxPatterns = 1` and therefore processing only one physical recipe operation
+per tick even though its Bulk provider could accept a much larger bounded
+window.
+
+## Root causes
+
+- AE2 can rebuild or wrap the returned `CraftingPlan`; the sidecar was attached
+  only to the authoritative calculation object.
+- The exact Quantum path incorrectly used AE2's logical operation budget as
+  the physical Bulk capacity.
+- ACO had an InsaneAE-specific execution branch, which blurred ownership and
+  made the two mods compete for the same execution state.
+
+## Required fix
+
+- ACO keeps the exact BigInteger plan in a sidecar and aliases that sidecar to
+  a rebuilt AE2 plan returned from `CraftingCalculation.run`.
+- ACO exposes only the public plan/sidecar API and an explicit external-consumer
+  registration method.
+- InsaneAE registers itself, reads the exact sidecar, and owns Quantum CPU
+  execution. Its `BulkExecutionWindow` converts only one physical window to a
+  lossless `long`; the BigInteger remainder stays exact.
+- AQE registers itself through its optional adapter and keeps its own CPU host
+  and job processing.
+- If no external consumer is registered, a wide plan is declined without an
+  exception or fake saturated execution; AE2 owns the normal fallback.
+
+## Invariants
+
+- Exact plan, missing amounts, capacity, and remainder are never clamped to
+  `long` as the source of truth.
+- A physical window is positive, bounded by provider capacity, and accounted
+  for exactly once.
+- A declined external plan is not submitted a second time by the external
+  consumer.
+- Normal small AE2 orders retain the original AE2 result and execution path.
+- ACO contains no InsaneAE-specific execution Mixin or Quantum CPU loop.
+
+## Verification
+
+The independent tests cover exact window selection, `Long.MAX_VALUE` windows,
+BigInteger remainder conservation, external registration, sidecar aliasing,
+and the ownership boundary. Forge 1.20.1 and NeoForge 1.21.1 are built and
+tested separately; game startup and in-world GameTest execution remain an
+operator-side step.
+
+## GitHub tracking
+
+- ACO Issue [#44](https://github.com/syarukasu/ae2-crafting-optimizer/issues/44): long overflow must not silently return to the saturated AE2 path.
+- ACO Issue [#55](https://github.com/syarukasu/ae2-crafting-optimizer/issues/55): NeoForge duplicate-calculation cancellation must not cancel a shared owner.
+- InsaneAE Issue [#6](https://github.com/syarukasu/InsaneAE/issues/6): external ACO plan handoff and Quantum CPU execution boundary.
+- AQE Issue [#23](https://github.com/syarukasu/advanced-quantum-engineering/issues/23): optional ACO BigInteger host integration.

--- a/docs/REGRESSION_HISTORY.md
+++ b/docs/REGRESSION_HISTORY.md
@@ -8,6 +8,7 @@
 | [#79](https://github.com/syarukasu/ae2-crafting-optimizer/issues/79) | 一つのroot内部だけでsigned long境界を超えるexact計画が失われる | 1.5.17 | 1.5.18 | [ISSUE-79.md](issues/ISSUE-79.md) |
 | [#90](https://github.com/syarukasu/ae2-crafting-optimizer/issues/90) | 無関係なProvider世代更新でBigInteger計画が提出時に失効する | 1.5.18 | 未リリース | [ISSUE-90.md](issues/ISSUE-90.md) |
 | [#93](https://github.com/syarukasu/ae2-crafting-optimizer/issues/93) | Java 25でBigInteger在庫Sidecarの可視コピー中にJVMが終了する | 1.5.18 | 未定 | [ISSUE-93.md](issues/ISSUE-93.md) |
+| 外部コンシューマ回帰 | 実経路でsidecarが消える、またはQuantum Bulkが`maxPatterns=1`へ誤って制限される | 1.5.18系 | 作業中 | [ISSUE-BIGINT-EXTERNAL-CONSUMER.md](ISSUE-BIGINT-EXTERNAL-CONSUMER.md) |
 
 ## 運用
 

--- a/docs/REGRESSION_HISTORY.md
+++ b/docs/REGRESSION_HISTORY.md
@@ -6,6 +6,7 @@
 | Issue | 症状 | 影響版 | 修正版 | 仕様書 |
 |---|---|---:|---:|---|
 | [#79](https://github.com/syarukasu/ae2-crafting-optimizer/issues/79) | 一つのroot内部だけでsigned long境界を超えるexact計画が失われる | 1.5.17 | 1.5.18 | [ISSUE-79.md](issues/ISSUE-79.md) |
+| [#90](https://github.com/syarukasu/ae2-crafting-optimizer/issues/90) | 無関係なProvider世代更新でBigInteger計画が提出時に失効する | 1.5.18 | 未リリース | [ISSUE-90.md](issues/ISSUE-90.md) |
 
 ## 運用
 

--- a/docs/REGRESSION_HISTORY.md
+++ b/docs/REGRESSION_HISTORY.md
@@ -6,6 +6,7 @@
 | Issue | 症状 | 影響版 | 修正版 | 仕様書 |
 |---|---|---:|---:|---|
 | [#79](https://github.com/syarukasu/ae2-crafting-optimizer/issues/79) | 一つのroot内部だけでsigned long境界を超えるexact計画が失われる | 1.5.17 | 1.5.18 | [ISSUE-79.md](issues/ISSUE-79.md) |
+| [#93](https://github.com/syarukasu/ae2-crafting-optimizer/issues/93) | Java 25でBigInteger在庫Sidecarの可視コピー中にJVMが終了する | 1.5.18 | 未定 | [ISSUE-93.md](issues/ISSUE-93.md) |
 
 ## 運用
 

--- a/docs/RELEASE_NOTES_1.5.19.md
+++ b/docs/RELEASE_NOTES_1.5.19.md
@@ -1,0 +1,20 @@
+# AE2 Crafting Optimizer 1.5.19
+
+## English
+
+- Adds a public registration boundary for add-ons that consume exact
+  BigInteger crafting plans.
+- Preserves exact plan sidecars when AE2 rebuilds a `CraftingPlan` facade on
+  the live calculation path.
+- Prevents a wide plan from silently entering AE2's overflowing standard
+  `long` CPU path when no compatible external consumer is registered.
+- Keeps external CPU execution, progress, cancellation, GUI, structures, and
+  persistence owned by the add-on.
+
+## 日本語
+
+- 正確なBigIntegerクラフト計画を利用するアドオン向けに、公開登録境界を追加しました。
+- AE2の実計算経路で`CraftingPlan` Facadeが再構築されても、正確なsidecarを維持します。
+- 対応する外部コンシューマが未登録の場合、wide計画がoverflowするAE2標準`long` CPU経路へ
+  無言で入ることを防止します。
+- 外部CPUの実行、進捗、キャンセル、GUI、構造、永続化は各アドオン側の責務として維持します。

--- a/docs/issues/ISSUE-90.md
+++ b/docs/issues/ISSUE-90.md
@@ -1,0 +1,115 @@
+# Issue #90: 無関係なProvider更新で全BigInteger計画が提出時に失効する
+
+- GitHub Issue: https://github.com/syarukasu/ae2-crafting-optimizer/issues/90
+- 状態: In Progress
+- 影響版: ACO 1.5.18
+- 対象ローダー: Forge 1.20.1 / NeoForge 1.21.1
+- 関連Issue: #44、#64、#79
+
+## 問題
+
+正確なBigInteger計画を作成できても、計算後からCPU提出までにネットワーク内の
+無関係なPattern Providerが一件更新されると、全Provider共通の世代番号が変わります。
+`BigIntegerCraftingPlan`と`BigCapacityCraftingPlan`はこの全体世代だけを比較するため、
+注文が実際に使うPatternが一つも変わっていなくても`INCOMPLETE_PLAN`で拒否されます。
+
+## 再現と証拠
+
+- ACO 1.5.18、AQE BigInteger CPU、BigInteger在庫セルを使用
+- 20段の決定的な3x3圧縮計画を計算
+- 確認画面を開いている間に別Providerの内容または接続状態が更新される
+- 開始時に`Couldn't submit crafting job ... INCOMPLETE_PLAN`となる
+- 実ログでは同じ注文が4回連続で`INCOMPLETE_PLAN`になった
+- BigInteger backend、AQE/InsaneAE profile、compiled graph、atomic plan、gameplay executionは全て有効
+
+## 期待結果
+
+- 注文が参照する全Patternが現在のCraftingServiceに同じ実体として残る場合は提出できる
+- 注文が参照するPattern自身、レシピ、在庫、CPU容量が変わった場合は提出前に拒否する
+- 通常long計画とBigInteger計画で、無関係なProvider更新に対する扱いを不必要に変えない
+- BigInteger正本、在庫、欠品、容量、進捗をlongへ丸めない
+
+## 現在結果
+
+`generationsAreCurrent()`が全Provider共通世代の完全一致だけを要求します。大規模ネットワークでは
+確認画面を開いている短時間にも世代が進み、BigInteger計画だけが恒常的に提出不能になります。
+
+## 所有権
+
+- AE2: 現在のCraftingService索引、通常long計画、通常CPU提出
+- ACO: exact計画、参照Pattern集合、BigInteger sidecar、提出前のexact計画検証
+- AQE・InsaneAE: CPU構造と実行
+- fallback境界: exact計画の所有権移転前。wide計画を標準long計算へ落とさない
+
+## 維持する不変条件
+
+- レシピ世代が変わった計画は拒否する
+- 参照Patternが一件でも現在のCraftingServiceから消えた計画は拒否する
+- 無関係なProvider更新だけではexact計画を拒否しない
+- Provider再検証は計画に含まれる固有Pattern数にだけ比例させる
+- 提出後の取消、保存、進捗会計は変更しない
+
+## やってはいけないこと
+
+- 世代検査を無条件に削除する
+- Patternの内容が変わった計画を許可する
+- BigInteger計画をAE2標準long計画へフォールバックする
+- AQEまたはInsaneAEのCPU実行ロジックへ新しい介入を追加する
+- 全Providerを再走査して提出処理を重くする
+
+## 修正方針
+
+1. 同一の全体世代なら従来どおり即時に有効と判定する。
+2. 全体世代だけが変わった場合、計画が使う各`IPatternDetails`について、主出力の
+   `ICraftingService#getCraftingFor`に同一参照が残るかを再検証する。
+3. レシピ世代が変わった場合は再検証で救済せず拒否する。
+4. BigInteger計画とBigCapacity計画で同じ検証器を共有する。
+5. 拒否理由を診断へ記録し、`INCOMPLETE_PLAN`の原因を区別できるようにする。
+
+## 実装前チェック
+
+- [x] `docs/PROJECT_CHARTER.md`を読んだ
+- [x] `docs/REGRESSION_HISTORY.md`を読んだ
+- [x] 関連クラスと既存試験を読んだ
+- [x] 再現条件を試験へ変換した
+- [x] 所有権とfallback境界を確定した
+- [x] 禁止事項を明記した
+- [x] Forge/NeoForgeの適用範囲を確定した
+
+## 試験計画
+
+- 同一世代は再走査なしで成功
+- 無関係なProvider世代更新後も、全参照Patternが残れば成功
+- 参照Pattern削除後は失敗
+- 参照Pattern置換後は、内容が同じでも古い実体を実行せず失敗
+- レシピ世代更新後は失敗
+- Forge 1.20.1 / NeoForge 1.21.1の全JUnitと`clean build`
+
+## 実装結果
+
+- `ExactPlanPatternRevalidator`を追加した。
+- 計画時と現在のレシピ世代が異なる場合は従来どおり拒否する。
+- Provider世代が一致する場合は索引を再走査しない。
+- Provider世代だけが異なる場合は、計画に含まれるPatternを主出力ごとにまとめ、
+  現在の`CraftingService`索引へ同一参照で残るか再検証する。
+- Patternを参照しない在庫完結計画は、無関係なProvider世代更新だけでは拒否しない。
+- `BigIntegerCraftingPlan`と`BigCapacityCraftingPlan`の提出判定を共通検証器へ接続した。
+- 再検証に失敗した場合は`GENERATION_CHANGED`診断へ具体的理由を記録する。
+- 容量比較、在庫会計、Pattern回数、実行Job、取消・保存処理は変更していない。
+
+## 検証結果
+
+- Forge 1.20.1 targeted JUnit: 6件成功
+- Forge 1.20.1 full JUnit: 347件中345件成功、2件skip
+- Forge 1.20.1 `clean build`: 成功
+- NeoForge 1.21.1 targeted JUnit: 6件成功
+- NeoForge 1.21.1 full JUnit: 369件成功、失敗・skipなし
+- NeoForge 1.21.1 `clean build`: 成功
+- Minecraft起動試験: 指示により未実施
+
+## 完了
+
+- Forge PR:
+- NeoForge PR:
+- 修正版:
+- リリース:

--- a/docs/issues/ISSUE-90.md
+++ b/docs/issues/ISSUE-90.md
@@ -109,7 +109,7 @@
 
 ## 完了
 
-- Forge PR:
-- NeoForge PR:
+- Forge PR: https://github.com/syarukasu/ae2-crafting-optimizer/pull/91
+- NeoForge PR: https://github.com/syarukasu/ae2-crafting-optimizer/pull/92
 - 修正版:
 - リリース:

--- a/docs/issues/ISSUE-93.md
+++ b/docs/issues/ISSUE-93.md
@@ -1,0 +1,110 @@
+# Issue #93: Java 25でBigInteger在庫Sidecarの可視コピー中にJVMが終了する
+
+- GitHub Issue: https://github.com/syarukasu/ae2-crafting-optimizer/issues/93
+- 状態: Verified
+- 対象版: ACO 1.5.18
+- 対象ローダー: Forge 1.20.1 / NeoForge 1.21.1
+- 関連Issue・PR: PR未作成
+
+## 問題
+
+正確なBigInteger在庫SnapshotをAE2のクラフト計算用`KeyCounter`へ伝播中、
+Java例外ではなくJVMが`EXCEPTION_ACCESS_VIOLATION`で終了しました。Minecraftの
+クラッシュレポートや正常停止処理は残らず、接続中クライアントも切断されます。
+
+## 再現と証拠
+
+- Minecraft 1.20.1、ACO 1.5.18、Temurin 25.0.4+7、G1 GC
+- Arclight Forge 1.20.1のServer threadで発生
+- `hs_err_pid5116.log`のproblematic frameはC2コンパイル済み
+  `BigKeyCounterSidecars.copyVisible(KeyCounter, KeyCounter)`
+- 読み取り先は`0x000000007f7c8de0`
+- compiled methodは`ImmutableCollections$MapN`を反復しながら、AE2の
+  `KeyCounter.get`が持つfastutil木を同じループ内で検索していた
+- サーバー消失後のクライアントNPEはTooManyRecipeViewersのlogout処理で発生した
+  二次障害であり、このIssueの変更対象ではない
+
+## 期待結果
+
+- 正確なBigInteger在庫値を丸めずに別`KeyCounter`へ伝播できる。
+- Java 25で対象処理が高頻度にC2コンパイルされてもJVMが終了しない。
+- AE2側で除外済みのキーをSidecarだけで復活させない。
+- source/targetが同一でも別インスタンスでも既存の可視性契約を維持する。
+
+## 現在結果
+
+不変Snapshotの`MapN`反復と可変`KeyCounter`検索が一つの大きなC2 methodへ融合し、
+Java 25上でネイティブアクセス違反を起こしました。
+
+## 所有権
+
+- AE2が所有する状態: long facadeの`KeyCounter`と可視キー集合
+- ACOが所有する状態: `KeyCounter`へ関連付ける不変BigInteger Snapshot
+- 任意アドオンが所有する状態: 一基ごとの正確なBigInteger在庫値
+- fallback可能な境界: Sidecarが存在しない場合だけlong facadeを正本にする
+
+## 維持する不変条件
+
+- BigInteger正本を`long`へクランプ、飽和、切り捨てしない。
+- targetのlong facadeに正量で存在するキーだけを伝播する。
+- Snapshot公開後に呼出側からMap/Setを変更できない。
+- source Snapshotとtarget可視キーを独立した一時点Snapshotとして扱う。
+- SidecarのIdentity弱参照による寿命管理を維持する。
+
+## やってはいけないこと
+
+- ACOのBigInteger在庫機能を無効化して回避する。
+- JVM起動引数へACO固有の`CompileCommand`を必須化する。
+- Java 25だけを一律非対応にして原因を隠す。
+- 可視性判定を省略して、抽出済みキーを復活させる。
+- クライアント側TooManyRecipeViewersをACOから改変する。
+
+## 修正方針
+
+`Snapshot`のMap/SetをACO所有の順序保持コレクションへ複製し、その読み取り専用viewを
+公開します。`copyVisible`はtargetの正量キー取得とsourceの正確値抽出を別工程へ分け、
+JDKの`MapN`反復とfastutil検索を一つのC2ループへ融合させません。
+
+## 実装前チェック
+
+- [x] `docs/PROJECT_CHARTER.md`を読んだ
+- [x] `docs/REGRESSION_HISTORY.md`を読んだ
+- [x] 関連クラスと既存試験を読んだ
+- [x] 再現条件を試験へ変換した
+- [x] 所有権とfallback境界を確定した
+- [x] 禁止事項を明記した
+- [x] Forge/NeoForgeの適用範囲を確定した
+
+## 試験計画
+
+- 単体試験: 可視キーだけのexact値・exact key・complete flag伝播
+- 境界試験: `Long.MAX_VALUE + 1`を丸めず維持
+- 故障試験: 元Map/Set変更後もSnapshotが変わらない
+- ストレス試験: 同一targetへの高頻度コピーで値と正確性が変化しない
+- ビルド: 両版のJUnit、静的検査、`clean build`
+- GameTestまたはユーザー側確認: Minecraft起動はユーザー側確認
+
+## 実装結果
+
+- `BigKeyCounterSidecars.copyVisible`から`KeyCounter.get`を使う複合ループを除去した。
+- targetの正量キー取得とsource BigInteger値の抽出を別メソッドへ分離した。
+- SnapshotのMap/SetをACO所有の`LinkedHashMap`/`LinkedHashSet`へ複製し、
+  `Collections.unmodifiableMap`/`unmodifiableSet`で公開するよう変更した。
+- 12,000キーを8回コピーするJava 25向け回帰試験を追加した。
+- BigInteger値、可視キー、キー単位exactness、complete flag、弱参照管理を維持した。
+
+## 検証結果
+
+- Forge 1.20.1: JUnit 344件、失敗0、エラー0、スキップ2
+- NeoForge 1.21.1: JUnit 366件、失敗0、エラー0、スキップ0
+- Temurin 25.0.4+7: 両版の12,000キー回帰試験成功
+- Forge 1.20.1 `clean build`: 成功
+- NeoForge 1.21.1 `clean build`: 成功
+- Minecraftクライアント・専用サーバー起動: 指示により未実施
+
+## 完了
+
+- PR: 未作成
+- マージコミット: 未定
+- 修正版: 未定
+- リリース: 未定

--- a/docs/issues/ISSUE-93.md
+++ b/docs/issues/ISSUE-93.md
@@ -4,7 +4,7 @@
 - 状態: Verified
 - 対象版: ACO 1.5.18
 - 対象ローダー: Forge 1.20.1 / NeoForge 1.21.1
-- 関連Issue・PR: PR未作成
+- 関連Issue・PR: PR #94、PR #95
 
 ## 問題
 
@@ -104,7 +104,7 @@ JDKの`MapN`反復とfastutil検索を一つのC2ループへ融合させませ�
 
 ## 完了
 
-- PR: 未作成
+- PR: Forge #94、NeoForge #95
 - マージコミット: 未定
 - 修正版: 未定
 - リリース: 未定

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -17,3 +17,4 @@
 - [Issue #79](ISSUE-79.md): 一つのroot内部だけでsigned long境界を超える計画
 - [Issue #84](ISSUE-84.md): Issue先行開発手順とプロジェクト境界
 - [Issue #87](ISSUE-87.md): 全クラスの責務明文化とexact数量Mapの安全な共通化
+- [Issue #93](ISSUE-93.md): Java 25でBigInteger在庫Sidecarの可視コピー中にJVMが終了する

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.18
+mod_version=1.5.19
 minecraft_version=1.20.1
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java
@@ -15,6 +15,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import appeng.api.crafting.IPatternDetails;
 import appeng.api.networking.crafting.ICraftingPlan;
 import appeng.api.stacks.AEKey;
@@ -33,12 +34,30 @@ public final class BigCraftingEngineApi {
     public static final int CALCULATION_PROFILE_API_VERSION = 1;
     /** アドオンがACOの正確なBigInteger上限を照会するAPIの契約番号。 */
     public static final int CAPACITY_LIMIT_API_VERSION = 1;
+    /** Version of the generic external CPU submission-boundary registration. */
+    public static final int EXTERNAL_CONSUMER_API_VERSION = 1;
+    private static final AtomicInteger EXTERNAL_CONSUMER_COUNT = new AtomicInteger();
 
     private BigCraftingEngineApi() {
     }
 
     public static boolean isEnabled() {
         return ACOConfig.enableBigIntegerCraftingBackend();
+    }
+
+    /**
+     * Registers a CPU add-on that owns execution of ACO BigInteger plans.
+     *
+     * <p>The registration is deliberately capability-based. ACO does not name,
+     * load, tick, or inspect any particular external CPU implementation.</p>
+     */
+    public static void registerExternalBigIntegerPlanConsumer() {
+        EXTERNAL_CONSUMER_COUNT.incrementAndGet();
+    }
+
+    /** Returns whether an external CPU has claimed the BigInteger submission boundary. */
+    public static boolean hasExternalBigIntegerPlanConsumer() {
+        return EXTERNAL_CONSUMER_COUNT.get() > 0;
     }
 
     /**

--- a/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
@@ -170,7 +170,7 @@ public final class ACOConfig {
     private static final ForgeConfigSpec.BooleanValue LOG_CACHE_STATISTICS;
     private static final ForgeConfigSpec.BooleanValue LOG_BIG_INTEGER_PLAN_DECLINES;
     private static final ForgeConfigSpec.BooleanValue ENABLE_AQE_BIG_CRAFTING_PROFILE;
-    private static final ForgeConfigSpec.BooleanValue ENABLE_INSANE_AE_BIG_CRAFTING_PROFILE;
+    private static final ForgeConfigSpec.BooleanValue ENABLE_EXTERNAL_BIG_CRAFTING_PROFILE;
     private static final ForgeConfigSpec.BooleanValue ENABLE_LONG_ROOT_CRAFT_AMOUNTS;
     private static final ForgeConfigSpec.BooleanValue ENABLE_EXPERIMENTAL_CRAFTING_ENGINE;
     private static final ForgeConfigSpec.BooleanValue ENABLE_CRAFTING_ENGINE_SHADOW_MODE;
@@ -735,12 +735,12 @@ public final class ACOConfig {
                         "Enable only the AQE BigInteger calculation and execution path when Advanced AE and Advanced Quantum Engineering are installed.",
                         "This does not enable Native Batch, bus rewrites, terminal rewrites, or normal-AE2 authoritative replacement.")
                 .define("enableAqeBigCraftingProfile", true);
-        ENABLE_INSANE_AE_BIG_CRAFTING_PROFILE = builder
+        ENABLE_EXTERNAL_BIG_CRAFTING_PROFILE = builder
                 .comment(
-                        "Enable the same strict BigInteger calculation profile when InsaneAE is installed.",
-                        "InsaneAE's calculation batch mixin defers to ACO while this profile is active.",
+                        "Enable the strict BigInteger calculation profile for an external CPU add-on.",
+                        "The add-on must explicitly register the public BigInteger plan-consumer API.",
                         "This does not enable Native Batch, bus rewrites, terminal rewrites, or ambiguous recipe replacement.")
-                .define("enableInsaneAeBigCraftingProfile", true);
+                .define("enableExternalBigCraftingProfile", true);
         ENABLE_LONG_ROOT_CRAFT_AMOUNTS = builder
                 .comment(
                         "Allow the AE2 craft-amount screen to submit root amounts from Integer.MAX_VALUE + 1 through Long.MAX_VALUE.",
@@ -1604,19 +1604,14 @@ public final class ACOConfig {
                 && ModList.get().isLoaded("advanced_quantum_engineering");
     }
 
-    /**
-     * InsaneAE搭載時だけ、AQEと同じ厳密BigInteger計算プロファイルを有効にする。
-     * 計画を作れない環境へ広い値を公開しないよう、設定とMod検出を両方確認する。
-     */
-    public static boolean enableInsaneAeBigCraftingProfile() {
-        return enableOptimizer()
-                && ENABLE_INSANE_AE_BIG_CRAFTING_PROFILE.get()
-                && ModList.get().isLoaded("insaneae");
+    /** 外部CPUアドオン向けの厳密BigInteger計算プロファイルを設定で切り替える。 */
+    public static boolean enableExternalBigCraftingProfile() {
+        return enableOptimizer() && ENABLE_EXTERNAL_BIG_CRAFTING_PROFILE.get();
     }
 
-    /** AQEまたはInsaneAEがBigInteger計算の連携先として存在するか。 */
+    /** AQEまたは公開APIへ登録された外部CPUがBigInteger計算の連携先として存在するか。 */
     public static boolean enableBigCraftingProfile() {
-        return enableAqeBigCraftingProfile() || enableInsaneAeBigCraftingProfile();
+        return enableAqeBigCraftingProfile() || enableExternalBigCraftingProfile();
     }
 
     public static boolean enableLongRootCraftAmounts() {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2CraftingPlanSidecars.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2CraftingPlanSidecars.java
@@ -50,6 +50,31 @@ public final class Ae2CraftingPlanSidecars {
         return facade;
     }
 
+    /**
+     * AE2や重複計算キャッシュが同じ内容のCraftingPlanを再構築した場合に、
+     * 元のACO計画の正確なSidecarだけを新しいFacadeへ引き継ぐ。
+     *
+     * <p>内容やbytesが同じという理由で別Jobへ紐付けることはしない。
+     * 元計画にACO Sidecarが無い場合も、通常AE2計画へ推測で追加しない。</p>
+     */
+    public static void alias(ICraftingPlan alias, ICraftingPlan source) {
+        // AE2の具体Facadeだけへ結び付け、ACO独自Planや外部Planを推測で書き換えない。
+        if (!(alias instanceof CraftingPlan aliasFacade) || alias == source) {
+            return;
+        }
+        // 同じ計算インスタンスのmetadataだけを再利用し、同値な別注文を混同しない。
+        WideCraftingPlan metadata = metadata(source).orElse(null);
+        if (metadata == null) {
+            return;
+        }
+        synchronized (SIDECARS) {
+            removeCollectedFacades();
+            SIDECARS.put(
+                    new IdentityWeakReference(aliasFacade, COLLECTED_FACADES),
+                    metadata);
+        }
+    }
+
     /** 純正Facadeまたは旧内部呼出しのACO計画から、正確なSidecarを取得する。 */
     public static Optional<WideCraftingPlan> metadata(ICraftingPlan plan) {
         if (plan instanceof WideCraftingPlan widePlan) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigCapacityCraftingPlan.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigCapacityCraftingPlan.java
@@ -1,6 +1,7 @@
 package com.syaru.ae2craftingoptimizer.engine;
 
 import appeng.api.crafting.IPatternDetails;
+import appeng.api.networking.IGrid;
 import appeng.api.stacks.GenericStack;
 import appeng.api.stacks.KeyCounter;
 import com.syaru.ae2craftingoptimizer.optimization.ProviderPatternGenerationTracker;
@@ -105,7 +106,30 @@ public final class BigCapacityCraftingPlan implements WideCraftingPlan {
         return exactBytes;
     }
 
-    /** 計算後にPatternまたはレシピが変わった計画を送信しない。 */
+    /** CPU提出時に、この計画が実際に参照するPatternだけを現在索引へ再照合する。 */
+    public ExactPlanPatternRevalidator.Result validateForSubmission(IGrid grid) {
+        return ExactPlanPatternRevalidator.validate(
+                grid,
+                patternGeneration,
+                recipeGeneration,
+                patternTimes.keySet());
+    }
+
+    public long patternGeneration() {
+        return patternGeneration;
+    }
+
+    public long recipeGeneration() {
+        return recipeGeneration;
+    }
+
+    /**
+     * 全体世代だけを確認する旧互換API。
+     *
+     * @deprecated CPU提出時は、無関係なProvider更新を区別できる
+     *     {@link #validateForSubmission(IGrid)}を使用する。
+     */
+    @Deprecated(forRemoval = false)
     public boolean generationsAreCurrent() {
         return patternGeneration == ProviderPatternGenerationTracker.generation()
                 && recipeGeneration == RecipeGenerationTracker.generation();

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerCraftingPlan.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerCraftingPlan.java
@@ -1,6 +1,7 @@
 package com.syaru.ae2craftingoptimizer.engine;
 
 import appeng.api.crafting.IPatternDetails;
+import appeng.api.networking.IGrid;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.GenericStack;
 import appeng.api.stacks.KeyCounter;
@@ -135,7 +136,30 @@ public final class BigIntegerCraftingPlan implements WideCraftingPlan {
         submissionClaimed.set(false);
     }
 
-    /** 計算後にPatternまたはrecipeが変わった親Jobを実行しない。 */
+    /** CPU提出時に、この親Jobが実際に参照するPatternだけを現在索引へ再照合する。 */
+    public ExactPlanPatternRevalidator.Result validateForSubmission(IGrid grid) {
+        return ExactPlanPatternRevalidator.validate(
+                grid,
+                preparedRoot.patternGeneration(),
+                preparedRoot.recipeGeneration(),
+                exactPatternTimes.keySet());
+    }
+
+    public long patternGeneration() {
+        return preparedRoot.patternGeneration();
+    }
+
+    public long recipeGeneration() {
+        return preparedRoot.recipeGeneration();
+    }
+
+    /**
+     * 全体世代だけを確認する旧互換API。
+     *
+     * @deprecated CPU提出時は、無関係なProvider更新を区別できる
+     *     {@link #validateForSubmission(IGrid)}を使用する。
+     */
+    @Deprecated(forRemoval = false)
     public boolean generationsAreCurrent() {
         return preparedRoot.patternGeneration() == ProviderPatternGenerationTracker.generation()
                 && preparedRoot.recipeGeneration() == RecipeGenerationTracker.generation();

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigKeyCounterSidecars.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigKeyCounterSidecars.java
@@ -5,6 +5,7 @@ import appeng.api.stacks.KeyCounter;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -74,22 +75,45 @@ public final class BigKeyCounterSidecars {
             return;
         }
 
-        Map<AEKey, BigInteger> visible = new LinkedHashMap<>();
-        // AE2の抽出Simulationで除外されたキーをBigInteger側だけ復活させない。
-        for (Map.Entry<AEKey, BigInteger> entry : sourceSnapshot.amounts().entrySet()) {
-            // long側に正の在庫として残ったキーだけを計画用Sidecarへ伝播する。
-            if (target.get(entry.getKey()) > 0L) {
-                visible.put(entry.getKey(), entry.getValue());
+        // Issue #93: KeyCounter検索とJDK MapN反復を同じC2ループへ融合させない。
+        Set<AEKey> visibleKeys = capturePositiveKeys(target);
+        put(target, retainVisibleAmounts(sourceSnapshot, visibleKeys));
+    }
+
+    /** AE2のlong Facadeから、現在正量として見えているキーだけを独立Snapshotへ取り出す。 */
+    private static Set<AEKey> capturePositiveKeys(KeyCounter target) {
+        Set<AEKey> visibleKeys = new LinkedHashSet<>();
+        // 可変KeyCounterの走査をBigInteger Mapの走査から分離し、二種類の実装を同時に触らない。
+        for (var entry : target) {
+            // 0以下はAE2側で在庫として見えていないため、Sidecarにも伝播しない。
+            if (entry.getLongValue() <= 0L) {
+                continue;
             }
+            visibleKeys.add(entry.getKey());
         }
+        return Collections.unmodifiableSet(visibleKeys);
+    }
+
+    /** 不変source Snapshotから、AE2のlong Facadeに残ったキーだけを抽出する。 */
+    private static Snapshot retainVisibleAmounts(
+            Snapshot sourceSnapshot,
+            Set<AEKey> visibleKeys) {
+        Map<AEKey, BigInteger> visible = new LinkedHashMap<>();
         Set<AEKey> exactVisible = new LinkedHashSet<>();
-        for (AEKey key : sourceSnapshot.exactKeys()) {
-            // 画面側Counterに存在しないキーを正確在庫として復活させない。
-            if (visible.containsKey(key)) {
+        // 可視キーSnapshotに存在する正確値だけを伝播し、AE2が除外したキーを復活させない。
+        for (Map.Entry<AEKey, BigInteger> entry : sourceSnapshot.amounts().entrySet()) {
+            AEKey key = entry.getKey();
+            // targetに存在しないキーは、BigInteger側だけで再追加しない。
+            if (!visibleKeys.contains(key)) {
+                continue;
+            }
+            visible.put(key, entry.getValue());
+            // sourceで値が証明済みのキーだけ、コピー先でもexactとして扱う。
+            if (sourceSnapshot.isExact(key)) {
                 exactVisible.add(key);
             }
         }
-        put(target, new Snapshot(visible, sourceSnapshot.complete(), exactVisible));
+        return new Snapshot(visible, sourceSnapshot.complete(), exactVisible);
     }
 
     /** long FacadeとBigInteger Sidecarを一つの独立したKeyCounterへ複製する。 */
@@ -194,7 +218,8 @@ public final class BigKeyCounterSidecars {
                     checked.put(key, amount);
                 }
             }
-            amounts = Map.copyOf(checked);
+            // Issue #93: MapNとfastutil検索のC2融合を避けるため、所有Mapを読み取り専用化する。
+            amounts = Collections.unmodifiableMap(checked);
 
             Set<AEKey> checkedExactKeys = new LinkedHashSet<>();
             for (AEKey key : exactKeys) {
@@ -204,7 +229,7 @@ public final class BigKeyCounterSidecars {
                     checkedExactKeys.add(key);
                 }
             }
-            exactKeys = Set.copyOf(checkedExactKeys);
+            exactKeys = Collections.unmodifiableSet(checkedExactKeys);
         }
 
         public BigInteger amount(AEKey key) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/ExactPlanPatternRevalidator.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/ExactPlanPatternRevalidator.java
@@ -1,0 +1,130 @@
+package com.syaru.ae2craftingoptimizer.engine;
+
+import appeng.api.crafting.IPatternDetails;
+import appeng.api.networking.IGrid;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.GenericStack;
+import com.syaru.ae2craftingoptimizer.optimization.ProviderPatternGenerationTracker;
+import java.util.Collection;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Exact計画が参照するPatternだけを、CPU提出直前のCraftingServiceへ再照合する。
+ *
+ * <p>Issue #90: 全Provider共通世代だけを比較すると、無関係なProvider更新でも
+ * BigInteger計画がすべて失効する。全体世代が変わった場合だけ、計画内のPatternが
+ * 現在の索引に同一参照で残ることを確認する。</p>
+ */
+public final class ExactPlanPatternRevalidator {
+    private ExactPlanPatternRevalidator() {
+    }
+
+    public static Result validate(
+            IGrid grid,
+            long plannedPatternGeneration,
+            long plannedRecipeGeneration,
+            Collection<IPatternDetails> plannedPatterns) {
+        Objects.requireNonNull(grid, "grid");
+        return validate(
+                plannedPatternGeneration,
+                plannedRecipeGeneration,
+                ProviderPatternGenerationTracker.generation(),
+                RecipeGenerationTracker.generation(),
+                plannedPatterns,
+                key -> grid.getCraftingService().getCraftingFor(key));
+    }
+
+    static Result validate(
+            long plannedPatternGeneration,
+            long plannedRecipeGeneration,
+            long currentPatternGeneration,
+            long currentRecipeGeneration,
+            Collection<IPatternDetails> plannedPatterns,
+            Function<AEKey, Collection<IPatternDetails>> currentPatterns) {
+        Objects.requireNonNull(plannedPatterns, "plannedPatterns");
+        Objects.requireNonNull(currentPatterns, "currentPatterns");
+
+        // Recipe reload後は同じPattern参照でも意味が変わり得るため、再利用しない。
+        if (plannedRecipeGeneration != currentRecipeGeneration) {
+            return Result.RECIPE_GENERATION_CHANGED;
+        }
+        // 同じ全体世代なら、計画時の厳密Topology検証をそのまま利用できる。
+        if (plannedPatternGeneration == currentPatternGeneration) {
+            return Result.CURRENT_GENERATION;
+        }
+        // Patternを持たない在庫完結計画には、Provider世代で失効する参照が存在しない。
+        if (plannedPatterns.isEmpty()) {
+            return Result.REFERENCED_PATTERNS_REVALIDATED;
+        }
+
+        Map<AEKey, Set<IPatternDetails>> requiredByOutput = new LinkedHashMap<>();
+        // 主出力ごとに必要Patternをまとめ、CraftingService索引の取得を一回へ抑える。
+        for (IPatternDetails pattern : plannedPatterns) {
+            IPatternDetails checkedPattern = Objects.requireNonNull(pattern, "planned pattern");
+            GenericStack primaryOutput = checkedPattern.getPrimaryOutput();
+            // 主出力なしのPatternは現在索引から安全に引き直せないため拒否する。
+            if (primaryOutput == null) {
+                return Result.REFERENCED_PATTERN_CHANGED;
+            }
+            requiredByOutput
+                    .computeIfAbsent(
+                            primaryOutput.what(),
+                            ignored -> java.util.Collections.newSetFromMap(
+                                    new IdentityHashMap<>()))
+                    .add(checkedPattern);
+        }
+
+        // 無関係なProvider更新は許容し、計画が実際に使うPatternだけを再照合する。
+        for (Map.Entry<AEKey, Set<IPatternDetails>> entry : requiredByOutput.entrySet()) {
+            Collection<IPatternDetails> indexed = currentPatterns.apply(entry.getKey());
+            // 出力索引自体が消えた場合は、古いPatternを実行対象へ残さない。
+            if (indexed == null || indexed.isEmpty()) {
+                return Result.REFERENCED_PATTERN_CHANGED;
+            }
+            Set<IPatternDetails> missing = java.util.Collections.newSetFromMap(
+                    new IdentityHashMap<>());
+            missing.addAll(entry.getValue());
+            // equalsではなく同一参照を照合し、同内容に見える差し替えを誤採用しない。
+            for (IPatternDetails current : indexed) {
+                missing.remove(current);
+                // この出力に必要な全Patternが見つかれば残りの索引走査を省略する。
+                if (missing.isEmpty()) {
+                    break;
+                }
+            }
+            // 一件でも参照Patternが消えていれば、計画全体を提出前に拒否する。
+            if (!missing.isEmpty()) {
+                return Result.REFERENCED_PATTERN_CHANGED;
+            }
+        }
+        return Result.REFERENCED_PATTERNS_REVALIDATED;
+    }
+
+    public enum Result {
+        CURRENT_GENERATION(true, "planning generations are current"),
+        REFERENCED_PATTERNS_REVALIDATED(true, "referenced patterns remain current"),
+        RECIPE_GENERATION_CHANGED(false, "recipe generation changed after planning"),
+        REFERENCED_PATTERN_CHANGED(false, "a referenced pattern changed after planning");
+
+        private final boolean valid;
+        private final String detail;
+
+        Result(boolean valid, String detail) {
+            this.valid = valid;
+            this.detail = detail;
+        }
+
+        public boolean valid() {
+            return valid;
+        }
+
+        public String detail() {
+            return detail;
+        }
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExperimentalCompatibilityValidator.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExperimentalCompatibilityValidator.java
@@ -37,8 +37,8 @@ public final class ExperimentalCompatibilityValidator {
     public static void validateEnabledFeatures() {
         List<String> failures = new ArrayList<>();
         /*
-         * InsaneAE単独プロファイルもBigInteger計算を使用する。
-         * AQEだけを見て早期returnすると、同じ必須Mixinの欠落を見逃すため共通判定を使う。
+         * AQEまたは登録済み外部コンシューマがBigInteger計算を使用する。
+         * 片方だけを見て早期returnすると、共通計算境界の欠落を見逃すため共通判定を使う。
          */
         boolean strictCraftingProfile = ACOConfig.enableExperimentalCraftingEngine()
                 || ACOConfig.enableBigCraftingProfile();

--- a/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOStartupReport.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOStartupReport.java
@@ -181,10 +181,10 @@ final class ACOStartupReport {
                 ACOConfig.coalesceAssemblerMatrixStatusUpdates());
         logDeepRewriteFlags();
         AE2CraftingOptimizer.LOGGER.info(
-                "ACO experimental crafting engine: {} (AQE profile {}, InsaneAE profile {}, shadow {}, compiled graph {}, proof-qualified long plans {}, transaction V2 {}, GT native {}, Mekanism native {}, fair scheduler {}, persistent journal {})",
+                "ACO experimental crafting engine: {} (AQE profile {}, external CPU profile {}, shadow {}, compiled graph {}, proof-qualified long plans {}, transaction V2 {}, GT native {}, Mekanism native {}, fair scheduler {}, persistent journal {})",
                 ACOConfig.enableExperimentalCraftingEngine(),
                 ACOConfig.enableAqeBigCraftingProfile(),
-                ACOConfig.enableInsaneAeBigCraftingProfile(),
+                ACOConfig.enableExternalBigCraftingProfile(),
                 ACOConfig.enableCraftingEngineShadowMode(),
                 ACOConfig.enableCompiledCraftingGraph(),
                 ACOConfig.enableProofQualifiedLongPlans(),

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AcoMixinPlugin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AcoMixinPlugin.java
@@ -23,12 +23,6 @@ public final class AcoMixinPlugin implements IMixinConfigPlugin {
             return shouldApplyNeoEcoExecutionMixin(simpleName, loadedNeoEcoExecutionProfile());
         }
 
-        // InsaneAEが同じAE2実行入口を所有する場合は、ACOの予算・通常Batch入口を重ねない。
-        // BigInteger会計とAQE専用のAdvanced AE連携Mixinはこの除外対象に含めない。
-        if (isInsaneAeLoadedDuringBootstrap()
-                && isInsaneAeOwnedExecutionMixin(mixinClassName)) {
-            return false;
-        }
         if (!isUelmLoadedDuringBootstrap()) {
             return true;
         }
@@ -55,20 +49,6 @@ public final class AcoMixinPlugin implements IMixinConfigPlugin {
                 || "NeoEco20_4CraftingCpuExecutionBudgetMixin".equals(simpleName);
     }
 
-    static boolean isInsaneAeOwnedExecutionMixin(String mixinClassName) {
-        String simpleName = simpleMixinName(mixinClassName);
-        return switch (simpleName) {
-            // 実行予算と実行入口だけをInsaneAEへ委譲する。
-            // BatchSourceReceiptMixinは実行を変更せず、V2会計に必要な状態APIを付与するため残す。
-            case "CraftingCpuLogicExecutionBudgetMixin",
-                    "CraftingCpuLogicTransactionalBatchV2Mixin",
-                    // Advanced AEの通常executeCraftingもInsaneAE側の互換Mixinを優先する。
-                    "AdvancedAeCraftingCpuLogicExecutionBudgetMixin",
-                    "AdvancedAeCraftingCpuLogicTransactionalBatchV2Mixin" -> true;
-            default -> false;
-        };
-    }
-
     /**
      * Mixinが渡す完全修飾名から、登録名との比較に使う単純名を取り出す。
      * 実行時の値はパッケージ付きになるため、単純名へ正規化しないと競合除外が働かない。
@@ -76,15 +56,6 @@ public final class AcoMixinPlugin implements IMixinConfigPlugin {
     private static String simpleMixinName(String mixinClassName) {
         int separator = mixinClassName.lastIndexOf('.');
         return separator >= 0 ? mixinClassName.substring(separator + 1) : mixinClassName;
-    }
-
-    private static boolean isInsaneAeLoadedDuringBootstrap() {
-        try {
-            return FMLLoader.getLoadingModList().getModFileById("insaneae") != null;
-        } catch (RuntimeException | LinkageError ignored) {
-            // 起動初期に判定できない場合は、既存のACO経路を維持する。
-            return false;
-        }
     }
 
     private static boolean isUelmLoadedDuringBootstrap() {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeBigCapacityPlanSubmissionMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeBigCapacityPlanSubmissionMixin.java
@@ -5,6 +5,7 @@ import appeng.api.networking.crafting.ICraftingPlan;
 import appeng.api.networking.crafting.ICraftingRequester;
 import appeng.api.networking.crafting.ICraftingSubmitResult;
 import appeng.api.networking.security.IActionSource;
+import appeng.api.stacks.GenericStack;
 import appeng.api.stacks.KeyCounter;
 import appeng.crafting.CraftingPlan;
 import appeng.crafting.execution.CraftingSubmitResult;
@@ -17,7 +18,10 @@ import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
 import com.syaru.ae2craftingoptimizer.engine.BigCapacityCraftingPlan;
 import com.syaru.ae2craftingoptimizer.engine.BigIntegerCraftingPlan;
+import com.syaru.ae2craftingoptimizer.engine.ExactPlanPatternRevalidator;
 import com.syaru.ae2craftingoptimizer.integration.AqeBigCraftingExecutionContext;
+import com.syaru.ae2craftingoptimizer.optimization.BigIntegerPlanDeclineReason;
+import com.syaru.ae2craftingoptimizer.optimization.BigIntegerPlanDiagnostics;
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -75,8 +79,20 @@ public abstract class AdvancedAeBigCapacityPlanSubmissionMixin
             // 自動要求は最終出力をCraftingLinkへ戻すExact転送が未対応なので、手動注文だけを受理する。
             if (requester != null
                     || !ACOConfig.enableBigIntegerGameplayExecution()
-                    || bigIntegerPlan.simulation()
-                    || !bigIntegerPlan.generationsAreCurrent()) {
+                    || bigIntegerPlan.simulation()) {
+                cir.setReturnValue(CraftingSubmitResult.INCOMPLETE_PLAN);
+                return;
+            }
+            ExactPlanPatternRevalidator.Result validation =
+                    bigIntegerPlan.validateForSubmission(grid);
+            // Issue #90: 無関係なProvider更新は通し、参照Patternの変更だけを拒否する。
+            if (!validation.valid()) {
+                aco$recordGenerationDecline(
+                        bigIntegerPlan.finalOutput(),
+                        bigIntegerPlan.exactPlan().requestedAmount(),
+                        bigIntegerPlan.patternGeneration(),
+                        bigIntegerPlan.recipeGeneration(),
+                        validation);
                 cir.setReturnValue(CraftingSubmitResult.INCOMPLETE_PLAN);
                 return;
             }
@@ -108,8 +124,19 @@ public abstract class AdvancedAeBigCapacityPlanSubmissionMixin
         // 実験機能OFF、Missing計画、古いPattern世代は入力を抜く前に拒否する。
         if (!ACOConfig.enableAtomicBigCapacityPlans()
                 || bigPlan.simulation()
-                || !bigPlan.missingItems().isEmpty()
-                || !bigPlan.generationsAreCurrent()) {
+                || !bigPlan.missingItems().isEmpty()) {
+            cir.setReturnValue(CraftingSubmitResult.INCOMPLETE_PLAN);
+            return;
+        }
+        ExactPlanPatternRevalidator.Result validation = bigPlan.validateForSubmission(grid);
+        // Issue #90: 合計容量だけがwideな計画にも、同じ対象限定の再検証を適用する。
+        if (!validation.valid()) {
+            aco$recordGenerationDecline(
+                    bigPlan.finalOutput(),
+                    BigInteger.valueOf(bigPlan.finalOutput().amount()),
+                    bigPlan.patternGeneration(),
+                    bigPlan.recipeGeneration(),
+                    validation);
             cir.setReturnValue(CraftingSubmitResult.INCOMPLETE_PLAN);
             return;
         }
@@ -347,6 +374,23 @@ public abstract class AdvancedAeBigCapacityPlanSubmissionMixin
                 new KeyCounter(),
                 new KeyCounter(),
                 Map.copyOf(oneExecution));
+    }
+
+    /** 世代再検証の拒否理由を、設定可能なBigInteger診断へ集約する。 */
+    @Unique
+    private static void aco$recordGenerationDecline(
+            GenericStack output,
+            BigInteger requestedAmount,
+            long patternGeneration,
+            long recipeGeneration,
+            ExactPlanPatternRevalidator.Result validation) {
+        BigIntegerPlanDiagnostics.record(
+                BigIntegerPlanDeclineReason.GENERATION_CHANGED,
+                output.what().getId().toString(),
+                requestedAmount,
+                patternGeneration,
+                recipeGeneration,
+                validation.detail());
     }
 
     private record SubmissionAttempt(

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCalculationDiagnosticsMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCalculationDiagnosticsMixin.java
@@ -11,6 +11,7 @@ import appeng.crafting.CraftingCalculation;
 import com.syaru.ae2craftingoptimizer.optimization.CraftingCalculationDiagnostics;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingShadowValidator;
 import com.syaru.ae2craftingoptimizer.engine.Ae2AuthoritativeCraftingPlanner;
+import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
 import appeng.crafting.inv.NetworkCraftingSimulationState;
 import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Final;
@@ -48,6 +49,9 @@ public abstract class CraftingCalculationDiagnosticsMixin {
 
     @Unique
     private Ae2AuthoritativeCraftingPlanner.Capture aco$authoritativeCapture;
+
+    @Unique
+    private ICraftingPlan aco$authoritativePlan;
 
     @Unique
     private boolean aco$usedAuthoritativePlan;
@@ -93,16 +97,22 @@ public abstract class CraftingCalculationDiagnosticsMixin {
         // Shadow認定済みProgramが結果を返した場合だけAE2計画本体を置き換える。
         if (accelerated != null) {
             aco$usedAuthoritativePlan = true;
+            aco$authoritativePlan = accelerated;
             cir.setReturnValue(accelerated);
         }
     }
 
     @Inject(method = "run", at = @At("RETURN"))
     private void aco$logSlowCalculation(CallbackInfoReturnable<ICraftingPlan> cir) {
+        ICraftingPlan returned = cir.getReturnValue();
+        // AE2の外側がFacadeを再構築しても、同じ計算インスタンスのSidecarだけを引き継ぐ。
+        if (aco$authoritativePlan != null && returned != null && returned != aco$authoritativePlan) {
+            Ae2CraftingPlanSidecars.alias(returned, aco$authoritativePlan);
+        }
         CraftingCalculationDiagnostics.logIfSlow(
                 output,
                 requestedAmount,
-                cir.getReturnValue(),
+                returned,
                 System.nanoTime() - aco$calculationStartedAt,
                 aco$usedAuthoritativePlan
                         ? "compiled-strict"
@@ -114,7 +124,7 @@ public abstract class CraftingCalculationDiagnosticsMixin {
                     output,
                     requestedAmount,
                     strategy,
-                    cir.getReturnValue());
+                    returned);
         }
     }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCpuClusterBigCapacityGuardMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCpuClusterBigCapacityGuardMixin.java
@@ -8,7 +8,7 @@ import appeng.api.networking.security.IActionSource;
 import appeng.crafting.execution.CraftingSubmitResult;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
 import com.syaru.ae2craftingoptimizer.access.BigCapacityPlanBoundaryAccess;
-import com.syaru.ae2craftingoptimizer.config.ACOConfig;
+import com.syaru.ae2craftingoptimizer.api.big.BigCraftingEngineApi;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -27,11 +27,11 @@ public abstract class CraftingCpuClusterBigCapacityGuardMixin
             ICraftingRequester requester,
             CallbackInfoReturnable<ICraftingSubmitResult> cir) {
         // Long.MAXは真の容量ではないため、対応Sidecarを持たない標準CPUでは実行しない。
-        boolean insaneAeExactPlan = ACOConfig.enableInsaneAeBigCraftingProfile()
-                && Ae2CraftingPlanSidecars.bigInteger(plan).isPresent();
-        // InsaneAE専用のExact受け渡しだけはInsaneAE側が同じPlanを所有するため通す。
-        // 容量だけをlongへ飽和したBigCapacity計画は標準CPUへ絶対に渡さない。
-        if (Ae2CraftingPlanSidecars.isWide(plan) && !insaneAeExactPlan) {
+        boolean exactPlan = Ae2CraftingPlanSidecars.bigInteger(plan).isPresent();
+        boolean integratedExactPlan = exactPlan
+                && BigCraftingEngineApi.hasExternalBigIntegerPlanConsumer();
+        // 外部CPUの登録が無い計画は、容量だけをlongへ飽和した標準CPUへ渡さない。
+        if (Ae2CraftingPlanSidecars.isWide(plan) && !integratedExactPlan) {
             cir.setReturnValue(CraftingSubmitResult.CPU_TOO_SMALL);
         }
     }

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/BigIntegerOwnershipContractTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/BigIntegerOwnershipContractTest.java
@@ -1,0 +1,33 @@
+package com.syaru.ae2craftingoptimizer.api;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class BigIntegerOwnershipContractTest {
+    @Test
+    void publicApiExposesExternalConsumerRegistration() throws IOException {
+        String source = readSource("src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java");
+
+        assertTrue(source.contains("registerExternalBigIntegerPlanConsumer"));
+        assertTrue(source.contains("EXTERNAL_CONSUMER_API_VERSION"));
+    }
+
+    @Test
+    void mixinPluginDoesNotOwnInsaneAeExecution() throws IOException {
+        String source = readSource("src/main/java/com/syaru/ae2craftingoptimizer/mixin/AcoMixinPlugin.java");
+
+        // ACO自身のMixin選択に、外部CPU実装のmod IDや実行分岐を戻さない。
+        assertFalse(source.contains("InsaneAE"));
+        assertFalse(source.contains("insaneae"));
+    }
+
+    private static String readSource(String relativePath) throws IOException {
+        return Files.readString(Path.of(relativePath), StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/Ae2CraftingPlanSidecarsTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/Ae2CraftingPlanSidecarsTest.java
@@ -103,6 +103,25 @@ class Ae2CraftingPlanSidecarsTest {
         assertEquals(Long.MAX_VALUE, exposed.bytes());
     }
 
+    @Test
+    void aliasesARebuiltAe2FacadeToTheSameCalculationSidecar() {
+        FakeWidePlan metadata = new FakeWidePlan("rebuilt");
+        CraftingPlan original = Ae2CraftingPlanSidecars.expose(metadata);
+        CraftingPlan rebuilt = new CraftingPlan(
+                original.finalOutput(),
+                original.bytes(),
+                original.simulation(),
+                original.multiplePaths(),
+                original.usedItems(),
+                original.emittedItems(),
+                original.missingItems(),
+                original.patternTimes());
+
+        Ae2CraftingPlanSidecars.alias(rebuilt, original);
+
+        assertSame(metadata, Ae2CraftingPlanSidecars.metadata(rebuilt).orElseThrow());
+    }
+
     private record FakeWidePlan(String id) implements WideCraftingPlan {
         @Override
         public GenericStack finalOutput() {

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/BigKeyCounterSidecarsTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/BigKeyCounterSidecarsTest.java
@@ -1,0 +1,183 @@
+package com.syaru.ae2craftingoptimizer.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.AEKeyType;
+import appeng.api.stacks.KeyCounter;
+import java.math.BigInteger;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/** Issue #93のJava 25 C2クラッシュとSidecar可視性契約を固定する試験。 */
+class BigKeyCounterSidecarsTest {
+    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
+    /** 実際のfatal errorで処理中だった約11,892キーを上回るストレス試験件数。 */
+    private static final int STRESS_KEY_COUNT = 12_000;
+    /** C2のloop最適化を促しつつ、単体試験時間を抑える反復回数。 */
+    private static final int STRESS_COPY_ROUNDS = 8;
+
+    @AfterEach
+    void clearSidecars() {
+        BigKeyCounterSidecars.clearForTests();
+    }
+
+    @Test
+    void copiesOnlyPositiveVisibleKeysWithoutTruncatingExactAmounts() {
+        TestKey visibleKey = new TestKey("visible");
+        TestKey hiddenKey = new TestKey("hidden");
+        BigInteger exactAmount = LONG_MAX.add(BigInteger.ONE);
+        KeyCounter source = new KeyCounter();
+        BigKeyCounterSidecars.merge(
+                source,
+                new BigKeyCounterSidecars.Snapshot(
+                        Map.of(visibleKey, exactAmount, hiddenKey, BigInteger.TEN),
+                        true));
+
+        KeyCounter target = new KeyCounter();
+        target.set(visibleKey, Long.MAX_VALUE);
+        BigKeyCounterSidecars.copyVisible(source, target);
+
+        BigKeyCounterSidecars.Snapshot copied =
+                BigKeyCounterSidecars.snapshot(target).orElseThrow();
+        assertEquals(exactAmount, copied.amount(visibleKey));
+        assertEquals(BigInteger.ZERO, copied.amount(hiddenKey));
+        assertTrue(copied.isExact(visibleKey));
+        assertTrue(copied.complete());
+    }
+
+    @Test
+    void snapshotOwnsItsCollectionsAndExposesReadOnlyViews() {
+        TestKey key = new TestKey("owned");
+        Map<AEKey, BigInteger> mutableAmounts = new LinkedHashMap<>();
+        Set<AEKey> mutableExactKeys = new LinkedHashSet<>();
+        mutableAmounts.put(key, BigInteger.TEN);
+        mutableExactKeys.add(key);
+
+        BigKeyCounterSidecars.Snapshot snapshot =
+                new BigKeyCounterSidecars.Snapshot(
+                        mutableAmounts,
+                        false,
+                        mutableExactKeys);
+        mutableAmounts.clear();
+        mutableExactKeys.clear();
+
+        assertEquals(BigInteger.TEN, snapshot.amount(key));
+        assertTrue(snapshot.isExact(key));
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> snapshot.amounts().put(key, BigInteger.ONE));
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> snapshot.exactKeys().clear());
+    }
+
+    @Test
+    void repeatedlyCopiesAProductionSizedVisibleSnapshot() {
+        Map<AEKey, BigInteger> exactAmounts = new LinkedHashMap<>();
+        KeyCounter source = new KeyCounter();
+        KeyCounter target = new KeyCounter();
+        TestKey first = null;
+        TestKey last = null;
+
+        // fatal error時より多いキーを用意し、同じ可視コピー経路をloop最適化対象にする。
+        for (int index = 0; index < STRESS_KEY_COUNT; index++) {
+            TestKey key = new TestKey("stress_" + index);
+            // 境界キーを後段の正確値検証へ残す。
+            if (index == 0) {
+                first = key;
+            }
+            last = key;
+            BigInteger amount = LONG_MAX.add(BigInteger.valueOf(index + 1L));
+            exactAmounts.put(key, amount);
+            target.set(key, Long.MAX_VALUE);
+        }
+        BigKeyCounterSidecars.merge(
+                source,
+                new BigKeyCounterSidecars.Snapshot(exactAmounts, true));
+
+        // 同一targetのSidecarを繰り返し置換し、値・exactness・寿命管理を同時に検証する。
+        for (int round = 0; round < STRESS_COPY_ROUNDS; round++) {
+            BigKeyCounterSidecars.copyVisible(source, target);
+        }
+
+        BigKeyCounterSidecars.Snapshot copied =
+                BigKeyCounterSidecars.snapshot(target).orElseThrow();
+        assertEquals(STRESS_KEY_COUNT, copied.amounts().size());
+        assertEquals(LONG_MAX.add(BigInteger.ONE), copied.amount(first));
+        assertEquals(
+                LONG_MAX.add(BigInteger.valueOf(STRESS_KEY_COUNT)),
+                copied.amount(last));
+        assertTrue(copied.isExact(first));
+        assertTrue(copied.isExact(last));
+        assertFalse(copied.amounts().isEmpty());
+    }
+
+    /** Minecraft Registry初期化なしで多数の異なるAEKeyを作る最小実装。 */
+    private static final class TestKey extends AEKey {
+        private final ResourceLocation id;
+
+        private TestKey(String path) {
+            this.id = new ResourceLocation("ae2_crafting_optimizer", path);
+        }
+
+        @Override
+        public AEKeyType getType() {
+            return null;
+        }
+
+        @Override
+        public AEKey dropSecondary() {
+            return this;
+        }
+
+        @Override
+        public CompoundTag toTag() {
+            return new CompoundTag();
+        }
+
+        @Override
+        public Object getPrimaryKey() {
+            return id;
+        }
+
+        @Override
+        public ResourceLocation getId() {
+            return id;
+        }
+
+        @Override
+        public void writeToPacket(FriendlyByteBuf buffer) {
+            // Packet同期を行わない単体試験なので書き込みは不要。
+        }
+
+        @Override
+        protected Component computeDisplayName() {
+            return Component.literal(id.toString());
+        }
+
+        @Override
+        public void addDrops(
+                long amount,
+                List<ItemStack> drops,
+                Level level,
+                BlockPos pos) {
+            // ワールド内ドロップを扱わない単体試験なので処理は不要。
+        }
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/ExactPlanPatternRevalidatorTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/ExactPlanPatternRevalidatorTest.java
@@ -1,0 +1,213 @@
+package com.syaru.ae2craftingoptimizer.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import appeng.api.crafting.IPatternDetails;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.AEKeyType;
+import appeng.api.stacks.GenericStack;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import org.junit.jupiter.api.Test;
+
+class ExactPlanPatternRevalidatorTest {
+    private static final long PLANNED_PATTERN_GENERATION = 10L;
+    private static final long UPDATED_PATTERN_GENERATION = 11L;
+    private static final long RECIPE_GENERATION = 20L;
+
+    @Test
+    void acceptsMatchingGenerationWithoutIndexScan() {
+        StubPattern pattern = new StubPattern(new TestKey("iron_block"));
+        AtomicInteger lookups = new AtomicInteger();
+
+        var result = ExactPlanPatternRevalidator.validate(
+                PLANNED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                PLANNED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                List.of(pattern),
+                ignored -> {
+                    lookups.incrementAndGet();
+                    return List.of();
+                });
+
+        assertEquals(ExactPlanPatternRevalidator.Result.CURRENT_GENERATION, result);
+        assertEquals(0, lookups.get());
+    }
+
+    @Test
+    void acceptsUnrelatedProviderGenerationWhenReferencedPatternRemains() {
+        StubPattern pattern = new StubPattern(new TestKey("iron_block"));
+
+        var result = ExactPlanPatternRevalidator.validate(
+                PLANNED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                UPDATED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                List.of(pattern),
+                ignored -> List.of(pattern));
+
+        assertEquals(
+                ExactPlanPatternRevalidator.Result.REFERENCED_PATTERNS_REVALIDATED,
+                result);
+    }
+
+    @Test
+    void acceptsProviderGenerationChangeForInventoryOnlyPlan() {
+        AtomicInteger lookups = new AtomicInteger();
+
+        var result = ExactPlanPatternRevalidator.validate(
+                PLANNED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                UPDATED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                List.of(),
+                ignored -> {
+                    lookups.incrementAndGet();
+                    return List.of();
+                });
+
+        assertEquals(
+                ExactPlanPatternRevalidator.Result.REFERENCED_PATTERNS_REVALIDATED,
+                result);
+        assertEquals(0, lookups.get());
+    }
+
+    @Test
+    void rejectsEqualLookingReplacementPattern() {
+        TestKey output = new TestKey("iron_block");
+        StubPattern planned = new StubPattern(output);
+        StubPattern replacement = new StubPattern(output);
+
+        var result = ExactPlanPatternRevalidator.validate(
+                PLANNED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                UPDATED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                List.of(planned),
+                ignored -> List.of(replacement));
+
+        assertEquals(
+                ExactPlanPatternRevalidator.Result.REFERENCED_PATTERN_CHANGED,
+                result);
+    }
+
+    @Test
+    void rejectsMissingReferencedPattern() {
+        StubPattern pattern = new StubPattern(new TestKey("iron_block"));
+
+        var result = ExactPlanPatternRevalidator.validate(
+                PLANNED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                UPDATED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                List.of(pattern),
+                ignored -> List.of());
+
+        assertEquals(
+                ExactPlanPatternRevalidator.Result.REFERENCED_PATTERN_CHANGED,
+                result);
+    }
+
+    @Test
+    void rejectsRecipeGenerationChangeWithoutIndexScan() {
+        StubPattern pattern = new StubPattern(new TestKey("iron_block"));
+        AtomicInteger lookups = new AtomicInteger();
+
+        var result = ExactPlanPatternRevalidator.validate(
+                PLANNED_PATTERN_GENERATION,
+                RECIPE_GENERATION,
+                UPDATED_PATTERN_GENERATION,
+                RECIPE_GENERATION + 1L,
+                List.of(pattern),
+                ignored -> {
+                    lookups.incrementAndGet();
+                    return List.of(pattern);
+                });
+
+        assertEquals(
+                ExactPlanPatternRevalidator.Result.RECIPE_GENERATION_CHANGED,
+                result);
+        assertEquals(0, lookups.get());
+    }
+
+    private static final class StubPattern implements IPatternDetails {
+        private final GenericStack[] outputs;
+
+        private StubPattern(AEKey output) {
+            this.outputs = new GenericStack[] {new GenericStack(output, 1L)};
+        }
+
+        @Override
+        public appeng.api.stacks.AEItemKey getDefinition() {
+            return null;
+        }
+
+        @Override
+        public IInput[] getInputs() {
+            return new IInput[0];
+        }
+
+        @Override
+        public GenericStack[] getOutputs() {
+            return outputs.clone();
+        }
+    }
+
+    /** Minecraftレジストリを起動せず、Pattern主出力の識別だけを行う最小AEKey。 */
+    private static final class TestKey extends AEKey {
+        private final String path;
+
+        private TestKey(String path) {
+            this.path = path;
+        }
+
+        @Override
+        public AEKeyType getType() {
+            return null;
+        }
+
+        @Override
+        public AEKey dropSecondary() {
+            return this;
+        }
+
+        @Override
+        public CompoundTag toTag() {
+            return new CompoundTag();
+        }
+
+        @Override
+        public Object getPrimaryKey() {
+            return this;
+        }
+
+        @Override
+        public ResourceLocation getId() {
+            return new ResourceLocation("ae2_crafting_optimizer", path);
+        }
+
+        @Override
+        public void writeToPacket(FriendlyByteBuf buffer) {
+            // この試験はネットワーク同期を行わない。
+        }
+
+        @Override
+        protected Component computeDisplayName() {
+            return Component.literal(path);
+        }
+
+        @Override
+        public void addDrops(long amount, List<ItemStack> drops, Level level, BlockPos pos) {
+            // この試験はワールド内ドロップを作らない。
+        }
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/mixin/AcoMixinPluginTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/mixin/AcoMixinPluginTest.java
@@ -8,26 +8,6 @@ import org.junit.jupiter.api.Test;
 
 class AcoMixinPluginTest {
     @Test
-    void keepsTransactionStateApiWhenInsaneAeIsInstalled() {
-        assertFalse(AcoMixinPlugin.isInsaneAeOwnedExecutionMixin(
-                "com.syaru.ae2craftingoptimizer.mixin.CraftingCpuLogicBatchSourceReceiptMixin"));
-        assertFalse(AcoMixinPlugin.isInsaneAeOwnedExecutionMixin(
-                "com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingCpuLogicBatchSourceReceiptMixin"));
-    }
-
-    @Test
-    void delegatesOnlyExecutionHooksToInsaneAe() {
-        assertTrue(AcoMixinPlugin.isInsaneAeOwnedExecutionMixin(
-                "com.syaru.ae2craftingoptimizer.mixin.CraftingCpuLogicExecutionBudgetMixin"));
-        assertTrue(AcoMixinPlugin.isInsaneAeOwnedExecutionMixin(
-                "com.syaru.ae2craftingoptimizer.mixin.CraftingCpuLogicTransactionalBatchV2Mixin"));
-        assertTrue(AcoMixinPlugin.isInsaneAeOwnedExecutionMixin(
-                "com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingCpuLogicExecutionBudgetMixin"));
-        assertTrue(AcoMixinPlugin.isInsaneAeOwnedExecutionMixin(
-                "com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingCpuLogicTransactionalBatchV2Mixin"));
-    }
-
-    @Test
     void selectsOnlyTheNeoEco20_3MixinForTheOldDescriptor() {
         assertTrue(AcoMixinPlugin.shouldApplyNeoEcoExecutionMixin(
                 "com.syaru.ae2craftingoptimizer.mixin.NeoEco20_3CraftingCpuExecutionBudgetMixin",


### PR DESCRIPTION
## 概要

Forge 1.20.1向けに、long超過クラフトを外部CPUへ安全に引き渡すBigInteger計画境界を修正します。

## 原因

- AE2の実計算経路が新しい `CraftingPlan` Facadeを返したとき、ACOの正確なsidecarが失われることがあった。
- 外部Bulk実行者がAE2の論理操作数を物理Bulk上限として扱うと、巨大な作業台クラフトが1操作ずつへ縮退する。
- ACO側にInsaneAEを直接意識した実行分岐があり、責務境界が曖昧だった。

## 変更

- `BigCraftingEngineApi`へ外部BigInteger計画コンシューマ登録APIを追加。
- `Ae2CraftingPlanSidecars`と計算戻りMixinで、再構築Facadeへ同一計画のsidecarを再接続。
- 外部コンシューマ未登録のwide計画を、飽和longの標準CPUへ渡さない境界を追加。
- ACOのInsaneAE直接実行分岐を除去し、公開API/sidecar/窓情報だけを責務として明文化。
- 回帰履歴、クラス責務、Issue仕様書、静的ownership testを追加。

## 検証

- `gradlew.bat clean build --no-daemon`
- sidecar alias、外部登録、責務境界、通常計画維持のJUnit
- `git diff --check`

ゲーム起動、専用サーバー起動、実環境GameTest、TPS計測はこのPRでは実施していません。

関連: #44, #55
