### PR TITLE
fix(1.20.1): isolate exact inventory snapshots from AE2 runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.22] - 2026-08-20
+
+### Fixed
+
+- Removed exact BigInteger inventory interception from normal AE2 network
+  storage, storage-service, and crafting-simulation runtime paths.
+- Limited exact inventory snapshots to authoritative BigInteger planning so
+  ordinary terminal insertion, extraction, serials, buses, and watchers remain
+  owned by AE2.
+- Preserved exact `10^64` test-cell amounts for planning while exposing only
+  the existing `Long.MAX_VALUE` compatibility facade to standard AE2 paths.
+- Limited ExtendedAE Plus cache refreshes to cells whose exact ledger was
+  directly changed by ACO.
+
 ## [1.5.21] - 2026-08-19
 
 ### Fixed

--- a/RELEASE_NOTES_1.5.22.md
+++ b/RELEASE_NOTES_1.5.22.md
@@ -1,0 +1,18 @@
+# AE2 Crafting Optimizer 1.5.22
+
+## Fixed
+
+- Exact BigInteger inventory snapshots are now created only inside ACO's
+  authoritative crafting planner.
+- Normal AE2 terminal insertion, extraction, serial allocation, storage buses,
+  import/export buses, and storage watchers no longer receive ACO sidecars.
+- Exact `10^64` test-cell amounts remain available to BigInteger planning
+  without replacing AE2's normal network inventory.
+- ExtendedAE Plus cache refreshes are limited to cells directly modified by
+  ACO's exact ledger.
+
+## Compatibility
+
+- Forge 1.20.1 with AE2 15.4.x or the audited AE2-UELM profile.
+- This release does not transfer CPU execution ownership to ACO. AQE and other
+  optional CPU add-ons continue to own submission, execution, and progress.

--- a/docs/CLASS_RESPONSIBILITIES.md
+++ b/docs/CLASS_RESPONSIBILITIES.md
@@ -377,16 +377,17 @@ mixin + access  ->  integration  ->  optimization / scheduler
 | `com.syaru.ae2craftingoptimizer.integration.AppliedECompatibility` | AppliedE本家とTPS Fix forkに共通する動的パターン境界を扱う。 |
 | `com.syaru.ae2craftingoptimizer.integration.AqeBigCraftingExecutionContext` | 標準容量判定へ、現在投入中のBig子Job一件分だけを一時的に貸し出すサーバースレッド文脈。 |
 | `com.syaru.ae2craftingoptimizer.integration.AqeBigCraftingExecutionManager` | Advanced AE CPU HostとACO exact計画を接続し、予約、実行、取消、復元を調停する外部境界。 |
-| `com.syaru.ae2craftingoptimizer.integration.BigIntegerStorageSnapshotBridge` | NetworkStorageが各mountを集計する境界で、AE2用long FacadeとBigInteger正本を分離する。 |
+| `com.syaru.ae2craftingoptimizer.integration.BigIntegerStorageSnapshotBridge` | Plannerが一つのmountを読む時だけ、AE2用long FacadeとBigInteger正本を分離する。通常NetworkStorageへは介入しない。 |
 | `com.syaru.ae2craftingoptimizer.integration.ExactBigIntegerCellConsistency` | ACOが直接更新したExtendedAE Plus在庫Mapと、同MODの保存用総量を結ぶ弱Sidecar。 |
 | `com.syaru.ae2craftingoptimizer.integration.ExactNetworkStorageBridge` | ME storageへのexact snapshot、reserve、insert、rollbackをAE2権限境界内で行う。 |
-| `com.syaru.ae2craftingoptimizer.integration.ExactNetworkStorageSnapshotCache` | 同一server tick内で完成済みのNetworkStorage在庫集計を再利用する。 |
+| `com.syaru.ae2craftingoptimizer.integration.ExactNetworkStorageSnapshotCache` | 旧共有Snapshot実装。Issue #109再発防止のためMixin未登録で、通常AE2からは使用しない。 |
 | `com.syaru.ae2craftingoptimizer.integration.ExactVectorGridTickBudget` | BigInteger親Jobと標準AQE Jobが共有する、Grid単位のExact Vector tick予算。 |
 | `com.syaru.ae2craftingoptimizer.integration.ExperimentalCompatibilityValidator` | 有効化された実験Mixinの対象クラス、Accessor、内部契約を起動時に監査する。 |
