### PR TITLE
[1.20.1] 外部CPUへBigCapacity計画を正しく引き渡す

### DIFF
--- a/docs/REGRESSION_HISTORY.md
+++ b/docs/REGRESSION_HISTORY.md
@@ -8,6 +8,7 @@
 | [#79](https://github.com/syarukasu/ae2-crafting-optimizer/issues/79) | 一つのroot内部だけでsigned long境界を超えるexact計画が失われる | 1.5.17 | 1.5.18 | [ISSUE-79.md](issues/ISSUE-79.md) |
 | [#90](https://github.com/syarukasu/ae2-crafting-optimizer/issues/90) | 無関係なProvider世代更新でBigInteger計画が提出時に失効する | 1.5.18 | 未リリース | [ISSUE-90.md](issues/ISSUE-90.md) |
 | [#93](https://github.com/syarukasu/ae2-crafting-optimizer/issues/93) | Java 25でBigInteger在庫Sidecarの可視コピー中にJVMが終了する | 1.5.18 | 未定 | [ISSUE-93.md](issues/ISSUE-93.md) |
+| [#98](https://github.com/syarukasu/ae2-crafting-optimizer/issues/98) | 外部CPU登録済みでも合計bytesだけlong超過するBigCapacity計画が拒否される | 1.5.19 | 未リリース | [ISSUE-98.md](issues/ISSUE-98.md) |
 | 外部コンシューマ回帰 | 実経路でsidecarが消える、またはQuantum Bulkが`maxPatterns=1`へ誤って制限される | 1.5.18系 | 作業中 | [ISSUE-BIGINT-EXTERNAL-CONSUMER.md](ISSUE-BIGINT-EXTERNAL-CONSUMER.md) |
 
 ## 運用

--- a/docs/issues/ISSUE-98.md
+++ b/docs/issues/ISSUE-98.md
@@ -1,0 +1,60 @@
+# Issue #98: 外部BigInteger CPUがBigCapacity計画をCPU_TOO_SMALLで拒否される
+
+- GitHub Issue: https://github.com/syarukasu/ae2-crafting-optimizer/issues/98
+- 状態: Implemented
+- 対象版: 1.5.19
+- 対象ローダー: Forge 1.20.1 / NeoForge 1.21.1
+- 関連Issue・PR: Issue #44、Issue #55、PR #96、PR #97
+
+## 問題
+
+形成済みの外部BigInteger CPUがACOへコンシューマ登録されていても、個別数量は`long`内、
+合計CPU bytesだけが`Long.MAX_VALUE`を超える注文が`CPU_TOO_SMALL`で拒否されます。
+
+## 再現と証拠
+
+- 注文: `1,000,000,000,000,000,000`個の単一成果物
+- 計画型: `BigCapacityCraftingPlan`
+- 外部コンシューマ登録ログ: 出力済み
+- 結果: `CPU_TOO_SMALL`
+
+## 原因
+
+`CraftingCpuClusterBigCapacityGuardMixin`が提出可能なexact計画を
+`Ae2CraftingPlanSidecars.bigInteger(plan)`だけで判定していました。このAPIは個別数量まで
+`long`を超えた`BigIntegerCraftingPlan`だけを返し、合計bytesだけ超過した
+`BigCapacityCraftingPlan`を返しません。
+
+公開APIの`BigCraftingEngineApi.inspectBigIntegerPlan`は両方を同じ正確なViewとして公開するため、
+ガードの局所判定が公開API契約より狭くなっていました。
+
+## 所有権
+
+- AE2: 標準CPUの選択、使用中判定、ジョブ提出
+- ACO: exact計画Sidecarと公開View、未対応CPUへの誤投入防止
+- 外部CPUアドオン: exact容量比較、実行、進捗、保存、取消
+
+## 維持する不変条件
+
+- 通常long計画はAE2本来の経路へ渡す
+- simulation計画を実行へ渡さない
+- 外部コンシューマ未登録のwide計画を標準long CPUへ渡さない
+- ACOから外部CPUの実装名、構造、実行へ介入しない
+
+## やってはいけないこと
+
+- `BigIntegerCraftingPlan`だけをexact計画として扱う
+- 正確なbytesを`Long.MAX_VALUE`へ切り捨てて比較する
+- 外部CPUのmod IDをACOへハードコードする
+
+## 修正
+
+wide計画を検出した後、公開APIが非simulationの正確なViewを返せて、かつ外部コンシューマが
+登録済みの場合だけ標準CPU保護ガードを通過させます。外部CPU側の容量判定と実行は変更しません。
+
+## 試験
+
+- 公開APIが`BigCapacityCraftingPlan`を正確なViewとして返す既存試験
+- CPUガードが公開APIを使い、狭い`bigInteger(plan)`判定へ戻らない契約試験
+- Forge 1.20.1 / NeoForge 1.21.1のJUnitと`clean build`
+- 実環境の再注文はユーザー側確認

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -18,3 +18,4 @@
 - [Issue #84](ISSUE-84.md): Issue先行開発手順とプロジェクト境界
 - [Issue #87](ISSUE-87.md): 全クラスの責務明文化とexact数量Mapの安全な共通化
 - [Issue #93](ISSUE-93.md): Java 25でBigInteger在庫Sidecarの可視コピー中にJVMが終了する
+- [Issue #98](ISSUE-98.md): 外部BigInteger CPUがBigCapacity計画を誤拒否する

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCpuClusterBigCapacityGuardMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCpuClusterBigCapacityGuardMixin.java
@@ -26,13 +26,21 @@ public abstract class CraftingCpuClusterBigCapacityGuardMixin
             IActionSource source,
             ICraftingRequester requester,
             CallbackInfoReturnable<ICraftingSubmitResult> cir) {
-        // Long.MAXは真の容量ではないため、対応Sidecarを持たない標準CPUでは実行しない。
-        boolean exactPlan = Ae2CraftingPlanSidecars.bigInteger(plan).isPresent();
-        boolean integratedExactPlan = exactPlan
-                && BigCraftingEngineApi.hasExternalBigIntegerPlanConsumer();
-        // 外部CPUの登録が無い計画は、容量だけをlongへ飽和した標準CPUへ渡さない。
-        if (Ae2CraftingPlanSidecars.isWide(plan) && !integratedExactPlan) {
-            cir.setReturnValue(CraftingSubmitResult.CPU_TOO_SMALL);
+        // 通常long計画はIssue #98の保護対象ではなく、AE2本来の提出処理へそのまま渡す。
+        if (!Ae2CraftingPlanSidecars.isWide(plan)) {
+            return;
         }
+
+        boolean externalConsumer = BigCraftingEngineApi.hasExternalBigIntegerPlanConsumer();
+        boolean executableExactPlan = BigCraftingEngineApi.inspectBigIntegerPlan(plan)
+                .filter(view -> !view.simulation())
+                .isPresent();
+        // Issue #98: 個別数量がlong内でも合計bytesだけ超過するBigCapacity計画を許可する。
+        if (externalConsumer && executableExactPlan) {
+            return;
+        }
+
+        // 対応CPUが無いwide計画を、容量だけLong.MAXへ飽和した標準CPUへ誤投入させない。
+        cir.setReturnValue(CraftingSubmitResult.CPU_TOO_SMALL);
     }
 }

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/BigIntegerOwnershipContractTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/BigIntegerOwnershipContractTest.java
@@ -19,6 +19,17 @@ class BigIntegerOwnershipContractTest {
     }
 
     @Test
+    void externalCpuGuardUsesThePublicExactViewForEveryWidePlanKind() throws IOException {
+        String source = readSource(
+                "src/main/java/com/syaru/ae2craftingoptimizer/mixin/"
+                        + "CraftingCpuClusterBigCapacityGuardMixin.java");
+
+        // Issue #98: BigCapacity計画をBigIntegerCraftingPlanだけの狭い判定へ戻さない。
+        assertTrue(source.contains("inspectBigIntegerPlan(plan)"));
+        assertFalse(source.contains("Ae2CraftingPlanSidecars.bigInteger(plan)"));
+    }
+
+    @Test
     void mixinPluginDoesNotOwnInsaneAeExecution() throws IOException {
         String source = readSource("src/main/java/com/syaru/ae2craftingoptimizer/mixin/AcoMixinPlugin.java");
 


### PR DESCRIPTION
## 概要

Forge 1.20.1で、外部BigInteger CPUが`BigCapacityCraftingPlan`を
`CPU_TOO_SMALL`として誤拒否する回帰を修正します。

## 原因

CPU保護ガードが`BigIntegerCraftingPlan`だけをexact計画として扱っていました。
そのため、個別Pattern回数は`long`内でも合計bytesだけ`Long.MAX_VALUE`を超える
`BigCapacityCraftingPlan`が、外部コンシューマ登録済みでも拒否されていました。

## 変更

- 提出可否を`BigCraftingEngineApi.inspectBigIntegerPlan`の公開Viewで判定
- 非simulationの`BigIntegerCraftingPlan`と`BigCapacityCraftingPlan`を同じ境界で許可
- 外部コンシューマ未登録、simulation、通常long計画の既存動作を維持
- Issue #98の仕様書、Javaコメント、回帰契約試験を追加

ACOは外部CPUの実行、構造、GUI、進捗へ介入しません。

## 検証

- `gradlew.bat clean test build --no-daemon`
- `BigCraftingEngineApiPlanInspectionTest`
- `BigIntegerOwnershipContractTest`
- `git diff --check`

実環境の再注文はユーザー側で確認します。

Closes #98
