### PR TITLE
fix: separate wide-plan and snapshot declines from capacity and ambig…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- Stopped reporting `CPU_TOO_SMALL` when a crafting CPU declines a plan whose
+  exact byte cost exceeds signed long (issue #103, problem 1). The refusal is
+  unrelated to free capacity, so the previous code sent players to add crafting
+  storage that could never help. The decline now counts the CPU as excluded
+  rather than too small and, unless `logWidePlanSubmissionDeclines` is off,
+  logs one warning per output with the exact byte cost and the free bytes the
+  CPU reports. The refusal itself remains fail-closed and unchanged.
+- Split the single "no compiled root program" fallback into distinct reasons
+  (issue #103, problem 2). Cycles, multiple producers, byproduct patterns, and
+  size limits keep their own reason codes; a root that failed only because that
+  generation's graph snapshot was incomplete now reports
+  `INCOMPLETE_GRAPH_SNAPSHOT` instead of being reported as an ambiguous
+  producer, and is logged once per output and generation pair. A root that AE2
+  currently has patterns for, but which is absent from the snapshot, is no
+  longer compiled into a degenerate terminal-only program.
+
+### Added
+
+- `retryIncompleteCraftingGraphSnapshot` rebuilds the compiled crafting graph
+  when a root program was unavailable only because that snapshot was
+  incomplete. The rebuild is bounded to one per snapshot, so a network holding
+  a pattern that can never compile does not rebuild the graph on every
+  calculation. Structural failures are never retried because they cannot change
+  within a generation.
+
 ## [1.6.2] - 2026-08-08
 
 ### Added

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -29,6 +29,8 @@ Important calculation options include:
 | `enableShadowMode` | `true` | Compares eligible compiled results against AE2 without changing normal results. |
 | `enableExactBigIntegerInventorySnapshots` | `true` | Keeps exact sidecar stock while AE2 sees a saturated long facade. |
 | `enableAtomicBigCapacityPlans` | `true` | Allows exact planning above signed-long aggregate limits for supported hosts. |
+| `retryIncompleteCraftingGraphSnapshot` | `true` | Rebuilds the compiled graph when a root program was unavailable only because that snapshot was incomplete, at most once per snapshot. Structural reasons are never retried. |
+| `logWidePlanSubmissionDeclines` | `true` | Logs once per output when a crafting CPU without a BigInteger ledger declines a plan above signed-long limits. The decline itself is unaffected. |
 | `bigIntegerMaximumBits` | implementation ceiling | Bounds all BigInteger intermediates and persistence. |
 
 The exact decimal ceiling is `10^16384 - 1`.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -24,6 +24,10 @@ Automated tests cover:
 - physical Worker formula multiplication;
 - durable terminal receipt identity and explicit forget.
 - nine identical signed-long input slots without merged-input rejection.
+- distinct compiled root-program failure reasons for cycles, multiple
+  producers, byproduct patterns, and incomplete graph snapshots;
+- retrying only snapshot-shaped root-program failures;
+- refusing a wide plan without claiming that the crafting CPU is too small.
 - exact NetworkStorage snapshot reuse within one tick;
 - same-tick invalidation after a storage generation change;
 - refusal to reuse a snapshot across ticks;
@@ -190,6 +194,50 @@ must return as output, never as both output and original input.
 3. Confirm per-grid start and active-stage budgets are respected.
 4. Confirm the small job continues to receive scheduler opportunities.
 5. Record TPS, MSPT, GC allocation, and `/aco stats`.
+
+### Wide Plan Submission Refusal
+
+Covers issue #103, problem 1.
+
+1. Build a two-stage chain whose total executions exceed `Long.MAX_VALUE`
+   (for example `1 log -> 4 planks` and `1 plank -> 1 button`, then order
+   `Long.MAX_VALUE` buttons). Two stages put the execution total at roughly
+   1.25x the order, which no longer fits a signed long.
+2. Give the network a standard AE2 crafting CPU with `Long.MAX_VALUE` free
+   bytes, so the required bytes and the free bytes print as the same number.
+3. Submit the job and confirm the refusal does **not** say the CPU is too
+   small. The plan is declined because no signed-long CPU ledger can hold it.
+4. Confirm `latest.log` contains exactly one `ACO refused to submit a plan for
+   ... to a standard AE2 crafting CPU` warning per output, carrying the exact
+   byte count and the free bytes the CPU reports.
+5. Add crafting storage and resubmit. The refusal must be unchanged; the
+   message must not have sent the player to add storage in the first place.
+6. Repeat with an Advanced AE crafting CPU that has no registered BigInteger
+   host and confirm the same non-capacity refusal.
+7. Set `logWidePlanSubmissionDeclines = false` and confirm the refusal itself
+   still happens with no new warning line.
+
+### Incomplete Graph Snapshot Fallback
+
+Covers issue #103, problem 2.
+
+1. Order the same two-stage chain while patterns are being added or removed so
+   the pattern generation moves during the calculation.
+2. When ACO returns the calculation to AE2, confirm `/aco stats` and the slow
+   calculation line report `INCOMPLETE_GRAPH_SNAPSHOT`, never
+   `AMBIGUOUS_PRODUCER`, for a root that has exactly one pattern.
+3. Confirm `latest.log` carries one `compiled crafting graph snapshot was
+   incomplete` warning per output and generation pair, including
+   `patternGeneration` and `recipeGeneration`.
+4. Encode a genuinely ambiguous root (two patterns for the same output) and
+   confirm it still reports `AMBIGUOUS_PRODUCER`, and that no graph rebuild
+   is triggered for it.
+5. Install a mod whose patterns ACO cannot compile (AppliedE is the reference
+   case) and order repeatedly through a root that touches one. Confirm with
+   Spark that the graph is rebuilt at most once per pattern generation, not
+   once per calculation.
+6. Set `retryIncompleteCraftingGraphSnapshot = false` and confirm the same
+   reason code is reported with no second graph build.
 
 ### Diagnostics
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
@@ -192,6 +192,8 @@ public final class ACOConfig {
     private static final ModConfigSpec.IntValue NATIVE_BATCH_MAXIMUM_EXECUTIONS;
     private static final ModConfigSpec.BooleanValue ENABLE_BIG_INTEGER_CRAFTING_BACKEND;
     private static final ModConfigSpec.BooleanValue ENABLE_EXACT_BIG_INTEGER_INVENTORY_SNAPSHOTS;
+    private static final ModConfigSpec.BooleanValue RETRY_INCOMPLETE_CRAFTING_GRAPH_SNAPSHOT;
+    private static final ModConfigSpec.BooleanValue LOG_WIDE_PLAN_SUBMISSION_DECLINES;
     private static final ModConfigSpec.BooleanValue ENABLE_ATOMIC_BIG_CAPACITY_PLANS;
     private static final ModConfigSpec.BooleanValue ENABLE_BIG_INTEGER_GAMEPLAY_EXECUTION;
     private static final ModConfigSpec.IntValue BIG_INTEGER_MAXIMUM_BITS;
@@ -832,6 +834,17 @@ public final class ACOConfig {
                         "Capture exact per-key BigInteger stock from supported storage add-ons while exposing a saturated long facade to AE2.",
                         "This prevents KeyCounter overflow and allows ACO planning to use ExtendedAE Plus Infinity BigInteger Cell amounts above Long.MAX_VALUE.")
                 .define("enableExactBigIntegerInventorySnapshots", true);
+        RETRY_INCOMPLETE_CRAFTING_GRAPH_SNAPSHOT = builder
+                .comment(
+                        "Rebuild the compiled crafting graph once when a root program is unavailable only because that snapshot was incomplete.",
+                        "Bounded to one rebuild per snapshot, so a network with permanently uncompilable patterns does not rebuild the graph on every calculation.",
+                        "Structural reasons (ambiguous producers, cycles, multiple outputs, size limits) are never retried because they cannot change within a generation.")
+                .define("retryIncompleteCraftingGraphSnapshot", true);
+        LOG_WIDE_PLAN_SUBMISSION_DECLINES = builder
+                .comment(
+                        "Log once per output when a plan above signed-long limits is declined by a crafting CPU that has no BigInteger ledger.",
+                        "The decline itself is fail-closed and is not affected by this switch.")
+                .define("logWidePlanSubmissionDeclines", true);
         ENABLE_ATOMIC_BIG_CAPACITY_PLANS = builder
                 .comment(
                         "Safely calculate plans whose individual or aggregate AEKey counts, Pattern counts, or exact CPU-byte cost exceed Long.MAX_VALUE.",
@@ -1683,6 +1696,15 @@ public final class ACOConfig {
     public static boolean enableExactBigIntegerInventorySnapshots() {
         return enableBigIntegerCraftingBackend()
                 && ENABLE_EXACT_BIG_INTEGER_INVENTORY_SNAPSHOTS.get();
+    }
+
+    public static boolean retryIncompleteCraftingGraphSnapshot() {
+        return enableCompiledCraftingGraph()
+                && RETRY_INCOMPLETE_CRAFTING_GRAPH_SNAPSHOT.get();
+    }
+
+    public static boolean logWidePlanSubmissionDeclines() {
+        return LOG_WIDE_PLAN_SUBMISSION_DECLINES.get();
     }
 
     public static boolean enableAtomicBigCapacityPlans() {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
@@ -32,6 +32,9 @@ public final class Ae2AuthoritativeCraftingPlanner {
     /** 64ノードごとに世代と割込みを再検証するためのbit mask。 */
     private static final int GENERATION_CHECK_INTERVAL_MASK = 63;
     private static final Set<String> LOGGED_FALLBACKS = ConcurrentHashMap.newKeySet();
+    /** Snapshot都合のFallbackログ重複除去表の固定上限。超えたら一括破棄する。 */
+    private static final int MAXIMUM_LOGGED_SNAPSHOT_FALLBACKS = 4096;
+    private static final Set<String> LOGGED_SNAPSHOT_FALLBACKS = ConcurrentHashMap.newKeySet();
 
     private Ae2AuthoritativeCraftingPlanner() {
     }
@@ -91,11 +94,29 @@ public final class Ae2AuthoritativeCraftingPlanner {
             capture.requireCurrentGenerations();
             Ae2CompiledCraftingGraphCache.Snapshot graphSnapshot =
                     Ae2CompiledCraftingGraphCache.getOrCompile(capture.grid(), capture.level());
-            var optionalProgram = graphSnapshot.rootProgram(output);
+            CompiledRootProgram.Outcome<AEKey> outcome = graphSnapshot.rootProgramOutcome(output);
+            /*
+             * 構造的に組めないルートは取り直しても同じ結果になる。Snapshotが揃わなかっただけの
+             * 失敗に限り、同じ注文の中で一度だけGraphを取り直してから諦める。
+             */
+            if (shouldRetryRootProgram(
+                    outcome.failure(),
+                    ACOConfig.retryIncompleteCraftingGraphSnapshot())) {
+                graphSnapshot = Ae2CompiledCraftingGraphCache.recompile(
+                        capture.grid(),
+                        capture.level(),
+                        graphSnapshot);
+                outcome = graphSnapshot.rootProgramOutcome(output);
+            }
+            var optionalProgram = outcome.program();
             // 曖昧、循環、複数出力などを含むルートはコンパイルせずAE2へ戻す。
             if (optionalProgram.isEmpty()) {
-                CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
-                        FallbackReasonCode.AMBIGUOUS_PRODUCER);
+                CraftingFallbackDiagnostics.record(
+                        output,
+                        capture.patternGeneration(),
+                        capture.recipeGeneration(),
+                        classifyRootProgramFailure(outcome.failure()));
+                logRootProgramFailureOnce(output, outcome.failure(), capture);
                 return null;
             }
             CompiledRootProgram<AEKey> program = optionalProgram.get();
@@ -434,6 +455,36 @@ public final class Ae2AuthoritativeCraftingPlanner {
     }
 
     /**
+     * Root Programを取り直す価値があるのは、Snapshot都合の失敗だけ。
+     *
+     * <p>曖昧・循環・複数出力・上限超過は同じ世代で必ず同じ結果になるため、
+     * 取り直しはGraph再構築の費用を払うだけで結果が変わらない。</p>
+     */
+    static boolean shouldRetryRootProgram(
+            RootProgramFailure failure,
+            boolean retryEnabled) {
+        return retryEnabled && failure.snapshotShaped();
+    }
+
+    /**
+     * 「プレイヤーが構成を直せば解ける理由」と「Snapshotが揃わなかった理由」を別の診断コードへ割る。
+     *
+     * <p>両方を{@code AMBIGUOUS_PRODUCER}へ潰すと、曖昧でないルートまで曖昧として報告される。</p>
+     */
+    static FallbackReasonCode classifyRootProgramFailure(RootProgramFailure failure) {
+        return switch (failure) {
+            case CYCLE -> FallbackReasonCode.CYCLE;
+            case MULTIPLE_PRODUCERS -> FallbackReasonCode.AMBIGUOUS_PRODUCER;
+            case MULTIPLE_OUTPUTS -> FallbackReasonCode.UNSUPPORTED_PATTERN;
+            case PROGRAM_TOO_LARGE -> FallbackReasonCode.PROGRAM_TOO_LARGE;
+            case INCOMPLETE_PATTERN_SNAPSHOT, MISSING_FROM_SNAPSHOT ->
+                    FallbackReasonCode.INCOMPLETE_GRAPH_SNAPSHOT;
+            // Programが無いのに理由もない結果は作れないが、診断を落とさず残す。
+            case NONE -> FallbackReasonCode.NO_COMPILED_PROGRAM;
+        };
+    }
+
+    /**
      * 厳密Topologyが既に成立した後の採用規則。
      * wide注文だけはAE2標準計算でShadow教材を作れないため、専用設定を維持する。
      */
@@ -501,6 +552,41 @@ public final class Ae2AuthoritativeCraftingPlanner {
         Map<String, BigInteger> result = new LinkedHashMap<>();
         counts.forEach((key, amount) -> result.put(key, BigInteger.valueOf(amount)));
         return Map.copyOf(result);
+    }
+
+    /**
+     * 取り直しても解けなかったSnapshot都合のFallbackだけを、世代付きで一度ずつ記録する。
+     *
+     * <p>構造的な理由はプレイヤーが構成を見れば分かるが、こちらは外から一切見えない。
+     * 表は出力・理由・世代の組で重複を除き、固定件数を超えたら丸ごと捨てる。</p>
+     */
+    private static void logRootProgramFailureOnce(
+            AEKey output,
+            RootProgramFailure failure,
+            Capture capture) {
+        // 構造的な理由は同じ世代で毎回再現するため、ログを増やす価値がない。
+        if (!failure.snapshotShaped()) {
+            return;
+        }
+        String key = output.getId()
+                + ":" + failure
+                + ":" + capture.patternGeneration()
+                + ":" + capture.recipeGeneration();
+        // 世代が進み続ける環境でも常駐量を固定するため、上限で一括破棄する。
+        if (LOGGED_SNAPSHOT_FALLBACKS.size() >= MAXIMUM_LOGGED_SNAPSHOT_FALLBACKS) {
+            LOGGED_SNAPSHOT_FALLBACKS.clear();
+        }
+        if (!LOGGED_SNAPSHOT_FALLBACKS.add(key)) {
+            return;
+        }
+        AE2CraftingOptimizer.LOGGER.warn(
+                "ACO returned {} to AE2 because its compiled crafting graph snapshot was incomplete"
+                        + " ({}); patternGeneration={} recipeGeneration={}."
+                        + " This is not an ambiguous recipe and cannot be fixed by changing patterns.",
+                output.getId(),
+                failure,
+                capture.patternGeneration(),
+                capture.recipeGeneration());
     }
 
     private static void logFallbackOnce(AEKey output, Throwable failure) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2CompiledCraftingGraphCache.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2CompiledCraftingGraphCache.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.LinkedHashSet;
 import java.util.WeakHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
 
@@ -70,6 +71,37 @@ public final class Ae2CompiledCraftingGraphCache {
                         0L,
                         RecipeGenerationTracker.generation()),
                 0);
+    }
+
+    /**
+     * 指定したSnapshotがまだ現役なら破棄してから、同じ世代でもう一度コンパイルする。
+     *
+     * <p>世代の取り遅れで不完全なSnapshotが残った場合の取り直し用。ただし
+     * AppliedEのように「その世代では必ずコンパイルできない」Patternも同じ不完全印を付けるため、
+     * 一つのSnapshotにつき取り直しは一回までに固定する。これがないと、恒久的に不完全な
+     * ネットワークで注文のたびにGraph全体を作り直してしまう。</p>
+     *
+     * <p>取り直しても不完全なままなら、その結果へ印が付き、以後は世代が変わるまで
+     * 再構築を行わない。</p>
+     */
+    public static Snapshot recompile(IGrid grid, Level level, Snapshot stale) {
+        // 同じSnapshotから二度目の取り直しはしない。原因が世代なら一度で解ける。
+        if (!stale.claimRetryRebuild()) {
+            return stale;
+        }
+        ICraftingService service = grid.getCraftingService();
+        synchronized (CACHE) {
+            Map<ResourceKey<Level>, Snapshot> byDimension = CACHE.get(service);
+            Snapshot current = byDimension == null ? null : byDimension.get(level.dimension());
+            // 取り直しの引き金になった当人がまだ載っている場合だけ捨てる。
+            if (current == stale && byDimension != null) {
+                byDimension.remove(level.dimension());
+            }
+        }
+        Snapshot rebuilt = getOrCompile(grid, level);
+        // 作り直した結果がまだ不完全でも、同じ世代でこれ以上作り直さない。
+        rebuilt.claimRetryRebuild();
+        return rebuilt;
     }
 
     public static void clear() {
@@ -152,10 +184,12 @@ public final class Ae2CompiledCraftingGraphCache {
         private final Set<AEKey> incompletelyCompiledOutputs;
         private final Set<AEKey> craftables;
         private final long recipeGeneration;
-        private final Map<AEKey, Optional<CompiledRootProgram<AEKey>>> rootPrograms =
+        private final Map<AEKey, CompiledRootProgram.Outcome<AEKey>> rootPrograms =
                 new LinkedHashMap<>();
         private final Map<AEKey, Optional<Ae2StrictCraftingTopology>> strictTopologies =
                 new LinkedHashMap<>();
+        /** このSnapshotを起点にした取り直しを既に一度使ったか。 */
+        private final AtomicBoolean retryRebuildClaimed = new AtomicBoolean();
 
         private Snapshot(
                 ICraftingService service,
@@ -180,6 +214,11 @@ public final class Ae2CompiledCraftingGraphCache {
 
         public CompiledCraftingGraph<AEKey> graph() {
             return graph;
+        }
+
+        /** 取り直し権を一度だけ与える。既に使われていればfalseを返す。 */
+        private boolean claimRetryRebuild() {
+            return retryRebuildClaimed.compareAndSet(false, true);
         }
 
         public String id(IPatternDetails pattern) {
@@ -223,24 +262,47 @@ public final class Ae2CompiledCraftingGraphCache {
          * 世代変更時はSnapshotごと破棄されるため、古いPattern参照は残らない。
          */
         public Optional<CompiledRootProgram<AEKey>> rootProgram(AEKey root) {
+            return rootProgramOutcome(root).program();
+        }
+
+        /**
+         * {@link #rootProgram} と同じ結果に、コンパイルできなかった理由を添えて返す。
+         *
+         * <p>構造的に組めないルートと、この世代のSnapshotが揃わなかっただけのルートを
+         * 呼出側が区別できないと、プレイヤーへ直せない原因を「曖昧」として提示してしまう。</p>
+         */
+        public CompiledRootProgram.Outcome<AEKey> rootProgramOutcome(AEKey root) {
             synchronized (rootPrograms) {
-                Optional<CompiledRootProgram<AEKey>> cached = rootPrograms.get(root);
+                CompiledRootProgram.Outcome<AEKey> cached = rootPrograms.get(root);
                 // 既に成功またはFallbackが確定したルートは、同じ世代中に再探索しない。
                 if (cached != null) {
                     return cached;
                 }
             }
 
-            Optional<CompiledRootProgram<AEKey>> compiled = CompiledRootProgram.tryCompile(
+            CompiledRootProgram.Outcome<AEKey> compiled = CompiledRootProgram.compile(
                     graph,
                     root,
                     service::canEmitFor);
-            if (compiled.isPresent() && touchesIncompletePattern(compiled.get())) {
+            if (compiled.program().isPresent()
+                    && touchesIncompletePattern(compiled.program().get())) {
                 // 未コンパイルPatternを終端素材と誤認したShadow計算も作らず、直ちにAE2へ戻す。
-                compiled = Optional.empty();
+                compiled = compiled.withFailure(RootProgramFailure.INCOMPLETE_PATTERN_SNAPSHOT);
+            } else if (compiled.program().isPresent()
+                    && graph.patternsFor(root).isEmpty()
+                    && registeredPatternsByOutput.getOrDefault(root, 0) == 0
+                    && !service.getCraftingFor(root).isEmpty()) {
+                /*
+                 * AE2は現在このルートのPatternを持っているのに、Snapshotには一件も無い。
+                 * その場合コンパイルは終端ノード一個のProgramとして成立してしまうが、正体は
+                 * 世代の取り遅れなので採用しない。AE2側にもPatternが無い通常の不足要求は、
+                 * これまで通り終端Programのまま扱う。
+                 */
+                compiled = CompiledRootProgram.Outcome.failed(
+                        RootProgramFailure.MISSING_FROM_SNAPSHOT);
             }
             synchronized (rootPrograms) {
-                Optional<CompiledRootProgram<AEKey>> raced = rootPrograms.get(root);
+                CompiledRootProgram.Outcome<AEKey> raced = rootPrograms.get(root);
                 // 別計算スレッドが先に登録した場合は、その同一世代Programを採用する。
                 if (raced != null) {
                     return raced;

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/CompiledRootProgram.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/CompiledRootProgram.java
@@ -99,6 +99,18 @@ public final class CompiledRootProgram<K> {
             CompiledCraftingGraph<K> graph,
             K root,
             Predicate<? super K> canEmit) {
+        return compile(graph, root, canEmit).program();
+    }
+
+    /**
+     * {@link #tryCompile} と同じ判定を行い、失敗した場合はその理由も返す。
+     *
+     * <p>診断側が「構成が曖昧」と「Snapshotが揃わなかった」を混同しないために必要。</p>
+     */
+    public static <K> Outcome<K> compile(
+            CompiledCraftingGraph<K> graph,
+            K root,
+            Predicate<? super K> canEmit) {
         Objects.requireNonNull(graph, "graph");
         Objects.requireNonNull(root, "root");
         Objects.requireNonNull(canEmit, "canEmit");
@@ -119,11 +131,11 @@ public final class CompiledRootProgram<K> {
             }
             // Emitterや終端だけが大量に並ぶ場合も、固定ノード上限を必ず適用する。
             if (reachable.size() > MAXIMUM_PROGRAM_NODES) {
-                return Optional.empty();
+                return Outcome.failed(RootProgramFailure.PROGRAM_TOO_LARGE);
             }
             // SCCに属するキーは数式一巡では安全に解けないため、AE2標準計算へ戻す。
             if (graph.isCyclic(key)) {
-                return Optional.empty();
+                return Outcome.failed(RootProgramFailure.CYCLE);
             }
             // Emitterで供給できるキーは終端として扱い、その先のPatternを展開しない。
             if (canEmit.test(key)) {
@@ -140,13 +152,13 @@ public final class CompiledRootProgram<K> {
             }
             // 複数Patternの優先順位は在庫状態に依存するため、数式経路では選択しない。
             if (candidates.size() != 1) {
-                return Optional.empty();
+                return Outcome.failed(RootProgramFailure.MULTIPLE_PRODUCERS);
             }
 
             CompiledPattern<K> pattern = candidates.get(0);
             // 副産物や複数出力は余剰在庫会計が必要なため、単一路線から除外する。
             if (pattern.outputs().size() != 1 || pattern.outputAmount(key) <= 0L) {
-                return Optional.empty();
+                return Outcome.failed(RootProgramFailure.MULTIPLE_OUTPUTS);
             }
 
             Set<K> children = new LinkedHashSet<>();
@@ -166,7 +178,7 @@ public final class CompiledRootProgram<K> {
         List<K> order = topologicalOrder(reachable, dependencies);
         // 全ノードを並べられなかった場合は、探索中に見えなかった循環があるためFallbackする。
         if (order.size() != reachable.size()) {
-            return Optional.empty();
+            return Outcome.failed(RootProgramFailure.CYCLE);
         }
 
         Map<K, Integer> indexByKey = new LinkedHashMap<>();
@@ -191,12 +203,12 @@ public final class CompiledRootProgram<K> {
                                 slot.alternatives().size());
                     }
                 } catch (ArithmeticException overflow) {
-                    return Optional.empty();
+                    return Outcome.failed(RootProgramFailure.PROGRAM_TOO_LARGE);
                 }
                 // slotまたは候補辺の固定上限を超えるデータは、配列確保前にFallbackする。
                 if (slotCount > MAXIMUM_PROGRAM_INPUT_EDGES
                         || alternativeCount > MAXIMUM_PROGRAM_INPUT_EDGES) {
-                    return Optional.empty();
+                    return Outcome.failed(RootProgramFailure.PROGRAM_TOO_LARGE);
                 }
             }
         }
@@ -241,7 +253,7 @@ public final class CompiledRootProgram<K> {
                      * トポロジカル順が壊れているためFallbackする。
                      */
                     if (childIndex == null || childIndex <= node) {
-                        return Optional.empty();
+                        return Outcome.failed(RootProgramFailure.CYCLE);
                     }
                     inputIndices[alternativeCursor] = childIndex;
                     inputAmounts[alternativeCursor] = input.amount();
@@ -256,9 +268,9 @@ public final class CompiledRootProgram<K> {
         Integer rootIndex = indexByKey.get(root);
         // ルートは必ず到達集合へ入るが、防御的に欠落を検出してFallbackする。
         if (rootIndex == null) {
-            return Optional.empty();
+            return Outcome.failed(RootProgramFailure.CYCLE);
         }
-        return Optional.of(new CompiledRootProgram<>(
+        return Outcome.compiled(new CompiledRootProgram<>(
                 graph.generation(),
                 root,
                 rootIndex,
@@ -1289,6 +1301,42 @@ public final class CompiledRootProgram<K> {
 
         public int size() {
             return amounts.length;
+        }
+    }
+
+    /**
+     * コンパイル結果と、失敗した場合の理由。
+     *
+     * <p>{@code program} が存在するときの {@code failure} は必ず {@link RootProgramFailure#NONE}。</p>
+     */
+    public record Outcome<K>(
+            Optional<CompiledRootProgram<K>> program,
+            RootProgramFailure failure) {
+        public Outcome {
+            Objects.requireNonNull(program, "program");
+            Objects.requireNonNull(failure, "failure");
+            // 成功と失敗理由が同時に立った結果は、診断側が読み違えるため作らせない。
+            if (program.isPresent() != (failure == RootProgramFailure.NONE)) {
+                throw new IllegalArgumentException(
+                        "compiled root program outcome must carry exactly one of a program or a failure");
+            }
+        }
+
+        static <K> Outcome<K> compiled(CompiledRootProgram<K> program) {
+            return new Outcome<>(Optional.of(program), RootProgramFailure.NONE);
+        }
+
+        static <K> Outcome<K> failed(RootProgramFailure failure) {
+            // NONEは成功を意味するため、失敗結果としては受け付けない。
+            if (failure == RootProgramFailure.NONE) {
+                throw new IllegalArgumentException("failed outcome requires a concrete reason");
+            }
+            return new Outcome<>(Optional.empty(), failure);
+        }
+
+        /** 数式としては成立したProgramを、採用しない理由付きの失敗へ落とす。 */
+        public Outcome<K> withFailure(RootProgramFailure replacement) {
+            return failed(replacement);
         }
     }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/RootProgramFailure.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/RootProgramFailure.java
@@ -1,0 +1,44 @@
+package com.syaru.ae2craftingoptimizer.engine;
+
+/**
+ * Root Programをコンパイルできなかった理由。
+ *
+ * <p>「プレイヤーが構成を直せば解ける構造的な理由」と「その世代のSnapshotが揃わなかった
+ * 一時的な理由」を必ず区別する。前者は同じ世代で何度試しても同じ結果になるが、後者は
+ * Patternのコンパイル失敗や世代のずれが原因なので、取り直せば解けることがある。</p>
+ */
+public enum RootProgramFailure {
+    /** 失敗していない。 */
+    NONE,
+    /** ルートから到達する枝が強連結成分に属する、または並べ直せない循環がある。 */
+    CYCLE,
+    /** 一つの出力へ複数のPatternが登録されており、数式経路では選べない。 */
+    MULTIPLE_PRODUCERS,
+    /** 副産物・複数出力・非正の出力量など、単一路線として扱えない出力形状のPatternが含まれる。 */
+    MULTIPLE_OUTPUTS,
+    /** ノード数または入力辺数が固定上限を超えた。 */
+    PROGRAM_TOO_LARGE,
+    /** この世代のSnapshotで一部のPatternをコンパイルできず、到達キーが不完全だった。 */
+    INCOMPLETE_PATTERN_SNAPSHOT,
+    /** AE2が作成可能と扱うルートが、この世代のSnapshotのcraftablesに存在しなかった。 */
+    MISSING_FROM_SNAPSHOT;
+
+    /**
+     * 同じ世代のまま取り直しても結果が変わらない、構成側の理由かどうか。
+     */
+    public boolean structural() {
+        return this == CYCLE
+                || this == MULTIPLE_PRODUCERS
+                || this == MULTIPLE_OUTPUTS
+                || this == PROGRAM_TOO_LARGE;
+    }
+
+    /**
+     * Snapshotを取り直せば解ける可能性がある理由かどうか。
+     *
+     * <p>プレイヤーが構成を直しても消えないため、曖昧と同じ扱いで報告してはいけない。</p>
+     */
+    public boolean snapshotShaped() {
+        return this == INCOMPLETE_PATTERN_SNAPSHOT || this == MISSING_FROM_SNAPSHOT;
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/WideCraftingPlan.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/WideCraftingPlan.java
@@ -1,6 +1,7 @@
 package com.syaru.ae2craftingoptimizer.engine;
 
 import appeng.api.networking.crafting.ICraftingPlan;
+import java.math.BigInteger;
 
 /**
  * AE2のsigned long APIだけでは表現できない真値を持つACO内部計画。
@@ -9,4 +10,10 @@ import appeng.api.networking.crafting.ICraftingPlan;
  * {@link Ae2CraftingPlanSidecars#expose(WideCraftingPlan)}が作る純正CraftingPlanを使用する。</p>
  */
 public interface WideCraftingPlan extends ICraftingPlan {
+    /**
+     * CPU容量台帳へ渡す真のbyte数。
+     *
+     * <p>{@link #bytes()}はAE2互換の飽和値なので、診断や受理判定へ使ってはいけない。</p>
+     */
+    BigInteger exactBytes();
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/WidePlanSubmissionGuard.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/WidePlanSubmissionGuard.java
@@ -1,0 +1,81 @@
+package com.syaru.ae2craftingoptimizer.engine;
+
+import appeng.api.networking.crafting.CraftingSubmitErrorCode;
+import appeng.api.networking.crafting.ICraftingPlan;
+import appeng.api.networking.crafting.ICraftingSubmitResult;
+import appeng.api.networking.crafting.UnsuitableCpus;
+import appeng.crafting.execution.CraftingSubmitResult;
+import com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer;
+import com.syaru.ae2craftingoptimizer.config.ACOConfig;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * BigInteger容量台帳を持たないCPUがwide計画を断るときの、共通の返答と記録。
+ *
+ * <p>断ること自体はfail-closedとして正しいが、AE2の{@link CraftingSubmitErrorCode#CPU_TOO_SMALL}
+ * は「容量が足りない」を意味するコードなので、そのまま返すとプレイヤーはストレージを
+ * 増やしに行ってしまう。実際には容量をいくら足しても受理されない。ここでは容量とは
+ * 無関係であることが伝わる理由コードを返し、原因をログへ一度だけ残す。</p>
+ */
+public final class WidePlanSubmissionGuard {
+    /** 重複除去表の固定上限。超えたら丸ごと捨てて、常駐量を一定に保つ。 */
+    private static final int MAXIMUM_LOGGED_DECLINES = 1024;
+    private static final Set<String> LOGGED_DECLINES = ConcurrentHashMap.newKeySet();
+
+    private WidePlanSubmissionGuard() {
+    }
+
+    /**
+     * 標準AE2 CPUがwide計画を断るときの返答を作り、その理由を記録する。
+     *
+     * @param plan             断る対象の計画
+     * @param availableStorage 断ったCPUがAE2へ見せている空きbyte数
+     */
+    public static ICraftingSubmitResult declineOnUnsupportedCpu(
+            ICraftingPlan plan,
+            long availableStorage) {
+        logDeclineOnce(plan, availableStorage);
+        return unsupportedCpuResult();
+    }
+
+    /**
+     * 容量不足と読み違えられない拒否理由。
+     *
+     * <p>AE2の理由コードは公開enumで拡張できないため、除外されたCPUが一台という
+     * 形で返す。{@code tooSmall}を0のまま返すことが、この修正の要点。</p>
+     */
+    public static ICraftingSubmitResult unsupportedCpuResult() {
+        return CraftingSubmitResult.noSuitableCpu(new UnsuitableCpus(0, 0, 0, 1));
+    }
+
+    private static void logDeclineOnce(ICraftingPlan plan, long availableStorage) {
+        if (!ACOConfig.logWidePlanSubmissionDeclines()) {
+            return;
+        }
+        String outputId = plan.finalOutput().what().getId().toString();
+        // 同じ出力の連続クリックで同じ警告を積み上げない。
+        if (LOGGED_DECLINES.size() >= MAXIMUM_LOGGED_DECLINES) {
+            LOGGED_DECLINES.clear();
+        }
+        if (!LOGGED_DECLINES.add(outputId)) {
+            return;
+        }
+        String exactBytes = Ae2CraftingPlanSidecars.metadata(plan)
+                .map(metadata -> metadata.exactBytes().toString())
+                .orElse("<unknown>");
+        AE2CraftingOptimizer.LOGGER.warn(
+                "ACO refused to submit a plan for {} to a standard AE2 crafting CPU: the plan needs {}"
+                        + " exact bytes, which no signed-long CPU ledger can hold (the CPU reports {} free)."
+                        + " Adding crafting storage cannot fix this; the job needs a crafting CPU with a"
+                        + " BigInteger ledger.",
+                outputId,
+                exactBytes,
+                availableStorage);
+    }
+
+    /** 単体テスト間で重複除去表を共有しないためのpackage-private reset。 */
+    static void clearForTests() {
+        LOGGED_DECLINES.clear();
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeBigCapacityPlanSubmissionMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeBigCapacityPlanSubmissionMixin.java
@@ -17,6 +17,7 @@ import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
 import com.syaru.ae2craftingoptimizer.engine.BigCapacityCraftingPlan;
 import com.syaru.ae2craftingoptimizer.engine.BigIntegerCraftingPlan;
+import com.syaru.ae2craftingoptimizer.engine.WidePlanSubmissionGuard;
 import com.syaru.ae2craftingoptimizer.integration.AqeBigCraftingExecutionContext;
 import java.math.BigInteger;
 import java.util.HashMap;
@@ -81,8 +82,14 @@ public abstract class AdvancedAeBigCapacityPlanSubmissionMixin
                 return;
             }
             var host = BigCraftingHostRegistry.find(this).orElse(null);
-            if (host == null
-                    || host.available().compareTo(bigIntegerPlan.exactBytes()) < 0) {
+            // BigInteger台帳が無いCPUは容量の問題ではないため、容量不足コードを返さない。
+            if (host == null) {
+                cir.setReturnValue(WidePlanSubmissionGuard.declineOnUnsupportedCpu(
+                        plan,
+                        ((AdvCraftingCPUCluster) (Object) this).getAvailableStorage()));
+                return;
+            }
+            if (host.available().compareTo(bigIntegerPlan.exactBytes()) < 0) {
                 cir.setReturnValue(CraftingSubmitResult.CPU_TOO_SMALL);
                 return;
             }
@@ -121,8 +128,14 @@ public abstract class AdvancedAeBigCapacityPlanSubmissionMixin
          * 文脈に真値があるのにPlanと一致しない場合は、別Windowの取り違えとして拒否する。
          */
         boolean parentOwnedWindow = parentOwnedAllowance.signum() > 0;
-        if (host == null
-                || (parentOwnedWindow
+        // BigInteger台帳が無いCPUは容量の問題ではないため、容量不足コードを返さない。
+        if (host == null) {
+            cir.setReturnValue(WidePlanSubmissionGuard.declineOnUnsupportedCpu(
+                    plan,
+                    ((AdvCraftingCPUCluster) (Object) this).getAvailableStorage()));
+            return;
+        }
+        if ((parentOwnedWindow
                         && !parentOwnedAllowance.equals(bigPlan.exactBytes()))
                 || (!parentOwnedWindow
                         && host.available().compareTo(bigPlan.exactBytes()) < 0)) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCpuClusterBigCapacityGuardMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCpuClusterBigCapacityGuardMixin.java
@@ -5,10 +5,10 @@ import appeng.api.networking.crafting.ICraftingPlan;
 import appeng.api.networking.crafting.ICraftingRequester;
 import appeng.api.networking.crafting.ICraftingSubmitResult;
 import appeng.api.networking.security.IActionSource;
-import appeng.crafting.execution.CraftingSubmitResult;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
 import com.syaru.ae2craftingoptimizer.access.BigCapacityPlanBoundaryAccess;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
+import com.syaru.ae2craftingoptimizer.engine.WidePlanSubmissionGuard;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -27,7 +27,13 @@ public abstract class CraftingCpuClusterBigCapacityGuardMixin
             CallbackInfoReturnable<ICraftingSubmitResult> cir) {
         // Long.MAXは真の容量ではないため、対応Sidecarを持たない標準CPUでは実行しない。
         if (Ae2CraftingPlanSidecars.isWide(plan)) {
-            cir.setReturnValue(CraftingSubmitResult.CPU_TOO_SMALL);
+            /*
+             * 容量不足コードを返すとプレイヤーはストレージを増やしに行くが、
+             * この拒否は空き容量と一切関係がない。理由が伝わる返答へ差し替える。
+             */
+            cir.setReturnValue(WidePlanSubmissionGuard.declineOnUnsupportedCpu(
+                    plan,
+                    ((CraftingCPUCluster) (Object) this).getAvailableStorage()));
         }
     }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/FallbackReasonCode.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/FallbackReasonCode.java
@@ -8,6 +8,16 @@ public enum FallbackReasonCode {
     PROCESSING_BOUNDARY,
     TAG_SELECTION_UNPROVEN,
     CYCLE,
+    /** ノード数または入力辺数が固定上限を超えた。 */
+    PROGRAM_TOO_LARGE,
+    /**
+     * その世代のコンパイル済みGraphが揃わず、Root Programを取れなかった。
+     *
+     * <p>構成が曖昧なわけではないため、プレイヤーがPatternを直しても解けない。</p>
+     */
+    INCOMPLETE_GRAPH_SNAPSHOT,
+    /** Root Programが無いのに具体的な理由も付いていなかった。 */
+    NO_COMPILED_PROGRAM,
     GENERATION_CHANGED,
     INVENTORY_CHANGED,
     UNSUPPORTED_PATTERN,

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlannerPolicyTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlannerPolicyTest.java
@@ -1,8 +1,10 @@
 package com.syaru.ae2craftingoptimizer.engine;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.syaru.ae2craftingoptimizer.optimization.FallbackReasonCode;
 import org.junit.jupiter.api.Test;
 
 class Ae2AuthoritativeCraftingPlannerPolicyTest {
@@ -42,6 +44,64 @@ class Ae2AuthoritativeCraftingPlannerPolicyTest {
                 false,
                 false,
                 false,
+                false));
+    }
+
+    @Test
+    void doesNotReportASnapshotFailureAsAnAmbiguousProducer() {
+        assertEquals(
+                FallbackReasonCode.INCOMPLETE_GRAPH_SNAPSHOT,
+                Ae2AuthoritativeCraftingPlanner.classifyRootProgramFailure(
+                        RootProgramFailure.INCOMPLETE_PATTERN_SNAPSHOT));
+        assertEquals(
+                FallbackReasonCode.INCOMPLETE_GRAPH_SNAPSHOT,
+                Ae2AuthoritativeCraftingPlanner.classifyRootProgramFailure(
+                        RootProgramFailure.MISSING_FROM_SNAPSHOT));
+    }
+
+    @Test
+    void keepsEachStructuralReasonDistinct() {
+        assertEquals(
+                FallbackReasonCode.AMBIGUOUS_PRODUCER,
+                Ae2AuthoritativeCraftingPlanner.classifyRootProgramFailure(
+                        RootProgramFailure.MULTIPLE_PRODUCERS));
+        assertEquals(
+                FallbackReasonCode.CYCLE,
+                Ae2AuthoritativeCraftingPlanner.classifyRootProgramFailure(
+                        RootProgramFailure.CYCLE));
+        assertEquals(
+                FallbackReasonCode.UNSUPPORTED_PATTERN,
+                Ae2AuthoritativeCraftingPlanner.classifyRootProgramFailure(
+                        RootProgramFailure.MULTIPLE_OUTPUTS));
+        assertEquals(
+                FallbackReasonCode.PROGRAM_TOO_LARGE,
+                Ae2AuthoritativeCraftingPlanner.classifyRootProgramFailure(
+                        RootProgramFailure.PROGRAM_TOO_LARGE));
+    }
+
+    @Test
+    void retriesOnlySnapshotShapedRootProgramFailures() {
+        assertTrue(Ae2AuthoritativeCraftingPlanner.shouldRetryRootProgram(
+                RootProgramFailure.INCOMPLETE_PATTERN_SNAPSHOT,
+                true));
+        assertTrue(Ae2AuthoritativeCraftingPlanner.shouldRetryRootProgram(
+                RootProgramFailure.MISSING_FROM_SNAPSHOT,
+                true));
+        assertFalse(Ae2AuthoritativeCraftingPlanner.shouldRetryRootProgram(
+                RootProgramFailure.MULTIPLE_PRODUCERS,
+                true));
+        assertFalse(Ae2AuthoritativeCraftingPlanner.shouldRetryRootProgram(
+                RootProgramFailure.CYCLE,
+                true));
+        assertFalse(Ae2AuthoritativeCraftingPlanner.shouldRetryRootProgram(
+                RootProgramFailure.NONE,
+                true));
+    }
+
+    @Test
+    void neverRetriesWhileTheConfigSwitchIsOff() {
+        assertFalse(Ae2AuthoritativeCraftingPlanner.shouldRetryRootProgram(
+                RootProgramFailure.INCOMPLETE_PATTERN_SNAPSHOT,
                 false));
     }
 

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/Ae2CraftingPlanSidecarsTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/Ae2CraftingPlanSidecarsTest.java
@@ -84,6 +84,11 @@ class Ae2CraftingPlanSidecarsTest {
         }
 
         @Override
+        public java.math.BigInteger exactBytes() {
+            return java.math.BigInteger.valueOf(Long.MAX_VALUE).add(java.math.BigInteger.ONE);
+        }
+
+        @Override
         public boolean simulation() {
             return false;
         }

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/CompiledRootProgramFailureReasonTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/CompiledRootProgramFailureReasonTest.java
@@ -1,0 +1,113 @@
+package com.syaru.ae2craftingoptimizer.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Root Programをコンパイルできなかったとき、その理由が構造的なのか
+ * Snapshot都合なのかを呼出側が区別できることを固定する。
+ */
+class CompiledRootProgramFailureReasonTest {
+    @Test
+    void reportsCycleRatherThanAmbiguity() {
+        var a = pattern("a", "b", 1L, "a", 1L);
+        var b = pattern("b", "a", 1L, "b", 1L);
+
+        var outcome = CompiledRootProgram.compile(
+                CompiledCraftingGraph.compile(1L, List.of(a, b)),
+                "a",
+                ignored -> false);
+
+        assertTrue(outcome.program().isEmpty());
+        assertEquals(RootProgramFailure.CYCLE, outcome.failure());
+        assertTrue(outcome.failure().structural());
+    }
+
+    @Test
+    void reportsMultipleProducersForAGenuinelyAmbiguousOutput() {
+        var first = pattern("first", "raw-a", 1L, "output", 1L);
+        var second = pattern("second", "raw-b", 1L, "output", 1L);
+
+        var outcome = CompiledRootProgram.compile(
+                CompiledCraftingGraph.compile(1L, List.of(first, second)),
+                "output",
+                ignored -> false);
+
+        assertEquals(RootProgramFailure.MULTIPLE_PRODUCERS, outcome.failure());
+    }
+
+    @Test
+    void reportsMultipleOutputsForAByproductPattern() {
+        var byproduct = new CompiledPattern<>(
+                "byproduct",
+                List.of(slot("raw", 1L)),
+                Map.of("output", 1L, "extra", 1L),
+                false);
+
+        var outcome = CompiledRootProgram.compile(
+                CompiledCraftingGraph.compile(1L, List.of(byproduct)),
+                "output",
+                ignored -> false);
+
+        assertEquals(RootProgramFailure.MULTIPLE_OUTPUTS, outcome.failure());
+    }
+
+    @Test
+    void keepsSuccessfulCompilationFreeOfAFailureReason() {
+        var outcome = CompiledRootProgram.compile(
+                CompiledCraftingGraph.compile(
+                        1L,
+                        List.of(pattern("output", "raw", 1L, "output", 1L))),
+                "output",
+                Set.of()::contains);
+
+        assertTrue(outcome.program().isPresent());
+        assertEquals(RootProgramFailure.NONE, outcome.failure());
+    }
+
+    @Test
+    void refusesToCarryBothAProgramAndAFailure() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new CompiledRootProgram.Outcome<String>(
+                        java.util.Optional.empty(),
+                        RootProgramFailure.NONE));
+    }
+
+    @Test
+    void separatesStructuralReasonsFromSnapshotShapedOnes() {
+        assertTrue(RootProgramFailure.MULTIPLE_PRODUCERS.structural());
+        assertTrue(RootProgramFailure.CYCLE.structural());
+        assertTrue(RootProgramFailure.MULTIPLE_OUTPUTS.structural());
+        assertTrue(RootProgramFailure.PROGRAM_TOO_LARGE.structural());
+
+        assertTrue(RootProgramFailure.INCOMPLETE_PATTERN_SNAPSHOT.snapshotShaped());
+        assertTrue(RootProgramFailure.MISSING_FROM_SNAPSHOT.snapshotShaped());
+        assertFalse(RootProgramFailure.INCOMPLETE_PATTERN_SNAPSHOT.structural());
+        assertFalse(RootProgramFailure.MISSING_FROM_SNAPSHOT.structural());
+    }
+
+    private static CompiledPattern.InputSlot<String> slot(String key, long amount) {
+        return new CompiledPattern.InputSlot<>(List.of(new CompiledPattern.Stack<>(key, amount)));
+    }
+
+    private static CompiledPattern<String> pattern(
+            String id,
+            String input,
+            long inputAmount,
+            String output,
+            long outputAmount) {
+        return new CompiledPattern<>(
+                id,
+                List.of(slot(input, inputAmount)),
+                Map.of(output, outputAmount),
+                false);
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/WidePlanSubmissionGuardTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/WidePlanSubmissionGuardTest.java
@@ -1,0 +1,44 @@
+package com.syaru.ae2craftingoptimizer.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import appeng.api.networking.crafting.CraftingSubmitErrorCode;
+import appeng.api.networking.crafting.UnsuitableCpus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * wide計画を断るCPUが「容量不足」を名乗らないことを固定する。
+ *
+ * <p>issue #103で報告された通り、この拒否は空き容量と無関係なので、
+ * CPU_TOO_SMALLを返すとプレイヤーはストレージを増やす作業へ誘導されてしまう。</p>
+ */
+class WidePlanSubmissionGuardTest {
+    @AfterEach
+    void clearDeduplicationTable() {
+        WidePlanSubmissionGuard.clearForTests();
+    }
+
+    @Test
+    void neverReportsAWideDeclineAsInsufficientCapacity() {
+        var result = WidePlanSubmissionGuard.unsupportedCpuResult();
+
+        assertFalse(result.successful());
+        assertNotEquals(CraftingSubmitErrorCode.CPU_TOO_SMALL, result.errorCode());
+    }
+
+    @Test
+    void countsTheCpuAsExcludedRatherThanTooSmall() {
+        var result = WidePlanSubmissionGuard.unsupportedCpuResult();
+
+        assertEquals(CraftingSubmitErrorCode.NO_SUITABLE_CPU_FOUND, result.errorCode());
+        UnsuitableCpus detail = assertInstanceOf(UnsuitableCpus.class, result.errorDetail());
+        assertEquals(0, detail.tooSmall());
+        assertEquals(0, detail.offline());
+        assertEquals(0, detail.busy());
+        assertEquals(1, detail.excluded());
+    }
+}


### PR DESCRIPTION
## Summary

Addresses both halves of issue #103: a request above `long` cannot be submitted, and the two reasons it fails are reported as something they are not. Neither is fixed on `main` at 1.6.2 — the wide-plan guard was in fact simplified in 1.6.x to reject unconditionally.

**Problem 1 — `CPU_TOO_SMALL` is returned regardless of capacity.** A crafting CPU without a BigInteger ledger declined every wide plan with `CPU_TOO_SMALL`. The refusal has nothing to do with free capacity: the required bytes and the CPU's free bytes both print as `9223372036854775807`, and AE2's own `available < bytes` check passes. Returning AE2's capacity code sends players to add crafting storage that can never help, and nothing was written to the log. Declines now count the CPU as *excluded* rather than *too small* (`NO_SUITABLE_CPU_FOUND` with `UnsuitableCpus(0, 0, 0, 1)` — `tooSmall` stays at 0, which is the point), and log one warning per output carrying the exact byte cost and the free bytes the CPU reports. The same misreport existed on the Advanced AE submission path when no BigInteger host was registered; a genuine `host.available() < exactBytes` shortfall still returns `CPU_TOO_SMALL`. The refusals themselves stay fail-closed and behaviourally unchanged.

**Problem 2 — the graph returns a root program but the planner reports no compiled program.** Every empty-root-program outcome was recorded as `AMBIGUOUS_PRODUCER`, so a root with exactly one pattern read as ambiguous and the real cause stayed invisible. `CompiledRootProgram` now reports *why* it could not compile, and the graph snapshot splits those reasons in two:

- structural (cycles, multiple producers, unusable output shapes, size limits) — the player can fix these, and they cannot change within a generation;
- snapshot-shaped (a pattern that failed to compile in that snapshot, or a root AE2 currently has patterns for that is absent from the snapshot) — the player cannot fix these.

Snapshot-shaped failures report the new `INCOMPLETE_GRAPH_SNAPSHOT`, are logged once per output and generation pair with `patternGeneration` / `recipeGeneration`, and get one graph rebuild before giving up. A root that AE2 currently has patterns for but that is missing from the snapshot is no longer compiled into a degenerate terminal-only program.

The rebuild is bounded to **one per snapshot**: AppliedE patterns carry the same incomplete mark permanently within a generation, so an unbounded retry would rebuild the whole graph on every calculation.

## Safety Boundary

- [x] AE2 remains authoritative for craft validity and storage mutation. No plan is newly accepted; the only paths that change acceptance are strictly narrowing (a degenerate terminal-only program now falls back to AE2 instead of being planned by ACO).
- [x] Optional-mod paths retain an original fallback. The Advanced AE guard keeps its existing structure; only the `host == null` branch is split out of the capacity branch.
- [x] New caches are bounded and have documented invalidation. The two log-deduplication tables are capped (4096 and 1024 entries) and cleared wholesale at the cap; the retry claim lives on the snapshot and is released when the generation changes and the snapshot is discarded.
- [x] Timing, ordering, or batching changes have a config switch. `retryIncompleteCraftingGraphSnapshot` (default `true`) gates the extra graph build; `logWidePlanSubmissionDeclines` (default `true`) gates the new warning and never affects the decline itself.

## Verification

- [x] `./gradlew clean build` — passes. 331 tests, 0 failures.
- [ ] Relevant checks in `docs/TESTING.md` — two new manual sections are **added but not executed**; they need a live world, which this branch was prepared without.
- [ ] Tested once with `enableOptimizer=false` — not run, same reason.
- [ ] Included before/after performance evidence where applicable — no performance change is claimed. The one performance-relevant risk (an extra graph build) is bounded to once per snapshot; step 5 of the new *Incomplete Graph Snapshot Fallback* section is the Spark check for it.

New automated coverage: distinct compiled root-program failure reasons for cycles, multiple producers and byproduct patterns; retrying only snapshot-shaped failures; and the wide-plan decline never claiming the CPU is too small.

The InsaneAE reproduction game tests (`insaneae_craft_past_long`, `insaneae_craft_past_long_processing`, run with `-PwithAco=true`) have **not** been run against this branch.

Note on scope: the handoff notes flag problem 2 as the one that may need a design decision from the author before it is touched. The change here is deliberately conservative — it splits and reports reasons, and adds one bounded retry behind a switch, without changing which plans are accepted — but the classification boundary is still worth a review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5QUaFs1z5BdxGxmFo58nE)_