-| `com.syaru.ae2craftingoptimizer.integration.GridStorageSnapshotBridge` | 通常MEネットワーク端末へ、AE2 StorageServiceが管理する同じ在庫Snapshotを複製する。 |
+| `com.syaru.ae2craftingoptimizer.integration.GridStorageSnapshotBridge` | 旧端末Snapshot実装。Issue #109再発防止のため通常ME端末からは使用しない。 |
 | `com.syaru.ae2craftingoptimizer.integration.NeoEcoVersionCompatibility` | Neo ECOの実行API世代を、Mixinが参照する前に文字列だけで判定する。 |
 | `com.syaru.ae2craftingoptimizer.integration.OptionalAqeBigCraftingExecution` | Advanced AE未導入環境で対象クラスを解決しないための遅延境界。 |
 | `com.syaru.ae2craftingoptimizer.integration.OptionalNativeBatchIntegrations` | 動作確認済みの依存MODバージョンに限ってNative Batch Adapterを遅延登録する。 |
+| `com.syaru.ae2craftingoptimizer.integration.PlanningExactInventorySnapshot` | Issue #109の責務分離。クラフト計算時だけmountを列挙し、端末・バス・通常AE2へSidecarを漏らさない。 |
 | `com.syaru.ae2craftingoptimizer.integration.ProgramFingerprintRevalidationCache` | 現在のPattern/recipe世代で再検証済みの数式Program指紋を保持する。 |
 
 ### `com.syaru.ae2craftingoptimizer.intent`
@@ -489,15 +490,15 @@ mixin + access  ->  integration  ->  optimization / scheduler
 | `com.syaru.ae2craftingoptimizer.mixin.NeoEco20_4CraftingCpuExecutionBudgetMixin` | NeoEco20_4CraftingCpuExecutionBudgetMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
 | `com.syaru.ae2craftingoptimizer.mixin.NeoEcoExecutionBudgetSupport` | Neo ECO 20.3/20.4の記述子差分から独立した、共通の実行予算計算。 |
 | `com.syaru.ae2craftingoptimizer.mixin.NetworkCraftingSimulationStateAccessor` | NetworkCraftingSimulationStateAccessorの対象となる非公開状態を型付きAccessorとして公開するMixin。 |
-| `com.syaru.ae2craftingoptimizer.mixin.NetworkCraftingSimulationStateBigIntegerSnapshotMixin` | NetworkCraftingSimulationStateBigIntegerSnapshotMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
-| `com.syaru.ae2craftingoptimizer.mixin.NetworkStorageBigIntegerSnapshotMixin` | NetworkStorageBigIntegerSnapshotMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.NetworkCraftingSimulationStateBigIntegerSnapshotMixin` | 旧共有Sidecar実装。Issue #109再発防止のためMixin設定へ登録しない。 |
+| `com.syaru.ae2craftingoptimizer.mixin.NetworkStorageBigIntegerSnapshotMixin` | 旧全Network介入実装。Issue #109再発防止のためMixin設定へ登録しない。 |
 | `com.syaru.ae2craftingoptimizer.mixin.NetworkStorageMountsAccessor` | NetworkStorageMountsAccessorの対象となる非公開状態を型付きAccessorとして公開するMixin。 |
 | `com.syaru.ae2craftingoptimizer.mixin.NumberEntryWidgetAccessor` | NumberEntryWidgetAccessorの対象となる非公開状態を型付きAccessorとして公開するMixin。 |
 | `com.syaru.ae2craftingoptimizer.mixin.P2PServiceTopologyDeduplicationMixin` | P2PServiceTopologyDeduplicationMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
 | `com.syaru.ae2craftingoptimizer.mixin.PatternProviderLogicIntentCaptureMixin` | PatternProviderLogicIntentCaptureMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
 | `com.syaru.ae2craftingoptimizer.mixin.PatternProviderLogicNativeBatchReceiptMixin` | PatternProviderLogicNativeBatchReceiptMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
 | `com.syaru.ae2craftingoptimizer.mixin.StorageServiceDeepCoalescingMixin` | StorageServiceDeepCoalescingMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
-| `com.syaru.ae2craftingoptimizer.mixin.StorageServiceExactSnapshotInvalidationMixin` | StorageServiceExactSnapshotInvalidationMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.StorageServiceExactSnapshotInvalidationMixin` | 旧共有Snapshot失効実装。Issue #109再発防止のためMixin設定へ登録しない。 |
 | `com.syaru.ae2craftingoptimizer.mixin.StorageServiceWatcherThrottleMixin` | StorageServiceWatcherThrottleMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
 | `com.syaru.ae2craftingoptimizer.mixin.TaskProgressTransactionAccessMixin` | TaskProgressTransactionAccessMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -177,27 +177,18 @@ The parent commit only:
 
 It does not create or insert output.
 
-## Exact Inventory Snapshot Reuse
+## Planner-local Exact Inventory Snapshot
 
-`NetworkStorageBigIntegerSnapshotMixin` still builds one saturated AE2
-`KeyCounter` facade plus one exact `BigInteger` sidecar. The completed pair is
-now reusable only when all of the following remain true:
+`PlanningExactInventorySnapshot` builds a saturated AE2 `KeyCounter` facade
+and an exact `BigInteger` sidecar only when ACO starts an authoritative
+crafting calculation. The shared `NetworkStorage#getAvailableStacks` path is
+not redirected.
 
-- the same `NetworkStorage` instance is queried;
-- the server tick is unchanged;
-- the global storage generation is unchanged;
-- the destination counter is empty.
-
-Real `NetworkStorage` insert/extract operations, mount changes, and AE2
-`StorageService.invalidateCache()` advance the shared generation immediately.
-An in-progress capture whose generation changes is discarded. The one-tick
-ceiling is intentional: an arbitrary storage add-on may not expose a durable
-content generation, so ACO does not retain its snapshot across ticks.
-
-Nested storage networks are still enumerated once when their current value is
-required. A second request for the same nested network in the same tick reuses
-the completed facade and exact sidecar instead of rebuilding every mounted
-storage.
+This separation keeps terminal serials, buses, watchers, normal insert/extract,
+and ordinary AE2 cached inventory under AE2 ownership. The planner-local
+snapshot still enumerates mounted storage in AE2 priority order, deduplicates
+identical mount instances, preserves `10^64` exact cell amounts, and exposes
+`Long.MAX_VALUE` only as the compatibility facade.
 
 For a normal full-grid ME terminal,
 `MEStorageMenuGridSnapshotReuseMixin` copies

--- a/docs/issues/ISSUE-109.md
+++ b/docs/issues/ISSUE-109.md
@@ -26,12 +26,33 @@ BigInteger APIの「利用可能」「consumer登録済み」「AE2標準経路�
 - ME端末の`getAvailableStacks`を置換するMixinを外し、AE2本来のMenu経路へ戻す
 - ACOは外部CPUへexact plan APIを提供するだけで、外部CPUの実行ロジックを所有しない
 
+## 1.5.21後に判明した残存介入
+
+1.5.21ではMenu専用Redirectを外しましたが、より下層の
+`NetworkStorage#getAvailableStacks`へ刺さる`NetworkStorageBigIntegerSnapshotMixin`が
+残っていました。このMixinは端末だけでなく、バス、監視、通常クラフトを含む全在庫列挙を
+独自集計と同一tick cacheへ置換していました。
+
+また、ExtendedAE Plusセルの通常`insert/extract`前にも、ACO直接取引の有無にかかわらず
+内部cache refreshを強制していました。どちらも「BigInteger計画/APIだけをACOが所有する」
+責務境界を越えています。
+
+## 追加修正
+
+- NetworkStorage、StorageService、NetworkCraftingSimulationStateへのexact在庫常時Mixinを登録しない
+- BigInteger正確量はクラフト計算開始時の`PlanningExactInventorySnapshot`だけで取得する
+- 通常AE2の在庫一覧、serial、insert、extract、watcherを変更しない
+- ExtendedAE Plusの通常搬入出へは、ACOが直接変更したセルの整合台帳が存在する時だけ介入する
+- テストセルの`10^64`正本とAE2向け`Long.MAX_VALUE`互換表示は維持する
+
 ## 回帰禁止事項
 
 - consumer登録の有無だけで標準AE2 CPUの提出結果を変更しない
 - BigInteger APIを有効化しただけで通常long計画を置換しない
 - master switchがOFFの時に在庫Snapshotやクラフト演算へ介入しない
 - ME端末の通常入出庫をwide在庫表示の都合でRedirectしない
+- `NetworkStorage#getAvailableStacks`を正確量取得のために常時Redirectしない
+- Planner用SidecarをStorageServiceの共有Cached Inventoryへ格納しない
 
 ## 確認項目
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.21
+mod_version=1.5.22
 minecraft_version=1.20.1
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
@@ -11,6 +11,7 @@ import appeng.api.stacks.KeyCounter;
 import appeng.crafting.CraftingPlan;
 import com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
+import com.syaru.ae2craftingoptimizer.integration.PlanningExactInventorySnapshot;
 import com.syaru.ae2craftingoptimizer.optimization.BigIntegerPlanDeclineReason;
 import com.syaru.ae2craftingoptimizer.optimization.BigIntegerPlanDiagnostics;
 import com.syaru.ae2craftingoptimizer.optimization.ProviderPatternGenerationTracker;
@@ -56,6 +57,7 @@ public final class Ae2AuthoritativeCraftingPlanner {
                 grid,
                 source,
                 networkSnapshot,
+                PlanningExactInventorySnapshot.capture(grid),
                 ProviderPatternGenerationTracker.generation(),
                 RecipeGenerationTracker.generation());
     }
@@ -172,11 +174,11 @@ public final class Ae2AuthoritativeCraftingPlanner {
             }
 
             BigKeyCounterSidecars.Snapshot inventoryMetadata =
-                    BigKeyCounterSidecars.snapshot(capture.inventorySnapshot()).orElse(null);
+                    BigKeyCounterSidecars.snapshot(capture.exactInventorySnapshot()).orElse(null);
             CompiledRootProgram.BigInventorySnapshot<AEKey> exactPlanningInventory =
                     Ae2ReferencedInventory.captureExactNetworkSnapshot(
                             program,
-                            capture.inventorySnapshot(),
+                            capture.exactInventorySnapshot(),
                             output);
             CompiledRootProgram.InventorySnapshot<AEKey> planningInventory = null;
             // 参照キーを個別に証明できない場合だけ、通常AE2のlong Snapshotへ戻す。
@@ -902,6 +904,7 @@ public final class Ae2AuthoritativeCraftingPlanner {
             IGrid grid,
             IActionSource source,
             KeyCounter inventorySnapshot,
+            KeyCounter exactInventorySnapshot,
             long patternGeneration,
             long recipeGeneration) {
         public Capture {
@@ -909,6 +912,7 @@ public final class Ae2AuthoritativeCraftingPlanner {
             Objects.requireNonNull(grid, "grid");
             Objects.requireNonNull(source, "source");
             Objects.requireNonNull(inventorySnapshot, "inventorySnapshot");
+            Objects.requireNonNull(exactInventorySnapshot, "exactInventorySnapshot");
             // 負の世代値はSnapshot識別へ使用できないため拒否する。
             if (patternGeneration < 0L || recipeGeneration < 0L) {
                 throw new IllegalArgumentException("generation values must not be negative");
@@ -932,6 +936,7 @@ public final class Ae2AuthoritativeCraftingPlanner {
                     grid,
                     source,
                     inventorySnapshot,
+                    exactInventorySnapshot,
                     ProviderPatternGenerationTracker.generation(),
                     RecipeGenerationTracker.generation());
         }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2ReferencedInventory.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2ReferencedInventory.java
@@ -7,6 +7,7 @@ import appeng.api.stacks.AEKey;
 import appeng.api.stacks.KeyCounter;
 import appeng.core.AEConfig;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
+import com.syaru.ae2craftingoptimizer.integration.PlanningExactInventorySnapshot;
 import java.math.BigInteger;
 import java.util.Objects;
 import org.jetbrains.annotations.Nullable;
@@ -78,7 +79,7 @@ final class Ae2ReferencedInventory {
             AEKey requestedOutput) {
         Objects.requireNonNull(grid, "grid");
         Objects.requireNonNull(source, "source");
-        KeyCounter cached = grid.getStorageService().getCachedInventory();
+        KeyCounter cached = PlanningExactInventorySnapshot.capture(grid);
         BigKeyCounterSidecars.Snapshot exact =
                 BigKeyCounterSidecars.snapshot(cached).orElse(null);
         // 再検証時も、計画が参照するキーだけはBigInteger正本で一致を確認する。

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExperimentalCompatibilityValidator.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExperimentalCompatibilityValidator.java
@@ -14,6 +14,7 @@ import com.syaru.ae2craftingoptimizer.access.CraftingTaskProgressAccess;
 import com.syaru.ae2craftingoptimizer.access.ExactBigIntegerInventoryHookAccess;
 import com.syaru.ae2craftingoptimizer.access.ExactCraftingInventoryAccess;
 import com.syaru.ae2craftingoptimizer.access.MekanismCachedRecipeAccess;
+import com.syaru.ae2craftingoptimizer.access.NetworkStorageMountsAccess;
 import com.syaru.ae2craftingoptimizer.access.PatternProviderTransactionAccess;
 import com.syaru.ae2craftingoptimizer.api.batch.v2.BatchSourceReceiptStore;
 import com.syaru.ae2craftingoptimizer.api.batch.v2.NativeBatchReceiptStore;
@@ -63,15 +64,11 @@ public final class ExperimentalCompatibilityValidator {
             require(failures, "appeng.crafting.inv.CraftingSimulationState",
                     CheckedCraftingArithmeticHookAccess.class);
         }
-        // BigInteger在庫は集計・複製・Sidecar破棄・Cache失効の四境界を一組として監査する。
+        // BigInteger在庫はPlanner専用mount列挙と一時KeyCounterのSidecar破棄だけを監査する。
         if (ACOConfig.enableExactBigIntegerInventorySnapshots()) {
             require(failures, "appeng.me.storage.NetworkStorage",
-                    ExactBigIntegerInventoryHookAccess.class);
-            require(failures, "appeng.crafting.inv.NetworkCraftingSimulationState",
-                    ExactBigIntegerInventoryHookAccess.class);
+                    NetworkStorageMountsAccess.class);
             require(failures, "appeng.api.stacks.KeyCounter",
-                    ExactBigIntegerInventoryHookAccess.class);
-            require(failures, "appeng.me.service.StorageService",
                     ExactBigIntegerInventoryHookAccess.class);
         }
         if ((ACOConfig.enableTransactionalBatchingV2()

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/PlanningExactInventorySnapshot.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/PlanningExactInventorySnapshot.java
@@ -1,0 +1,58 @@
+package com.syaru.ae2craftingoptimizer.integration;
+
+import appeng.api.networking.IGrid;
+import appeng.api.stacks.KeyCounter;
+import appeng.api.storage.MEStorage;
+import appeng.me.storage.NetworkStorage;
+import com.syaru.ae2craftingoptimizer.access.NetworkStorageMountsAccess;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * BigInteger Planner専用の在庫Snapshotを作る。
+ *
+ * <p>Issue #109の回帰では、正確量の取得をNetworkStorage#getAvailableStacksへ
+ * 常時注入したため、端末・バス・通常クラフトまでACOの集計処理を通っていた。
+ * このクラスは計算開始時だけmountを列挙し、通常AE2の在庫一覧には介入しない。</p>
+ */
+public final class PlanningExactInventorySnapshot {
+    private PlanningExactInventorySnapshot() {
+    }
+
+    /** AE2の現在のmount構成から、long互換値とBigInteger正本を一度だけ取得する。 */
+    public static KeyCounter capture(IGrid grid) {
+        Objects.requireNonNull(grid, "grid");
+        MEStorage networkInventory = grid.getStorageService().getInventory();
+        // 標準NetworkStorageなら各mountを個別に読み、BigIntegerセルの正本を失わない。
+        if (networkInventory instanceof NetworkStorage
+                && networkInventory instanceof NetworkStorageMountsAccess mounts) {
+            return captureMountedStorages(mounts.aco$getPriorityInventory().values());
+        }
+
+        KeyCounter result = new KeyCounter();
+        // UELM等の独自Network実装では、公開MEStorageを一回だけ安全に取得する。
+        BigIntegerStorageSnapshotBridge.collect(networkInventory, result, true);
+        return result;
+    }
+
+    /** mount単位の取得規則をMinecraft起動なしで検証するためのpackage-private入口。 */
+    static KeyCounter captureMountedStorages(
+            Iterable<? extends Iterable<MEStorage>> priorities) {
+        Objects.requireNonNull(priorities, "priorities");
+        KeyCounter result = new KeyCounter();
+        Set<MEStorage> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        // 優先度は合計量へ影響しないが、AE2と同じ順序で決定的に列挙する。
+        for (Iterable<MEStorage> priority : priorities) {
+            // 同一Storageが複数回mountされても在庫量を二重計上しない。
+            for (MEStorage mountedStorage : priority) {
+                if (!visited.add(mountedStorage)) {
+                    continue;
+                }
+                BigIntegerStorageSnapshotBridge.collect(mountedStorage, result, true);
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/ExtendedAePlusBigIntegerCellConsistencyMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/ExtendedAePlusBigIntegerCellConsistencyMixin.java
@@ -55,6 +55,12 @@ public abstract class ExtendedAePlusBigIntegerCellConsistencyMixin {
             Actionable mode,
             IActionSource source,
             CallbackInfoReturnable<Long> callback) {
+        Object2ObjectMap<AEKey, BigInteger> amounts =
+                getCellStoredMap();
+        // ACOが直接変更していないセルは、ExtendedAE Plus本来の搬入出だけへ完全に任せる。
+        if (ExactBigIntegerCellConsistency.expectedTotal(amounts).isEmpty()) {
+            return;
+        }
         refreshCachedStateFromStorage();
     }
 
@@ -86,6 +92,10 @@ public abstract class ExtendedAePlusBigIntegerCellConsistencyMixin {
         }
         Object2ObjectMap<AEKey, BigInteger> amounts =
                 getCellStoredMap();
+        // 通常経路しか使っていないセルへACOの台帳を新規作成しない。
+        if (ExactBigIntegerCellConsistency.expectedTotal(amounts).isEmpty()) {
+            return;
+        }
         ExactBigIntegerCellConsistency.record(
                 amounts,
                 totalAEKey2Amounts);

--- a/src/main/resources/ae2_crafting_optimizer.mixins.json
+++ b/src/main/resources/ae2_crafting_optimizer.mixins.json
@@ -57,9 +57,7 @@
     "MultiCraftingTrackerCraftRequestThrottleMixin",
     "NeoEco20_3CraftingCpuExecutionBudgetMixin",
     "NeoEco20_4CraftingCpuExecutionBudgetMixin",
-    "NetworkCraftingSimulationStateBigIntegerSnapshotMixin",
     "NetworkCraftingSimulationStateAccessor",
-    "NetworkStorageBigIntegerSnapshotMixin",
     "NetworkStorageMountsAccessor",
     "PatternProviderLogicIntentCaptureMixin",
     "PatternProviderLogicNativeBatchReceiptMixin",
@@ -69,7 +67,6 @@
     "ExtendedAePlusBigIntegerCellConsistencyMixin",
     "ExtendedAePlusInfinityDataStorageConsistencyMixin",
     "MekanismCachedRecipeAccessor",
-    "StorageServiceExactSnapshotInvalidationMixin",
     "P2PServiceTopologyDeduplicationMixin"
   ],
   "client": [

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/BigIntegerStorageSnapshotBridgeTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/BigIntegerStorageSnapshotBridgeTest.java
@@ -109,6 +109,24 @@ class BigIntegerStorageSnapshotBridgeTest {
     }
 
     @Test
+    void planningSnapshotKeepsExactAmountsWithoutChangingTheSharedNetworkPath() {
+        BigInteger exactAmount = BigInteger.TEN.pow(64);
+        FakePublicExactStorage exactStorage =
+                new FakePublicExactStorage(exactAmount, true);
+
+        KeyCounter planning = PlanningExactInventorySnapshot.captureMountedStorages(
+                List.of(
+                        List.of(exactStorage),
+                        List.of(exactStorage, new LongStorage(7L))));
+
+        assertEquals(Long.MAX_VALUE, planning.get(TEST_KEY));
+        BigKeyCounterSidecars.Snapshot exact =
+                BigKeyCounterSidecars.snapshot(planning).orElseThrow();
+        assertTrue(exact.complete());
+        assertEquals(exactAmount.add(BigInteger.valueOf(7L)), exact.amount(TEST_KEY));
+    }
+
+    @Test
     void rejectsAPublicProviderThatOmitsAnExposedFacadeKey() {
         KeyCounter network = new KeyCounter();
 

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/CriticalMixinContractSourceTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/CriticalMixinContractSourceTest.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
-/** BigInteger正本を支える必須Mixinが、将来の編集で静かに任意化されることを防ぐ。 */
+/** BigInteger正本を支える必須Mixinと通常AE2境界の分離を固定する。 */
 class CriticalMixinContractSourceTest {
     private static final Path PRODUCTION_ROOT = Path.of("src", "main", "java");
     private static final Path MIXIN_ROOT = PRODUCTION_ROOT.resolve(
@@ -35,13 +35,7 @@ class CriticalMixinContractSourceTest {
                 new Contract("CheckedCraftingArithmeticHookAccess", 1L),
                 "CraftingSimulationStateCheckedMathMixin.java",
                 new Contract("CheckedCraftingArithmeticHookAccess", 4L),
-                "NetworkCraftingSimulationStateBigIntegerSnapshotMixin.java",
-                new Contract("ExactBigIntegerInventoryHookAccess", 1L),
-                "NetworkStorageBigIntegerSnapshotMixin.java",
-                new Contract("ExactBigIntegerInventoryHookAccess", 6L),
                 "KeyCounterBigIntegerSidecarLifecycleMixin.java",
-                new Contract("ExactBigIntegerInventoryHookAccess", 1L),
-                "StorageServiceExactSnapshotInvalidationMixin.java",
                 new Contract("ExactBigIntegerInventoryHookAccess", 1L));
 
         contracts.forEach((fileName, contract) -> {
@@ -57,12 +51,26 @@ class CriticalMixinContractSourceTest {
     }
 
     @Test
+    void exactInventoryCaptureDoesNotHookTheSharedAe2InventoryPath() {
+        String mixinConfig = read(Path.of(
+                "src", "main", "resources", "ae2_crafting_optimizer.mixins.json"));
+        assertFalse(mixinConfig.contains("NetworkStorageBigIntegerSnapshotMixin"));
+        assertFalse(mixinConfig.contains("NetworkCraftingSimulationStateBigIntegerSnapshotMixin"));
+        assertFalse(mixinConfig.contains("StorageServiceExactSnapshotInvalidationMixin"));
+        assertTrue(read(PRODUCTION_ROOT.resolve(Path.of(
+                "com", "syaru", "ae2craftingoptimizer", "integration",
+                "PlanningExactInventorySnapshot.java")))
+                .contains("BigIntegerStorageSnapshotBridge.collect"));
+    }
+
+    @Test
     void compatibilityAuditCoversBothBigIntegerProfilesAndCriticalSurfaces() {
         String source = read(VALIDATOR);
         assertTrue(source.contains("enableBigCraftingProfile()"));
         assertTrue(source.contains("CraftingServiceCalculationHookAccess.class"));
         assertTrue(source.contains("CheckedCraftingArithmeticHookAccess.class"));
         assertTrue(source.contains("ExactBigIntegerInventoryHookAccess.class"));
+        assertTrue(source.contains("NetworkStorageMountsAccess.class"));
     }
 
     @Test


### PR DESCRIPTION
## 概要

Issue #109で残っていたBigInteger在庫取得の全Network介入を除去し、正確量Snapshotをクラフト計算内へ隔離します。

## 変更

- `NetworkStorage`、`StorageService`、`NetworkCraftingSimulationState`へのexact在庫常時Mixinを登録対象から除外
- `PlanningExactInventorySnapshot`を追加し、Authoritative Planner開始時だけmountを列挙
- `10^64`の正確量と`Long.MAX_VALUE`互換Facadeを分離したまま維持
- ExtendedAE Plus通常搬入出へのcache refreshを、ACO直接変更後の台帳があるセルだけに限定
- 起動時互換監査をPlanner専用Accessor構成へ更新
- Issue #109の回帰仕様書とクラス責務一覧を更新

## 不変条件

- 通常AE2の在庫一覧、端末serial、insert/extract、バス、watcherへACO Sidecarを流さない
- ACOはInsaneAEへBigInteger計画/APIだけを提供し、CPU実行へ介入しない
- テストセルの正確な`10^64`在庫を削除・縮小・longへ切り捨てない

## 検証

- `gradlew.bat clean build --no-daemon`: 成功
- JUnit: 378件、失敗0、エラー0、skip 2
- Minecraft起動試験: 実施していません

Closes #109

