### PR TITLE
fix: port standard AE2 BigInteger physical execution to Forge

### DIFF
--- a/docs/CLASS_RESPONSIBILITIES.md
+++ b/docs/CLASS_RESPONSIBILITIES.md
@@ -44,8 +44,9 @@ mixin + access  ->  integration  ->  optimization / scheduler
 | クラス | 行数 | 判断 |
 |---|---:|---|
 | `PhysicalCraftingTreeTransaction` | 3493 | 高。state machineと永続Codecが同居。Issue #87では数量Mapだけ分離し、Receipt/Codec分割は専用回帰試験を伴う別Issueにする。 |
-| `ACOConfig` | 1828 | 中。長大だがConfig IDと既定値の正本として凝集している。key互換を固定する試験なしに分割しない。 |
+| `ACOConfig` | 1834 | 中。長大だがConfig IDと既定値の正本として凝集している。key互換を固定する試験なしに分割しない。 |
 | `AqeBigCraftingExecutionManager` | 1631 | 高。外部CPU所有権と復旧境界。起動・再起動・取消試験を用意してから段階分割する。 |
+| `Ae2BigCraftingExecutionManager` | 499 | 高。標準AE2 exact Jobの物理所有権、Receipt、取消、復旧を一元管理する。Issue #115の境界試験なしに分割しない。 |
 | `CompiledRootProgram` | 1294 | 中。計算核として大きいが副作用は限定的。コンパイルと評価の分離候補。 |
 | `BigCraftingJob` | 1215 | 高。永続状態とWindow貸出を所有。NBT Codec分離はschema回帰試験と同時に行う。 |
 | `Ae2AuthoritativeCraftingPlanner` | 967 | 中。採用判定と計画生成の境界を維持し、fallback条件を別クラスへ散らさない。 |
@@ -103,6 +104,8 @@ mixin + access  ->  integration  ->  optimization / scheduler
 |---|---|
 | `com.syaru.ae2craftingoptimizer.access.AdvancedAeClusterExecutionAccess` | AdvancedAeClusterExecutionAccessが示す外部状態を型付きで公開するMixin用Access契約。判断や会計は持たない。 |
 | `com.syaru.ae2craftingoptimizer.access.AdvancedAeExactCraftingJobAccess` | Advanced AE実JobへBigInteger正本を設置・同期するためのversion-pinned契約。 |
+| `com.syaru.ae2craftingoptimizer.access.ExactCraftingJobAccess` | AE2系の実JobへBigInteger正本、Receipt Journal、正確カウンタを設置・同期する共通契約。 |
+| `com.syaru.ae2craftingoptimizer.access.ExactCraftingLogicAccess` | AE2系CraftingCpuLogicを本来の完了通知順序で閉じる共通契約。 |
 | `com.syaru.ae2craftingoptimizer.access.AdvancedAeExactCraftingLogicAccess` | Advanced AE標準の完了・取消通知経路へExact Jobを戻すための最小Invoker契約。 |
 | `com.syaru.ae2craftingoptimizer.access.BigCapacityPlanBoundaryAccess` | Big容量計画を受理または拒否する専用Mixinが対象CPUへ適用済みであることを示す。 |
 | `com.syaru.ae2craftingoptimizer.access.CheckedCraftingArithmeticHookAccess` | AE2クラフト計算のlong境界検査Mixinが適用済みであることを示す印。 |
@@ -377,6 +380,7 @@ mixin + access  ->  integration  ->  optimization / scheduler
 | `com.syaru.ae2craftingoptimizer.integration.AppliedECompatibility` | AppliedE本家とTPS Fix forkに共通する動的パターン境界を扱う。 |
 | `com.syaru.ae2craftingoptimizer.integration.AqeBigCraftingExecutionContext` | 標準容量判定へ、現在投入中のBig子Job一件分だけを一時的に貸し出すサーバースレッド文脈。 |
 | `com.syaru.ae2craftingoptimizer.integration.AqeBigCraftingExecutionManager` | Advanced AE CPU HostとACO exact計画を接続し、予約、実行、取消、復元を調停する外部境界。 |
+| `com.syaru.ae2craftingoptimizer.integration.Ae2BigCraftingExecutionManager` | 標準AE2クラスタが受理したexact Jobだけを既存PhysicalCraftingTreeTransactionへ接続するIssue #115の実行境界。 |
 | `com.syaru.ae2craftingoptimizer.integration.BigIntegerStorageSnapshotBridge` | Plannerが一つのmountを読む時だけ、AE2用long FacadeとBigInteger正本を分離する。通常NetworkStorageへは介入しない。 |
 | `com.syaru.ae2craftingoptimizer.integration.ExactBigIntegerCellConsistency` | ACOが直接更新したExtendedAE Plus在庫Mapと、同MODの保存用総量を結ぶ弱Sidecar。 |
 | `com.syaru.ae2craftingoptimizer.integration.ExactNetworkStorageBridge` | ME storageへのexact snapshot、reserve、insert、rollbackをAE2権限境界内で行う。 |
@@ -424,6 +428,8 @@ mixin + access  ->  integration  ->  optimization / scheduler
 |---|---|
 | `com.syaru.ae2craftingoptimizer.mixin.AcoMixinPlugin` | AcoMixinPluginが担当するMixin群の適用可否を、対象MODと対応版から決定する。 |
 | `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeBigCapacityPlanSubmissionMixin` | AdvancedAeBigCapacityPlanSubmissionMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
+| `com.syaru.ae2craftingoptimizer.mixin.Ae2BigCapacityPlanSubmissionMixin` | 標準AE2が受理したACO exact計画だけを一回分Facadeで実Job化し、正確Sidecarを設置する提出境界。 |
+| `com.syaru.ae2craftingoptimizer.mixin.Ae2ExactCraftingLogicMixin` | 標準AE2 exact Jobの保存、復元、取消、完了を物理Receipt Managerへ接続する薄いMixin境界。 |
 | `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingBlockEntityTransactionAccessMixin` | AdvancedAeCraftingBlockEntityTransactionAccessMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
 | `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingClusterBigWindowMixin` | AdvancedAeCraftingClusterBigWindowMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
 | `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingCpuAccessorMixin` | AdvancedAeCraftingCpuAccessorMixinの対象となる非公開状態を型付きAccessorとして公開するMixin。 |

--- a/docs/RELEASE_NOTES_1.5.23.md
+++ b/docs/RELEASE_NOTES_1.5.23.md
@@ -1,0 +1,19 @@
+# AE2 Crafting Optimizer 1.5.23
+
+## Forge 1.20.1 and NeoForge 1.21.1
+
+- Added exact BigInteger physical execution for jobs accepted by the standard AE2
+  `CraftingCPUCluster`.
+- Standard AE2 clusters now reuse ACO's quantity-independent
+  `PhysicalCraftingTreeTransaction` instead of requiring repeated `Long.MAX_VALUE`
+  execution windows.
+- Preserved AE2 ownership of CPU capacity checks, busy state, crafting links, job
+  creation, and normal long crafting.
+- Added exact task, waiting-output, final-output, receipt, cancellation, and NBT
+  recovery accounting to the same AE2 `ExecutingCraftingJob`.
+- Added regression guards that prevent this path from depending on Advanced AE or
+  InsaneAE implementation classes.
+
+This release does not add or modify CPU blocks, structures, recipes, models, or
+textures. The new path only activates for an ACO exact plan that the target AE2 CPU
+has already accepted.

--- a/docs/issues/ISSUE-109.md
+++ b/docs/issues/ISSUE-109.md
@@ -61,3 +61,9 @@ BigInteger APIの「利用可能」「consumer登録済み」「AE2標準経路�
 - 標準AE2 CPUの提出、使用中判定、容量判定はAE2本来の経路で決まる
 - AQE/InsaneAEは各MOD自身のCPU境界でexact planを受理する
 - ME端末の入庫、出庫、クラフト開始操作がACOなしの場合と一致する
+
+## Issue #115による限定追加
+
+Issue #115では、標準AE2クラスタが自身の容量・使用中・セキュリティ判定を通して既に受理した
+ACO exact計画に限り、同じAE2 JobへSidecarを設置してACO物理Receipt経路を使用する。
+外部consumer登録の有無では分岐せず、通常long計画、共有在庫一覧、端末、バスは変更しない。

--- a/docs/issues/ISSUE-115.md
+++ b/docs/issues/ISSUE-115.md
@@ -1,0 +1,119 @@
+# Issue #115: 標準AE2クラスタでBigInteger物理実行を所有する
+
+- GitHub Issue: https://github.com/syarukasu/ae2-crafting-optimizer/issues/115
+- 状態: Released
+- 対象版: ACO 1.5.22以降
+- 対象ローダー: Forge 1.20.1 / NeoForge 1.21.1
+- 関連Issue・PR: Issue #79、Issue #98、Issue #103、Issue #109
+
+## 問題
+
+ACOの`PhysicalCraftingTreeTransaction`は、正確なBigInteger回数を注文量に比例せず処理できます。
+しかし1.5.22では、この物理実行を所有する入口がAdvanced AEの
+`AdvCraftingCPUCluster`に限定されています。標準AE2の`CraftingCPUCluster`を使用するCPUは、
+ACOのexact計画を受理できても、アドオン側の`Long.MAX_VALUE`窓へ戻るため、回数に比例して
+処理時間が増えます。
+
+InsaneAEのQuantum CPUは標準AE2クラスタを使用する一例です。ACOはInsaneAE固有クラスへ
+依存せず、標準AE2クラスタが既に受理したexact計画を同じAE2 Job上で物理実行できる必要が
+あります。
+
+## 再現と証拠
+
+- 再現手順: 1024桁級のACO exact計画を、標準`CraftingCPUCluster`を使用するBigInteger CPUへ提出する
+- 境界値: `8^100`回を含む多段作業台クラフト
+- ログ・スタックトレース: 例外ではなく、long窓が順次減るため進捗が実用時間内に完了しない
+- 正常だった版: なし。Advanced AE専用の物理経路では注文量非依存で進む
+- 失敗する版: 1.5.22
+
+## 期待結果
+
+- 標準AE2クラスタが受理したACO exact計画だけ、同じ`ExecutingCraftingJob`へ正確Sidecarを設置する
+- Pattern、waitingFor、最終出力、物理ReceiptをBigIntegerで保存・復元する
+- 作業台の固有段数と実設備応答に比例して進み、注文回数には比例しない
+- CPU容量、使用中判定、CraftingLink、構造、GUIはAE2またはCPUアドオンが所有する
+- 取消時は物理TransactionがEscrowを返却してからAE2本来のJob終了通知を行う
+
+## 現在結果
+
+- ACO物理TransactionはAdvanced AEクラスタだけを列挙する
+- 標準AE2 Jobにはexact Sidecarが設置されない
+- InsaneAEなど標準クラスタ型CPUは、アドオン固有のlong窓実行へ戻る
+
+## 所有権
+
+- AE2が所有する状態: CPU構造、容量判定、使用中判定、CraftingLink、Job生成、通常long Job
+- ACOが所有する状態: ACO exact計画、BigInteger Sidecar、物理Transaction、Escrow、Receipt、復旧
+- 任意アドオンが所有する状態: 追加CPUブロック、正確容量の公開と判定、GUI、電力、独自Provider
+- fallback可能な境界: 物理Transactionが入力所有権を取得する前だけ待機または提出失敗へ戻せる
+
+## 維持する不変条件
+
+- 通常long計画はAE2の提出・初期抽出・実行をそのまま使う
+- 標準AE2クラスタの提出結果をACOから成功へ上書きしない
+- 一つのAE2 CPUは一つのJobだけを所有する
+- exact計画のTask、waitingFor、最終出力、Receipt Journalは常に一致する
+- 物理開始後は通常AE2 executorへfallbackしない
+- InsaneAE、AQE、AAC固有クラスを標準AE2アダプタから参照しない
+
+## やってはいけないこと
+
+- 外部consumer登録だけを理由に任意の標準CPUへwide計画を強制提出する
+- `Long.MAX_VALUE`窓の反復をACO物理実行として扱う
+- BigInteger正本をlongへ変換して容量・残数・完了を判定する
+- 実クラフトまたはReceiptなしで最終成果物を生成する
+- InsaneAEのQuantum CPU、Task Fusion、構造、GUI、モデル、レシピへ介入する
+- 物理入力取得後にAE2標準executorと同じTaskを二重実行する
+
+## 修正方針
+
+1. Advanced AE専用だったexact Job契約を、標準AE2 Jobも実装できる共通契約へ分離する。
+2. 標準`CraftingCPUCluster.submitJob`がACO exact計画を既に受理する場合だけ、AE2 Job生成へ
+   一回分Facadeを渡し、成功後に元計画の正確Sidecarを同じJobへ設置する。
+3. 標準`CraftingCpuLogic`の保存、復元、取消、完了へSidecarを接続する。
+4. 標準AE2クラスタ用Managerを追加し、既存`PhysicalCraftingTreeTransaction`をtickする。
+5. exact JobだけAE2標準Pattern配送を停止し、通常Jobは完全に素通しする。
+6. 物理Targetが存在しない間は入力へ触れず待機し、存在後に開始する。
+
+## 実装前チェック
+
+- [x] `docs/PROJECT_CHARTER.md`を読んだ
+- [x] `docs/REGRESSION_HISTORY.md`を読んだ
+- [x] 関連クラスと既存試験を読んだ
+- [x] 再現条件を試験へ変換した
+- [x] 所有権とfallback境界を確定した
+- [x] 禁止事項を明記した
+- [x] Forge/NeoForgeの適用範囲を確定した
+
+## 試験計画
+
+- 単体試験: exact Job会計、Facade生成、標準クラスタ登録、通常計画素通し
+- 境界試験: `Long.MAX_VALUE`以下、`Long.MAX_VALUE + 1`、`8^100`のTask回数
+- 故障・取消・復旧試験: 未開始取消、物理開始後取消、NBT保存復元、会計不一致隔離
+- ビルド: `gradlew clean test`、`gradlew clean build`
+- GameTestまたはユーザー側確認: 標準AE2クラスタ型CPU、20段作業台クラフト、再起動復旧
+
+## 実装結果
+
+- `ExactCraftingJobAccess`と`ExactCraftingLogicAccess`へ共通契約を分離した。
+- 標準AE2 JobへBigInteger Sidecarと正確なTask/waitingFor/remainingOutputを設置した。
+- 標準AE2提出が成功した時だけ一回分Facadeから同じ実Jobを初期化するMixinを追加した。
+- `Ae2BigCraftingExecutionManager`で既存物理Transaction、Grid予算、世代再検証、
+  Receipt照合、取消、隔離、NBT復旧を接続した。
+- 標準ManagerはAdvanced AEおよびInsaneAEの実装クラスを参照しない。
+
+## 検証結果
+
+- Forge 1.20.1 `gradlew test --no-daemon`: 383件中381件成功、2件skip、失敗0件
+- NeoForge 1.21.1 `gradlew test --no-daemon`: 395件成功、失敗0件
+- 両版 `gradlew clean build --no-daemon`: 成功
+- `git diff --check`: 問題なし
+- 生成JAR: `build/libs/aco1.5.23_1.20.1.jar` / `build/libs/aco1.5.23_1.21.1.jar`
+- 起動、GameTest、実環境試験: ユーザー指示により未実施
+
+## 完了
+
+- PR:
+- マージコミット:
+- 修正版: 1.5.23
+- リリース: https://github.com/syarukasu/ae2-crafting-optimizer/releases/tag/v1.5.23

--- a/docs/issues/ISSUE-115.md
+++ b/docs/issues/ISSUE-115.md
@@ -113,7 +113,7 @@ InsaneAEのQuantum CPUは標準AE2クラスタを使用する一例です。ACO�
 
 ## 完了
 
-- PR:
-- マージコミット:
+- PR: NeoForge #116 / Forge #117
+- マージコミット: NeoForge `18e8777e84e159eb1f37e861fb0defc0c8b28b7e` / ForgeはPR #117で生成
 - 修正版: 1.5.23
 - リリース: https://github.com/syarukasu/ae2-crafting-optimizer/releases/tag/v1.5.23

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -24,3 +24,4 @@
 - [Issue #102](ISSUE-102.md): 小規模クラフトの初回プローブによる配送遅延
 - [Issue #103](ISSUE-103.md): wide計画の実行裏付け不足をCPU容量不足と誤報する
 - [Issue #109](ISSUE-109.md): BigInteger API連携が通常AE2の責務境界を越える
+- [Issue #115](ISSUE-115.md): 標準AE2クラスタでBigInteger物理実行を所有する

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.22
+mod_version=1.5.23
 minecraft_version=1.20.1
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/access/AdvancedAeExactCraftingJobAccess.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/access/AdvancedAeExactCraftingJobAccess.java
@@ -1,38 +1,5 @@
 package com.syaru.ae2craftingoptimizer.access;
 
-import appeng.api.stacks.AEItemKey;
-import appeng.api.stacks.AEKey;
-import com.syaru.ae2craftingoptimizer.engine.BigIntegerCraftingPlan;
-import com.syaru.ae2craftingoptimizer.engine.ExactCraftingJobState;
-import java.math.BigInteger;
-import java.util.Map;
-import net.minecraft.nbt.CompoundTag;
-import org.jetbrains.annotations.Nullable;
-
 /** Advanced AE実JobへBigInteger正本を設置・同期するためのversion-pinned契約。 */
-public interface AdvancedAeExactCraftingJobAccess {
-    void aco$installExactState(BigIntegerCraftingPlan plan);
-
-    void aco$loadExactState(CompoundTag owner);
-
-    void aco$writeExactState(CompoundTag owner);
-
-    boolean aco$isExactJob();
-
-    @Nullable
-    ExactCraftingJobState aco$getExactState();
-
-    void aco$reconcileExactAccounting(
-            Map<AEItemKey, BigInteger> dispatchedTasks,
-            Map<AEKey, BigInteger> introducedOutputs,
-            Map<AEKey, BigInteger> creditedOutputs,
-            BigInteger remainingOutput);
-
-    Map<AEItemKey, BigInteger> aco$getExactRemainingTasks();
-
-    Map<AEKey, BigInteger> aco$getExactWaitingFor();
-
-    BigInteger aco$getExactRemainingOutput();
-
-    boolean aco$isExactAccountingBalanced();
+public interface AdvancedAeExactCraftingJobAccess extends ExactCraftingJobAccess {
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/access/AdvancedAeExactCraftingLogicAccess.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/access/AdvancedAeExactCraftingLogicAccess.java
@@ -1,6 +1,5 @@
 package com.syaru.ae2craftingoptimizer.access;
 
 /** Advanced AE標準の完了・取消通知経路へExact Jobを戻すための最小Invoker契約。 */
-public interface AdvancedAeExactCraftingLogicAccess {
-    void aco$finishExactJob(boolean successful);
+public interface AdvancedAeExactCraftingLogicAccess extends ExactCraftingLogicAccess {
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/access/ExactCraftingJobAccess.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/access/ExactCraftingJobAccess.java
@@ -1,0 +1,38 @@
+package com.syaru.ae2craftingoptimizer.access;
+
+import appeng.api.stacks.AEItemKey;
+import appeng.api.stacks.AEKey;
+import com.syaru.ae2craftingoptimizer.engine.BigIntegerCraftingPlan;
+import com.syaru.ae2craftingoptimizer.engine.ExactCraftingJobState;
+import java.math.BigInteger;
+import java.util.Map;
+import net.minecraft.nbt.CompoundTag;
+import org.jetbrains.annotations.Nullable;
+
+/** AE2系の実ExecutingCraftingJobへBigInteger正本を設置・同期する共通契約。 */
+public interface ExactCraftingJobAccess {
+    void aco$installExactState(BigIntegerCraftingPlan plan);
+
+    void aco$loadExactState(CompoundTag owner);
+
+    void aco$writeExactState(CompoundTag owner);
+
+    boolean aco$isExactJob();
+
+    @Nullable
+    ExactCraftingJobState aco$getExactState();
+
+    void aco$reconcileExactAccounting(
+            Map<AEItemKey, BigInteger> dispatchedTasks,
+            Map<AEKey, BigInteger> introducedOutputs,
+            Map<AEKey, BigInteger> creditedOutputs,
+            BigInteger remainingOutput);
+
+    Map<AEItemKey, BigInteger> aco$getExactRemainingTasks();
+
+    Map<AEKey, BigInteger> aco$getExactWaitingFor();
+
+    BigInteger aco$getExactRemainingOutput();
+
+    boolean aco$isExactAccountingBalanced();
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/access/ExactCraftingLogicAccess.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/access/ExactCraftingLogicAccess.java
@@ -1,0 +1,6 @@
+package com.syaru.ae2craftingoptimizer.access;
+
+/** AE2系CraftingCpuLogicを本来の完了通知順序で閉じる共通契約。 */
+public interface ExactCraftingLogicAccess {
+    void aco$finishExactJob(boolean successful);
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
@@ -848,7 +848,7 @@ public final class ACOConfig {
                 .define("enableAtomicBigCapacityPlans", true);
         ENABLE_BIG_INTEGER_GAMEPLAY_EXECUTION = builder
                 .comment(
-                        "Execute explicitly submitted BigInteger root jobs as bounded standard AE2 child jobs on an AQE Quantum Computer.",
+                        "Execute explicitly submitted BigInteger jobs through an integrated exact CPU path.",
                         "False until phase-9 live testing. Capacity display and ordinary long jobs continue to work while this is false.")
                 .define("enableBigIntegerGameplayExecution", true);
         BIG_INTEGER_MAXIMUM_BITS = builder
@@ -891,7 +891,8 @@ public final class ACOConfig {
                 .define("enabled", true);
         ENABLE_AQE_BIG_INTEGER_VECTOR_PARENTS = builder
                 .comment(
-                        "Try one Exact Vector parent transaction before creating checked-long child windows.",
+                        "Try one Exact Vector physical transaction before creating checked-long child windows.",
+                        "The saved key name is retained for compatibility, and now also gates standard AE2 exact CPU adapters.",
                         "After input ownership transfer, failure is recovered or quarantined and never falls back.")
                 .define("enableAqeBigIntegerParents", true);
         EXACT_VECTOR_MAXIMUM_PATTERN_NODES = builder
@@ -1769,6 +1770,11 @@ public final class ACOConfig {
     }
 
     public static boolean enableAqeBigIntegerVectorParents() {
+        return enableExactBigIntegerPhysicalExecution();
+    }
+
+    /** AQEと標準AE2クラスタで共有する、exact BigInteger物理実行の安全条件。 */
+    public static boolean enableExactBigIntegerPhysicalExecution() {
         return enableExactVectorCrafting()
                 && enableBigIntegerGameplayExecution()
                 && ENABLE_AQE_BIG_INTEGER_VECTOR_PARENTS.get();

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/ExactCraftingJobState.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/ExactCraftingJobState.java
@@ -11,7 +11,7 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 
 /**
- * Advanced AEの実ExecutingCraftingJobへ付随するBigInteger Sidecar。
+ * AE2系の実ExecutingCraftingJobへ付随するBigInteger Sidecar。
  *
  * <p>CPU容量だけでなく、Pattern task、waitingFor、remainingOutput、物理Receiptを同じJob NBTへ
  * 保存する。別の親Job台帳をクラフト完了の正本にはしない。</p>
@@ -237,7 +237,7 @@ public final class ExactCraftingJobState {
     }
 
     /**
-     * Advanced AE実Jobの現在値と永続Receipt Journalが完全一致するか確認する。
+     * AE2系実Jobの現在値と永続Receipt Journalが完全一致するか確認する。
      *
      * <p>TaskProgressとwaitingForが実行時会計の正本であり、Journal側の値で補正しない。</p>
      */
@@ -256,7 +256,7 @@ public final class ExactCraftingJobState {
                 || !checkedWaiting.equals(ledger.waitingFor())
                 || !checkedRemaining.equals(ledger.remainingOutput())) {
             throw new IllegalStateException(
-                    "Advanced AE exact runtime counters diverged from their receipt journal");
+                    "exact runtime counters diverged from their receipt journal");
         }
     }
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/Ae2BigCraftingExecutionManager.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/Ae2BigCraftingExecutionManager.java
@@ -1,0 +1,499 @@
+package com.syaru.ae2craftingoptimizer.integration;
+
+import appeng.api.crafting.IPatternDetails;
+import appeng.api.networking.IGrid;
+import appeng.api.networking.crafting.ICraftingProvider;
+import appeng.api.stacks.AEItemKey;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.GenericStack;
+import appeng.me.cluster.implementations.CraftingCPUCluster;
+import appeng.me.service.CraftingService;
+import com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer;
+import com.syaru.ae2craftingoptimizer.access.CraftingJobTransactionAccess;
+import com.syaru.ae2craftingoptimizer.access.CraftingLogicTransactionAccess;
+import com.syaru.ae2craftingoptimizer.access.ExactCraftingJobAccess;
+import com.syaru.ae2craftingoptimizer.access.ExactCraftingLogicAccess;
+import com.syaru.ae2craftingoptimizer.api.batch.ExactPatternFormula;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.ProviderOwnedPatternBatchTarget;
+import com.syaru.ae2craftingoptimizer.api.craftingtable.CraftingTableBatchTarget;
+import com.syaru.ae2craftingoptimizer.api.vector.ExactVectorDiagnostics;
+import com.syaru.ae2craftingoptimizer.api.vector.PreparedVectorBatch;
+import com.syaru.ae2craftingoptimizer.config.ACOConfig;
+import com.syaru.ae2craftingoptimizer.engine.Ae2BigCraftingPlanFactory;
+import com.syaru.ae2craftingoptimizer.engine.Ae2CompiledCraftingGraphCache;
+import com.syaru.ae2craftingoptimizer.engine.CompiledRootProgram;
+import com.syaru.ae2craftingoptimizer.engine.ExactCraftingJobLedger;
+import com.syaru.ae2craftingoptimizer.engine.ExactCraftingJobState;
+import com.syaru.ae2craftingoptimizer.engine.PlanningRuntimeEpoch;
+import com.syaru.ae2craftingoptimizer.engine.RecipeGenerationTracker;
+import com.syaru.ae2craftingoptimizer.engine.craftingtable.PhysicalCraftingTreeTransaction;
+import com.syaru.ae2craftingoptimizer.engine.vector.VectorBatchPlanValidator;
+import com.syaru.ae2craftingoptimizer.engine.vector.VectorBatchPlanner;
+import com.syaru.ae2craftingoptimizer.optimization.ProviderPatternGenerationTracker;
+import com.syaru.ae2craftingoptimizer.scheduler.PatternProviderRoutingCache;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+/**
+ * Issue #115: 標準AE2 CraftingCPUCluster上のexact Jobを物理Receipt経路で進める。
+ *
+ * <p>CPU構造、容量判定、Job生成、CraftingLinkはAE2またはCPUアドオンが所有する。
+ * このManagerはACO Sidecarを持つJobだけを列挙し、InsaneAEなどの固有クラスを参照しない。</p>
+ */
+public final class Ae2BigCraftingExecutionManager {
+    private static final Map<CraftingCPUCluster, Controller> CONTROLLERS =
+            new IdentityHashMap<>();
+    private static int roundRobinCursor;
+
+    private Ae2BigCraftingExecutionManager() {
+    }
+
+    /** exact Sidecarを設置または復元した標準AE2クラスタだけを追跡する。 */
+    public static synchronized void register(CraftingCPUCluster cluster) {
+        if (cluster == null) {
+            return;
+        }
+        CONTROLLERS.computeIfAbsent(cluster, Controller::new);
+    }
+
+    /** 入力所有権を持たないJobを閉じた時だけ、追跡を即時解除する。 */
+    public static synchronized void unregister(CraftingCPUCluster cluster) {
+        Controller removed = CONTROLLERS.remove(cluster);
+        if (removed != null) {
+            removed.close();
+        }
+    }
+
+    /** Server tick末尾で、同一Gridの共有予算を守りながら各exact Jobを一巡する。 */
+    public static synchronized void tick(MinecraftServer server) {
+        if (CONTROLLERS.isEmpty()) {
+            return;
+        }
+        List<Controller> ordered = new ArrayList<>(CONTROLLERS.values());
+        ordered.removeIf(controller -> !controller.belongsTo(server));
+        ordered.sort(Comparator.comparing(Controller::stableKey));
+        if (ordered.isEmpty()) {
+            CONTROLLERS.entrySet().removeIf(entry -> !entry.getValue().belongsTo(server));
+            roundRobinCursor = 0;
+            return;
+        }
+        int start = Math.floorMod(roundRobinCursor, ordered.size());
+        // 保存Cursorから全Controllerを一巡し、一つの巨大Jobが常に先頭で予算を取らないようにする。
+        for (int offset = 0; offset < ordered.size(); offset++) {
+            Controller controller = ordered.get(Math.floorMod(start + offset, ordered.size()));
+            boolean alive;
+            try {
+                alive = controller.tick();
+            } catch (RuntimeException | LinkageError failure) {
+                controller.quarantine("standard AE2 exact executor failed", failure);
+                alive = true;
+            }
+            if (!alive) {
+                CONTROLLERS.remove(controller.cluster);
+                controller.close();
+            }
+        }
+        CONTROLLERS.entrySet().removeIf(entry -> !entry.getValue().belongsTo(server));
+        roundRobinCursor = Math.floorMod(start + 1, Math.max(1, ordered.size()));
+    }
+
+    /** Server停止時にRuntime cacheだけを破棄する。永続正本はJob NBTに残る。 */
+    public static synchronized void clear() {
+        // 全ControllerのRuntime transaction参照を破棄し、次回はJob NBTから復元する。
+        for (Controller controller : CONTROLLERS.values()) {
+            controller.close();
+        }
+        CONTROLLERS.clear();
+        roundRobinCursor = 0;
+    }
+
+    private static final class Controller {
+        private final CraftingCPUCluster cluster;
+        private final ProgramFingerprintRevalidationCache revalidatedPrograms =
+                new ProgramFingerprintRevalidationCache();
+        private PhysicalCraftingTreeTransaction transaction;
+        private UUID transactionJobId;
+        private ExactCraftingJobAccess lastExactJob;
+
+        private Controller(CraftingCPUCluster cluster) {
+            this.cluster = cluster;
+        }
+
+        private boolean belongsTo(MinecraftServer server) {
+            return !cluster.isDestroyed()
+                    && cluster.getLevel() != null
+                    && cluster.getLevel().getServer() == server;
+        }
+
+        private String stableKey() {
+            return cluster.getLevel().dimension().location()
+                    + ":"
+                    + cluster.getBoundsMin().asLong();
+        }
+
+        /** @return 同じクラスタを次tickも追跡する場合true。 */
+        private boolean tick() {
+            Context context = context();
+            if (context == null) {
+                transaction = null;
+                transactionJobId = null;
+                lastExactJob = null;
+                return false;
+            }
+            lastExactJob = context.exactJob();
+            ExactCraftingJobState state = context.state();
+            if (state.quarantined()) {
+                return true;
+            }
+            IGrid grid = cluster.getGrid();
+            if (grid == null || !cluster.isActive()) {
+                return true;
+            }
+            var graphSnapshot = Ae2CompiledCraftingGraphCache.getOrCompile(
+                    grid,
+                    cluster.getLevel());
+            try {
+                restoreOrStart(context, grid, graphSnapshot);
+            } catch (PhysicalCraftingTreeTransaction.PatternUnavailableException deferred) {
+                return true;
+            } catch (RuntimeException | LinkageError failure) {
+                if (!state.hasPhysicalExecution()) {
+                    AE2CraftingOptimizer.LOGGER.error(
+                            "Cancelled standard AE2 exact job {} before physical ownership because its plan could not be rebuilt",
+                            context.jobId(),
+                            failure);
+                    finish(context, false);
+                    return false;
+                }
+                quarantine("failed to restore standard AE2 exact physical execution", failure);
+                return true;
+            }
+            // WorkerやConfig待ちではまだ物理所有権がないため、同じJobをそのまま維持する。
+            if (transaction == null) {
+                return true;
+            }
+            if (state.cancellationRequested()) {
+                transaction.requestCancellation();
+            }
+            int operationBudget = ExactVectorGridTickBudget.claimActiveStages(
+                    grid,
+                    Math.max(1, transaction.plan().craftingSteps().size()));
+            if (operationBudget == 0) {
+                return true;
+            }
+            long startedNanos = System.nanoTime();
+            PhysicalCraftingTreeTransaction.TickOutcome outcome;
+            try {
+                outcome = transaction.tick(
+                        grid,
+                        cluster.getLevel(),
+                        cluster.getSrc(),
+                        graphSnapshot,
+                        operationBudget);
+            } finally {
+                ExactVectorGridTickBudget.settleActiveStageClaim(
+                        grid,
+                        operationBudget,
+                        transaction.lastConsumedOperations());
+            }
+            ExactVectorDiagnostics.activeTick(System.nanoTime() - startedNanos);
+            /*
+             * Forge 1.20.1のTransactionにはrevision診断がないため、実行tickごとに
+             * Receipt会計と復旧NBTを同期する。Issue #115のexact Jobだけがこの経路へ入る。
+             */
+            reconcile(context, graphSnapshot);
+            state.updatePhysicalExecution(transaction.save());
+            cluster.markDirty();
+            if (outcome.kind() == PhysicalCraftingTreeTransaction.Kind.COMPLETE) {
+                if (!context.exactJob().aco$isExactAccountingBalanced()) {
+                    quarantine("standard AE2 exact job completed with unbalanced counters", null);
+                    return true;
+                }
+                ExactVectorDiagnostics.transactionCompleted();
+                finish(context, true);
+                return false;
+            }
+            if (outcome.kind() == PhysicalCraftingTreeTransaction.Kind.CANCELLED) {
+                ExactVectorDiagnostics.transactionCancelled();
+                finish(context, false);
+                return false;
+            }
+            if (outcome.kind() == PhysicalCraftingTreeTransaction.Kind.QUARANTINED) {
+                quarantine(outcome.detail(), null);
+            }
+            return true;
+        }
+
+        private Context context() {
+            Object job = ((CraftingLogicTransactionAccess) (Object) cluster.craftingLogic)
+                    .aco$getExecutingJob();
+            if (!(job instanceof ExactCraftingJobAccess exactJob)
+                    || !exactJob.aco$isExactJob()
+                    || !(job instanceof CraftingJobTransactionAccess transactionAccess)) {
+                return null;
+            }
+            ExactCraftingJobState state = exactJob.aco$getExactState();
+            if (state == null) {
+                throw new IllegalStateException("standard AE2 exact job lost its sidecar state");
+            }
+            return new Context(
+                    transactionAccess.aco$getCraftingJobId(),
+                    exactJob,
+                    state);
+        }
+
+        private void restoreOrStart(
+                Context context,
+                IGrid grid,
+                Ae2CompiledCraftingGraphCache.Snapshot graphSnapshot) {
+            if (transaction != null && !context.jobId().equals(transactionJobId)) {
+                throw new IllegalStateException("physical transaction belongs to another AE2 job");
+            }
+            if (transaction == null && context.state().hasPhysicalExecution()) {
+                transaction = PhysicalCraftingTreeTransaction.load(
+                        context.state().physicalExecution());
+                if (!transaction.plan().parentJobId().equals(context.jobId())) {
+                    throw new IllegalArgumentException(
+                            "exact physical execution belongs to another AE2 job");
+                }
+                transactionJobId = context.jobId();
+            }
+            if (transaction != null) {
+                return;
+            }
+            /* Issue #115: 新規開始が無効でも、開始済みTransactionの復元・取消は上で継続する。 */
+            if (!ACOConfig.enableExactBigIntegerPhysicalExecution()) {
+                return;
+            }
+            // 入力所有権取得前の世代不一致だけは、同じAE2 Jobを通常取消経路で閉じられる。
+            if (isStale(context.state(), graphSnapshot)) {
+                finish(context, false);
+                return;
+            }
+            PreparedVectorBatch plan = prepare(context.jobId(), context.state(), graphSnapshot);
+            if (!supportsPhysicalPlan(grid, graphSnapshot, plan)) {
+                return;
+            }
+            ExactVectorGridTickBudget startBudget = ExactVectorGridTickBudget.forGrid(grid);
+            if (!startBudget.tryStart()) {
+                ExactVectorDiagnostics.startBudgetDeferred();
+                return;
+            }
+            PhysicalCraftingTreeTransaction created = PhysicalCraftingTreeTransaction.create(
+                    plan,
+                    PhysicalCraftingTreeTransaction.capturePatternAccounting(
+                            plan,
+                            graphSnapshot,
+                            cluster.getLevel()));
+            validate(context, created.accountingSnapshot(graphSnapshot, cluster.getLevel()));
+            context.state().beginPhysicalExecution(created.save());
+            transaction = created;
+            transactionJobId = context.jobId();
+            cluster.markDirty();
+            ExactVectorDiagnostics.planPrepared();
+            ExactVectorDiagnostics.transactionStarted(
+                    com.syaru.ae2craftingoptimizer.api.vector.VectorResourceMode.NETWORK_STORAGE);
+        }
+
+        private PreparedVectorBatch prepare(
+                UUID jobId,
+                ExactCraftingJobState state,
+                Ae2CompiledCraftingGraphCache.Snapshot graphSnapshot) {
+            long patternGeneration = ProviderPatternGenerationTracker.generation();
+            long recipeGeneration = RecipeGenerationTracker.generation();
+            CompiledRootProgram<AEKey> program = graphSnapshot.rootProgram(state.requestedKey())
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "standard AE2 exact CPU root program is unavailable"));
+            if (!state.programFingerprint().equals(
+                    Ae2BigCraftingPlanFactory.programFingerprint(program))) {
+                throw new IllegalArgumentException("standard AE2 exact CPU fingerprint changed");
+            }
+            int maximumBits = ACOConfig.getBigIntegerMaximumBits();
+            CompiledRootProgram.BigInventorySnapshot<AEKey> inventory =
+                    program.captureBigInventory(
+                            key -> state.plannedInventory().getOrDefault(key, BigInteger.ZERO),
+                            maximumBits);
+            PreparedVectorBatch plan = VectorBatchPlanner.prepare(
+                    UUID.randomUUID(),
+                    jobId,
+                    program,
+                    inventory,
+                    state.requestedAmount(),
+                    state.programFingerprint(),
+                    patternGeneration,
+                    recipeGeneration,
+                    maximumBits);
+            VectorBatchPlanValidator.validate(
+                    plan,
+                    maximumBits,
+                    ACOConfig.getExactVectorMaximumPatternNodes(),
+                    ACOConfig.getExactVectorMaximumInputKeys(),
+                    ACOConfig.getExactVectorMaximumOutputKeys());
+            if (ProviderPatternGenerationTracker.generation() != patternGeneration
+                    || RecipeGenerationTracker.generation() != recipeGeneration) {
+                throw new IllegalStateException(
+                        "standard AE2 exact graph changed while preparing its physical plan");
+            }
+            return plan;
+        }
+
+        private boolean supportsPhysicalPlan(
+                IGrid grid,
+                Ae2CompiledCraftingGraphCache.Snapshot snapshot,
+                PreparedVectorBatch plan) {
+            if (!(grid.getCraftingService() instanceof CraftingService service)) {
+                return false;
+            }
+            // 全固有Patternについて、決定的作業台式と永続物理Targetを開始前に証明する。
+            for (var step : plan.craftingSteps()) {
+                IPatternDetails pattern = snapshot.pattern(step.patternId());
+                if (pattern == null
+                        || ExactPatternFormula.tryCreate(
+                                        pattern,
+                                        cluster.getLevel(),
+                                        step.selectedInputs())
+                                .isEmpty()) {
+                    return false;
+                }
+                boolean found = false;
+                // このPatternを所有するProvider候補だけを一巡する。
+                for (ICraftingProvider provider : PatternProviderRoutingCache.candidates(
+                        service,
+                        pattern)) {
+                    if (!(provider instanceof ProviderOwnedPatternBatchTarget owned)) {
+                        continue;
+                    }
+                    BlockEntity target = owned.aco$getProviderOwnedBatchTarget();
+                    if (target instanceof CraftingTableBatchTarget) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private void validate(
+                Context context,
+                PhysicalCraftingTreeTransaction.AccountingSnapshot accounting) {
+            if (!accounting.plannedPatternDefinitions().equals(context.state().taskTotals())
+                    || !context.state().initialWaiting().isEmpty()) {
+                throw new IllegalArgumentException(
+                        "physical plan does not match standard AE2 exact-job accounting");
+            }
+        }
+
+        private void reconcile(
+                Context context,
+                Ae2CompiledCraftingGraphCache.Snapshot graphSnapshot) {
+            PhysicalCraftingTreeTransaction.AccountingSnapshot accounting =
+                    transaction.accountingSnapshot(graphSnapshot, cluster.getLevel());
+            validate(context, accounting);
+            BigInteger remainingOutput = accounting.finalOutputReturned()
+                    ? BigInteger.ZERO
+                    : context.state().requestedAmount();
+            context.exactJob().aco$reconcileExactAccounting(
+                    accounting.dispatchedPatternDefinitions(),
+                    accounting.introducedOutputs(),
+                    accounting.creditedOutputs(),
+                    remainingOutput);
+            BigInteger exactRemaining = context.exactJob().aco$getExactRemainingOutput();
+            cluster.updateOutput(exactRemaining.signum() == 0
+                    ? null
+                    : new GenericStack(
+                            context.state().requestedKey(),
+                            ExactCraftingJobLedger.saturatedLong(exactRemaining)));
+        }
+
+        private boolean isStale(
+                ExactCraftingJobState state,
+                Ae2CompiledCraftingGraphCache.Snapshot graphSnapshot) {
+            long patternGeneration = ProviderPatternGenerationTracker.generation();
+            long recipeGeneration = RecipeGenerationTracker.generation();
+            if (PlanningRuntimeEpoch.current().equals(state.planningEpoch())
+                    && state.patternGeneration() == patternGeneration
+                    && state.recipeGeneration() == recipeGeneration) {
+                return false;
+            }
+            if (revalidatedPrograms.contains(
+                    patternGeneration,
+                    recipeGeneration,
+                    state.programFingerprint())) {
+                return false;
+            }
+            CompiledRootProgram<AEKey> current = graphSnapshot.rootProgram(state.requestedKey())
+                    .orElse(null);
+            boolean matches = current != null
+                    && state.programFingerprint().equals(
+                            Ae2BigCraftingPlanFactory.programFingerprint(current));
+            if (matches) {
+                revalidatedPrograms.record(
+                        patternGeneration,
+                        recipeGeneration,
+                        state.programFingerprint());
+                ExactVectorDiagnostics.fingerprintRevalidated();
+            }
+            return !matches;
+        }
+
+        private void finish(Context context, boolean successful) {
+            ((ExactCraftingLogicAccess) (Object) cluster.craftingLogic)
+                    .aco$finishExactJob(successful);
+            cluster.updateOutput(null);
+            transaction = null;
+            transactionJobId = null;
+            lastExactJob = null;
+            cluster.markDirty();
+        }
+
+        private void quarantine(String detail, Throwable failure) {
+            String checked = detail == null || detail.isBlank()
+                    ? "unknown standard AE2 exact-job failure"
+                    : detail;
+            if (transaction != null) {
+                transaction.quarantineForAccounting(checked);
+            }
+            if (lastExactJob != null && lastExactJob.aco$getExactState() != null) {
+                ExactCraftingJobState state = lastExactJob.aco$getExactState();
+                if (transaction != null && state.hasPhysicalExecution()) {
+                    state.updatePhysicalExecution(transaction.save());
+                }
+                state.quarantine();
+                cluster.markDirty();
+            }
+            ExactVectorDiagnostics.transactionQuarantined();
+            if (failure == null) {
+                AE2CraftingOptimizer.LOGGER.error(
+                        "Quarantined standard AE2 exact job: {}",
+                        checked);
+            } else {
+                AE2CraftingOptimizer.LOGGER.error(
+                        "Quarantined standard AE2 exact job: {}",
+                        checked,
+                        failure);
+            }
+        }
+
+        private void close() {
+            transaction = null;
+            transactionJobId = null;
+            lastExactJob = null;
+        }
+    }
+
+    private record Context(
+            UUID jobId,
+            ExactCraftingJobAccess exactJob,
+            ExactCraftingJobState state) {
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOServerLifecycle.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOServerLifecycle.java
@@ -9,6 +9,7 @@ import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingShadowValidator;
 import com.syaru.ae2craftingoptimizer.engine.RecipeGenerationTracker;
 import com.syaru.ae2craftingoptimizer.gtceu.GTCEuRecipeIntentFastPath;
 import com.syaru.ae2craftingoptimizer.integration.ExperimentalCompatibilityValidator;
+import com.syaru.ae2craftingoptimizer.integration.Ae2BigCraftingExecutionManager;
 import com.syaru.ae2craftingoptimizer.integration.ExactNetworkStorageSnapshotCache;
 import com.syaru.ae2craftingoptimizer.integration.OptionalAqeBigCraftingExecution;
 import com.syaru.ae2craftingoptimizer.integration.OptionalNativeBatchIntegrations;
@@ -79,6 +80,7 @@ public final class ACOServerLifecycle {
         long gameTime = event.getServer().overworld().getGameTime();
         RecipeIntentRegistry.cleanupExpired(gameTime);
         BatchTransactionRecovery.tick(event.getServer(), gameTime);
+        Ae2BigCraftingExecutionManager.tick(event.getServer());
         OptionalAqeBigCraftingExecution.tick(event.getServer());
     }
 
@@ -116,6 +118,7 @@ public final class ACOServerLifecycle {
         OptimizationMetrics.reset();
         Ae2CraftingShadowValidator.resetDiagnostics();
         BigCraftingStatusInbox.clear();
+        Ae2BigCraftingExecutionManager.clear();
         OptionalAqeBigCraftingExecution.clear();
         /*
          * AQE側の未送信窓を先に戻してからRegistryを破棄する。

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/Ae2BigCapacityPlanSubmissionMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/Ae2BigCapacityPlanSubmissionMixin.java
@@ -1,0 +1,191 @@
+package com.syaru.ae2craftingoptimizer.mixin;
+
+import appeng.api.networking.IGrid;
+import appeng.api.networking.crafting.ICraftingPlan;
+import appeng.api.networking.crafting.ICraftingRequester;
+import appeng.api.networking.crafting.ICraftingSubmitResult;
+import appeng.api.networking.security.IActionSource;
+import appeng.api.stacks.KeyCounter;
+import appeng.crafting.CraftingPlan;
+import appeng.crafting.execution.CraftingCpuLogic;
+import appeng.crafting.execution.CraftingSubmitResult;
+import appeng.me.cluster.implementations.CraftingCPUCluster;
+import com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer;
+import com.syaru.ae2craftingoptimizer.access.CraftingLogicTransactionAccess;
+import com.syaru.ae2craftingoptimizer.access.ExactCraftingJobAccess;
+import com.syaru.ae2craftingoptimizer.config.ACOConfig;
+import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
+import com.syaru.ae2craftingoptimizer.engine.BigIntegerCraftingPlan;
+import com.syaru.ae2craftingoptimizer.engine.ExactPlanPatternRevalidator;
+import com.syaru.ae2craftingoptimizer.integration.Ae2BigCraftingExecutionManager;
+import com.syaru.ae2craftingoptimizer.optimization.BigIntegerPlanDeclineReason;
+import com.syaru.ae2craftingoptimizer.optimization.BigIntegerPlanDiagnostics;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/** Issue #115: 標準AE2クラスタが受理したexact計画を同じAE2 Jobへ昇格する。 */
+@Mixin(value = CraftingCPUCluster.class, remap = false)
+public abstract class Ae2BigCapacityPlanSubmissionMixin {
+    @Shadow
+    @Final
+    public CraftingCpuLogic craftingLogic;
+
+    @Shadow
+    public abstract void cancelJob();
+
+    @Shadow
+    public abstract void markDirty();
+
+    /** 同じサーバースレッド上の一回のsubmitだけへ元exact計画を渡す。 */
+    @Unique
+    private static final ThreadLocal<SubmissionAttempt> ACO_SUBMISSION = new ThreadLocal<>();
+
+    @Inject(method = "submitJob", at = @At("HEAD"), cancellable = true, require = 1)
+    private void aco$validateExactPlan(
+            IGrid grid,
+            ICraftingPlan plan,
+            IActionSource source,
+            ICraftingRequester requester,
+            CallbackInfoReturnable<ICraftingSubmitResult> cir) {
+        ACO_SUBMISSION.remove();
+        BigIntegerCraftingPlan exact = Ae2CraftingPlanSidecars.bigInteger(plan).orElse(null);
+        // 通常long計画と合計容量だけwideな計画は、AE2本来の提出経路へ完全に委譲する。
+        if (exact == null) {
+            return;
+        }
+        // 自動要求のExact最終出力転送は未対応なので、手動注文だけを対象にする。
+        if (requester != null
+                || !ACOConfig.enableBigIntegerGameplayExecution()
+                || exact.simulation()) {
+            cir.setReturnValue(CraftingSubmitResult.INCOMPLETE_PLAN);
+            return;
+        }
+        ExactPlanPatternRevalidator.Result validation = exact.validateForSubmission(grid);
+        // Issue #90: 参照Patternが変わった計画だけを入力所有権移転前に拒否する。
+        if (!validation.valid()) {
+            BigIntegerPlanDiagnostics.record(
+                    BigIntegerPlanDeclineReason.GENERATION_CHANGED,
+                    exact.finalOutput().what().getId().toString(),
+                    exact.exactPlan().requestedAmount(),
+                    exact.patternGeneration(),
+                    exact.recipeGeneration(),
+                    validation.detail());
+            cir.setReturnValue(CraftingSubmitResult.INCOMPLETE_PLAN);
+            return;
+        }
+        // 同じ確認画面から二重送信されたPlanは、一つの実Jobへだけ結び付ける。
+        if (!exact.claimSubmission()) {
+            cir.setReturnValue(CraftingSubmitResult.CPU_BUSY);
+            return;
+        }
+        ACO_SUBMISSION.set(new SubmissionAttempt(this, plan, exact));
+    }
+
+    /**
+     * CPU使用中判定とCraftingLink生成は標準AE2へ任せ、Job初期化時だけ一回分Facadeを渡す。
+     */
+    @Redirect(
+            method = "submitJob",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lappeng/crafting/execution/CraftingCpuLogic;trySubmitJob(Lappeng/api/networking/IGrid;Lappeng/api/networking/crafting/ICraftingPlan;Lappeng/api/networking/security/IActionSource;Lappeng/api/networking/crafting/ICraftingRequester;)Lappeng/api/networking/crafting/ICraftingSubmitResult;"),
+            require = 1)
+    private ICraftingSubmitResult aco$submitExactJobFacade(
+            CraftingCpuLogic logic,
+            IGrid grid,
+            ICraftingPlan plan,
+            IActionSource source,
+            ICraftingRequester requester) {
+        SubmissionAttempt attempt = ACO_SUBMISSION.get();
+        if (attempt == null
+                || attempt.cluster() != this
+                || attempt.originalPlan() != plan) {
+            return logic.trySubmitJob(grid, plan, source, requester);
+        }
+        try {
+            return logic.trySubmitJob(
+                    grid,
+                    aco$singleExecutionFacade(attempt.exactPlan()),
+                    source,
+                    requester);
+        } catch (RuntimeException | LinkageError failure) {
+            ACO_SUBMISSION.remove();
+            attempt.exactPlan().releaseSubmissionClaim();
+            throw failure;
+        }
+    }
+
+    @Inject(method = "submitJob", at = @At("RETURN"), cancellable = true, require = 1)
+    private void aco$installExactJob(
+            IGrid grid,
+            ICraftingPlan plan,
+            IActionSource source,
+            ICraftingRequester requester,
+            CallbackInfoReturnable<ICraftingSubmitResult> cir) {
+        BigIntegerCraftingPlan exact = Ae2CraftingPlanSidecars.bigInteger(plan).orElse(null);
+        if (exact == null) {
+            return;
+        }
+        SubmissionAttempt attempt = ACO_SUBMISSION.get();
+        ACO_SUBMISSION.remove();
+        // AE2が容量・使用中・安全性で拒否した場合は、ACOから成功へ上書きしない。
+        if (attempt == null
+                || attempt.cluster() != this
+                || cir.getReturnValue() == null
+                || !cir.getReturnValue().successful()) {
+            if (attempt != null && attempt.exactPlan() == exact) {
+                exact.releaseSubmissionClaim();
+            }
+            return;
+        }
+        try {
+            Object job = ((CraftingLogicTransactionAccess) (Object) craftingLogic)
+                    .aco$getExecutingJob();
+            if (!(job instanceof ExactCraftingJobAccess exactJob)) {
+                throw new IllegalStateException("AE2 exact-job access mixin is missing");
+            }
+            exactJob.aco$installExactState(exact);
+            Ae2BigCraftingExecutionManager.register((CraftingCPUCluster) (Object) this);
+            markDirty();
+        } catch (RuntimeException | LinkageError failure) {
+            cancelJob();
+            exact.releaseSubmissionClaim();
+            AE2CraftingOptimizer.LOGGER.error(
+                    "ACO cancelled an AE2 exact CPU because exact job accounting could not be installed",
+                    failure);
+            cir.setReturnValue(CraftingSubmitResult.INCOMPLETE_PLAN);
+        }
+    }
+
+    @Unique
+    private static CraftingPlan aco$singleExecutionFacade(BigIntegerCraftingPlan plan) {
+        Map<appeng.api.crafting.IPatternDetails, Long> oneExecution = new LinkedHashMap<>();
+        // 固有Patternを一件ずつ登録し、AE2のJob構造だけを数量非依存で初期化する。
+        for (var pattern : plan.exactPatternTimes().keySet()) {
+            oneExecution.put(pattern, 1L);
+        }
+        return new CraftingPlan(
+                plan.finalOutput(),
+                Long.MAX_VALUE,
+                false,
+                false,
+                new KeyCounter(),
+                new KeyCounter(),
+                new KeyCounter(),
+                Map.copyOf(oneExecution));
+    }
+
+    private record SubmissionAttempt(
+            Object cluster,
+            ICraftingPlan originalPlan,
+            BigIntegerCraftingPlan exactPlan) {
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/Ae2ExactCraftingLogicMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/Ae2ExactCraftingLogicMixin.java
@@ -1,0 +1,111 @@
+package com.syaru.ae2craftingoptimizer.mixin;
+
+import appeng.api.config.Actionable;
+import appeng.api.networking.energy.IEnergyService;
+import appeng.api.stacks.AEKey;
+import appeng.crafting.execution.CraftingCpuLogic;
+import appeng.crafting.execution.ExecutingCraftingJob;
+import appeng.me.cluster.implementations.CraftingCPUCluster;
+import appeng.me.service.CraftingService;
+import com.syaru.ae2craftingoptimizer.access.ExactCraftingJobAccess;
+import com.syaru.ae2craftingoptimizer.access.ExactCraftingLogicAccess;
+import com.syaru.ae2craftingoptimizer.integration.Ae2BigCraftingExecutionManager;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+/** Issue #115: 標準AE2 exact Jobを保存・取消・物理実行境界へ接続する。 */
+@Mixin(value = CraftingCpuLogic.class, remap = false, priority = 1200)
+public abstract class Ae2ExactCraftingLogicMixin implements ExactCraftingLogicAccess {
+    @Shadow
+    private ExecutingCraftingJob job;
+
+    @Shadow
+    @Final
+    private CraftingCPUCluster cluster;
+
+    @Override
+    @Invoker("finishJob")
+    public abstract void aco$finishExactJob(boolean successful);
+
+    @Inject(method = "executeCrafting", at = @At("HEAD"), cancellable = true, require = 1)
+    private void aco$keepExactJobOnPhysicalExecutor(
+            int maxPatterns,
+            CraftingService craftingService,
+            IEnergyService energyService,
+            Level level,
+            CallbackInfoReturnable<Integer> cir) {
+        // exact Jobだけを止め、通常AE2 Jobと他アドオンの通常実行は変更しない。
+        if (job instanceof ExactCraftingJobAccess exact && exact.aco$isExactJob()) {
+            cir.setReturnValue(0);
+        }
+    }
+
+    @Inject(method = "insert", at = @At("HEAD"), cancellable = true, require = 1)
+    private void aco$rejectUnreceiptedExactOutput(
+            AEKey key,
+            long amount,
+            Actionable mode,
+            CallbackInfoReturnable<Long> cir) {
+        /* exact出力は物理Receiptで証明後に同じJobへ反映し、通常挿入との二重会計を防ぐ。 */
+        if (job instanceof ExactCraftingJobAccess exact && exact.aco$isExactJob()) {
+            cir.setReturnValue(0L);
+        }
+    }
+
+    @Inject(method = "writeToNBT", at = @At("RETURN"), require = 1)
+    private void aco$saveExactJob(
+            CompoundTag owner,
+            CallbackInfo ci) {
+        if (!(job instanceof ExactCraftingJobAccess exact) || !exact.aco$isExactJob()) {
+            return;
+        }
+        CompoundTag jobTag = owner.getCompound("job");
+        exact.aco$writeExactState(jobTag);
+        owner.put("job", jobTag);
+    }
+
+    @Inject(method = "readFromNBT", at = @At("RETURN"), require = 1)
+    private void aco$loadExactJob(
+            CompoundTag owner,
+            CallbackInfo ci) {
+        if (!(job instanceof ExactCraftingJobAccess exact)) {
+            return;
+        }
+        exact.aco$loadExactState(owner.getCompound("job"));
+        // 保存済みexact Jobだけを再登録し、通常Jobのtick経路を増やさない。
+        if (exact.aco$isExactJob()) {
+            Ae2BigCraftingExecutionManager.register(cluster);
+        }
+    }
+
+    @Inject(method = "cancel", at = @At("HEAD"), cancellable = true, require = 1)
+    private void aco$cancelExactJobSafely(CallbackInfo ci) {
+        if (!(job instanceof ExactCraftingJobAccess exact) || !exact.aco$isExactJob()) {
+            return;
+        }
+        var state = exact.aco$getExactState();
+        if (state == null) {
+            throw new IllegalStateException("Exact AE2 job lost its accounting state");
+        }
+        /* 物理所有権取得後はManagerへ取消要求だけを渡し、Escrow所有者を先に消さない。 */
+        if (state.hasPhysicalExecution()) {
+            state.requestCancellation();
+            cluster.markDirty();
+            ci.cancel();
+            return;
+        }
+        // 入力へ触る前ならAE2本来のLink通知とJob破棄をそのまま使える。
+        aco$finishExactJob(false);
+        cluster.updateOutput(null);
+        Ae2BigCraftingExecutionManager.unregister(cluster);
+        ci.cancel();
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/ExecutingCraftingJobTransactionAccessMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/ExecutingCraftingJobTransactionAccessMixin.java
@@ -1,20 +1,38 @@
 package com.syaru.ae2craftingoptimizer.mixin;
 
 import appeng.api.crafting.IPatternDetails;
+import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
 import appeng.crafting.CraftingLink;
 import appeng.crafting.execution.ExecutingCraftingJob;
 import appeng.crafting.inv.ICraftingInventory;
 import appeng.crafting.inv.ListCraftingInventory;
 import com.syaru.ae2craftingoptimizer.access.CraftingJobTransactionAccess;
+import com.syaru.ae2craftingoptimizer.access.CraftingTaskProgressAccess;
+import com.syaru.ae2craftingoptimizer.access.ExactCraftingInventoryAccess;
+import com.syaru.ae2craftingoptimizer.access.ExactCraftingJobAccess;
+import com.syaru.ae2craftingoptimizer.config.ACOConfig;
+import com.syaru.ae2craftingoptimizer.engine.BigIntegerCraftingPlan;
+import com.syaru.ae2craftingoptimizer.engine.ExactCraftingJobLedger;
+import com.syaru.ae2craftingoptimizer.engine.ExactCraftingJobState;
+import java.math.BigInteger;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 
+/** 標準AE2 Jobの通常取引Accessorと、Issue #115のexact Sidecarを同じ実Jobへ公開する。 */
 @Mixin(value = ExecutingCraftingJob.class, remap = false)
-public abstract class ExecutingCraftingJobTransactionAccessMixin implements CraftingJobTransactionAccess {
+public abstract class ExecutingCraftingJobTransactionAccessMixin
+        implements CraftingJobTransactionAccess, ExactCraftingJobAccess {
+    @Unique
+    private static final String ACO_EXACT_JOB_NBT = "acoExactCraftingJob";
+
     @Shadow
     @Final
     private Map<IPatternDetails, Object> tasks;
@@ -26,6 +44,17 @@ public abstract class ExecutingCraftingJobTransactionAccessMixin implements Craf
     @Shadow
     @Final
     private CraftingLink link;
+
+    @Shadow
+    private long remainingAmount;
+
+    /** nullは通常AE2 Job、非nullは同じ実Jobへ付随するBigInteger正本。 */
+    @Unique
+    private ExactCraftingJobState aco$exactState;
+
+    /** AE2のremainingAmountをBigIntegerへ拡張した、同じ実Job上の正確な残数。 */
+    @Unique
+    private BigInteger aco$exactRemainingAmount;
 
     @Override
     public Map<IPatternDetails, Object> aco$getTasks() {
@@ -45,5 +74,150 @@ public abstract class ExecutingCraftingJobTransactionAccessMixin implements Craf
     @Override
     public UUID aco$getCraftingJobId() {
         return link.getCraftingID();
+    }
+
+    @Override
+    public void aco$installExactState(BigIntegerCraftingPlan plan) {
+        if (aco$exactState != null) {
+            throw new IllegalStateException("AE2 job already has exact accounting");
+        }
+        aco$exactState = ExactCraftingJobState.fromPlan(plan);
+        aco$applyExactRuntimeCounters();
+    }
+
+    @Override
+    public void aco$loadExactState(CompoundTag owner) {
+        // exactタグが無い通常JobはSidecarを作らず、AE2本来のlong会計だけを使う。
+        if (!owner.contains(ACO_EXACT_JOB_NBT, Tag.TAG_COMPOUND)) {
+            aco$exactState = null;
+            return;
+        }
+        aco$exactState = ExactCraftingJobState.load(
+                owner.getCompound(ACO_EXACT_JOB_NBT),
+                ACOConfig.getBigIntegerMaximumBits());
+        aco$applyExactRuntimeCounters();
+    }
+
+    @Override
+    public void aco$writeExactState(CompoundTag owner) {
+        if (aco$exactState == null) {
+            return;
+        }
+        /* 保存前に実カウンタとReceipt Journalの完全一致だけを検証し、値を補正しない。 */
+        aco$exactState.verifyRuntimeCounters(
+                aco$getExactRemainingTasks(),
+                aco$getExactWaitingFor(),
+                aco$getExactRemainingOutput());
+        owner.put(
+                ACO_EXACT_JOB_NBT,
+                aco$exactState.save(ACOConfig.getBigIntegerMaximumBits()));
+    }
+
+    @Override
+    public boolean aco$isExactJob() {
+        return aco$exactState != null;
+    }
+
+    @Override
+    public ExactCraftingJobState aco$getExactState() {
+        return aco$exactState;
+    }
+
+    @Override
+    public void aco$reconcileExactAccounting(
+            Map<AEItemKey, BigInteger> dispatchedTasks,
+            Map<AEKey, BigInteger> introducedOutputs,
+            Map<AEKey, BigInteger> creditedOutputs,
+            BigInteger remainingOutput) {
+        ExactCraftingJobState state = aco$requireExactState();
+        state.reconcile(dispatchedTasks, introducedOutputs, creditedOutputs, remainingOutput);
+        aco$applyExactRuntimeCounters();
+    }
+
+    @Override
+    public Map<AEItemKey, BigInteger> aco$getExactRemainingTasks() {
+        aco$requireExactState();
+        Map<AEItemKey, BigInteger> remaining = new LinkedHashMap<>();
+        // 実Jobの全TaskProgressをPattern定義単位へまとめ、正確な残タスク数を得る。
+        for (var entry : tasks.entrySet()) {
+            if (!(entry.getValue() instanceof CraftingTaskProgressAccess progress)) {
+                throw new IllegalStateException("AE2 task progress access is missing");
+            }
+            BigInteger amount = progress.aco$getExactTaskProgress();
+            if (amount.signum() < 0) {
+                throw new IllegalStateException("AE2 exact task progress is negative");
+            }
+            if (amount.signum() > 0) {
+                remaining.merge(entry.getKey().getDefinition(), amount, BigInteger::add);
+            }
+        }
+        return Map.copyOf(remaining);
+    }
+
+    @Override
+    public Map<AEKey, BigInteger> aco$getExactWaitingFor() {
+        aco$requireExactState();
+        if (!(waitingFor instanceof ExactCraftingInventoryAccess exactInventory)
+                || !exactInventory.aco$hasExactCounts()) {
+            throw new IllegalStateException("AE2 waitingFor has no exact accounting");
+        }
+        return exactInventory.aco$getExactCounts();
+    }
+
+    @Override
+    public BigInteger aco$getExactRemainingOutput() {
+        aco$requireExactState();
+        if (aco$exactRemainingAmount == null) {
+            throw new IllegalStateException("AE2 final output has no exact accounting");
+        }
+        return aco$exactRemainingAmount;
+    }
+
+    @Override
+    public boolean aco$isExactAccountingBalanced() {
+        return aco$getExactRemainingTasks().isEmpty()
+                && aco$getExactWaitingFor().isEmpty()
+                && aco$getExactRemainingOutput().signum() == 0;
+    }
+
+    @Unique
+    private ExactCraftingJobState aco$requireExactState() {
+        if (aco$exactState == null) {
+            throw new IllegalStateException("AE2 job has no exact accounting");
+        }
+        return aco$exactState;
+    }
+
+    @Unique
+    private void aco$applyExactRuntimeCounters() {
+        ExactCraftingJobState state = aco$requireExactState();
+        Map<AEItemKey, BigInteger> remaining = state.remainingTasks();
+        Map<AEItemKey, CraftingTaskProgressAccess> taskCounters = new LinkedHashMap<>();
+        /* 第一巡目では値を変更せず、全TaskProgressとPattern定義の一対一対応を証明する。 */
+        for (var entry : tasks.entrySet()) {
+            AEItemKey definition = entry.getKey().getDefinition();
+            if (!(entry.getValue() instanceof CraftingTaskProgressAccess progress)) {
+                throw new IllegalStateException("AE2 task progress access is missing");
+            }
+            if (taskCounters.putIfAbsent(definition, progress) != null) {
+                throw new IllegalStateException(
+                        "AE2 exact job contains duplicate pattern definitions");
+            }
+        }
+        if (!taskCounters.keySet().equals(state.taskTotals().keySet())) {
+            throw new IllegalStateException(
+                    "exact task definitions do not match the AE2 job");
+        }
+        if (!(waitingFor instanceof ExactCraftingInventoryAccess exactInventory)) {
+            throw new IllegalStateException("AE2 waitingFor exact mixin is missing");
+        }
+        // 第二巡目で、BigInteger正本とAE2向け飽和long Facadeを同じTaskへ設置する。
+        for (var entry : taskCounters.entrySet()) {
+            entry.getValue().aco$setExactTaskProgress(
+                    remaining.getOrDefault(entry.getKey(), BigInteger.ZERO));
+        }
+        aco$exactRemainingAmount = state.remainingOutput();
+        remainingAmount = ExactCraftingJobLedger.saturatedLong(aco$exactRemainingAmount);
+        exactInventory.aco$replaceExactCounts(state.waitingFor());
     }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/TaskProgressTransactionAccessMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/TaskProgressTransactionAccessMixin.java
@@ -1,15 +1,22 @@
 package com.syaru.ae2craftingoptimizer.mixin;
 
 import com.syaru.ae2craftingoptimizer.access.CraftingTaskProgressAccess;
+import com.syaru.ae2craftingoptimizer.engine.ExactCraftingJobLedger;
+import java.math.BigInteger;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 
 @Pseudo
 @Mixin(targets = "appeng.crafting.execution.ExecutingCraftingJob$TaskProgress", remap = false)
 public abstract class TaskProgressTransactionAccessMixin implements CraftingTaskProgressAccess {
     @Shadow
     private long value;
+
+    /** 通常Jobではnull、Issue #115のexact Jobではこの値が残タスク数の正本になる。 */
+    @Unique
+    private BigInteger aco$exactValue;
 
     @Override
     public long aco$getTaskProgress() {
@@ -19,5 +26,17 @@ public abstract class TaskProgressTransactionAccessMixin implements CraftingTask
     @Override
     public void aco$setTaskProgress(long value) {
         this.value = value;
+    }
+
+    @Override
+    public BigInteger aco$getExactTaskProgress() {
+        return aco$exactValue == null ? BigInteger.valueOf(value) : aco$exactValue;
+    }
+
+    @Override
+    public void aco$setExactTaskProgress(BigInteger value) {
+        aco$exactValue = value;
+        // AE2自身が読むlong欄は互換Facadeとして常に0..Long.MAX_VALUEへ収める。
+        this.value = ExactCraftingJobLedger.saturatedLong(value);
     }
 }

--- a/src/main/resources/ae2_crafting_optimizer.mixins.json
+++ b/src/main/resources/ae2_crafting_optimizer.mixins.json
@@ -25,6 +25,8 @@
     "CraftingCalculationDiagnosticsMixin",
     "CraftingCalculationCheckedMathMixin",
     "CraftingCalculationMemoLifecycleMixin",
+    "Ae2BigCapacityPlanSubmissionMixin",
+    "Ae2ExactCraftingLogicMixin",
     "CraftAmountMenuLongAmountMixin",
     "CraftConfirmMenuLongAmountMixin",
     "CraftingPlanSummaryWidePlanMixin",

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue109MixinBoundarySourceTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue109MixinBoundarySourceTest.java
@@ -21,10 +21,15 @@ class Issue109MixinBoundarySourceTest {
     }
 
     @Test
-    void standardAe2CpuSubmissionIsNotIntercepted() {
+    void externalConsumerRegistrationDoesNotInstallTheRemovedBroadCpuGuard() {
         String mixins = read(MAIN.resolve(Path.of(
                 "resources", "ae2_crafting_optimizer.mixins.json")));
         assertFalse(mixins.contains("CraftingCpuClusterBigCapacityGuardMixin"));
+        String issue115Boundary = read(MAIN.resolve(Path.of(
+                "java", "com", "syaru", "ae2craftingoptimizer", "mixin",
+                "Ae2BigCapacityPlanSubmissionMixin.java")));
+        assertFalse(issue115Boundary.contains("hasExternalBigIntegerPlanConsumer"));
+        assertTrue(issue115Boundary.contains("if (exact == null)"));
     }
 
     @Test

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue115StandardAe2ExactExecutionSourceTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue115StandardAe2ExactExecutionSourceTest.java
@@ -1,0 +1,91 @@
+package com.syaru.ae2craftingoptimizer.integration;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import appeng.crafting.execution.CraftingCpuLogic;
+import com.syaru.ae2craftingoptimizer.mixin.Ae2ExactCraftingLogicMixin;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import net.minecraft.nbt.CompoundTag;
+import org.junit.jupiter.api.Test;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/** Issue #115の標準AE2境界と、外部CPU非依存をソース契約として固定する。 */
+class Issue115StandardAe2ExactExecutionSourceTest {
+    private static final Path JAVA = Path.of("src", "main", "java", "com", "syaru",
+            "ae2craftingoptimizer");
+
+    @Test
+    void standardManagerUsesThePhysicalReceiptTransactionWithoutAddonClasses() {
+        String source = read(JAVA.resolve(Path.of(
+                "integration", "Ae2BigCraftingExecutionManager.java")));
+        assertTrue(source.contains("PhysicalCraftingTreeTransaction"));
+        assertTrue(source.contains("CraftingCPUCluster"));
+        assertFalse(source.contains("net.pedroksl"));
+        assertFalse(source.contains("jp.main.taikun"));
+        assertFalse(source.contains("insaneae$"));
+    }
+
+    @Test
+    void submissionOnlyPromotesAnExactPlanAfterAe2AcceptedIt() {
+        String source = read(JAVA.resolve(Path.of(
+                "mixin", "Ae2BigCapacityPlanSubmissionMixin.java")));
+        assertTrue(source.contains("if (exact == null)"));
+        assertTrue(source.contains("!cir.getReturnValue().successful()"));
+        assertTrue(source.contains("aco$singleExecutionFacade"));
+        assertFalse(source.contains("registerExternalBigIntegerPlanConsumer"));
+    }
+
+    @Test
+    void exactExecutorDoesNotCancelNormalAe2Execution() {
+        String source = read(JAVA.resolve(Path.of(
+                "mixin", "Ae2ExactCraftingLogicMixin.java")));
+        assertTrue(source.contains("exact.aco$isExactJob()"));
+        assertTrue(source.contains("state.hasPhysicalExecution()"));
+        assertTrue(source.contains("state.requestCancellation()"));
+    }
+
+    @Test
+    void forgeNbtHooksMatchAe2OneArgumentMethods() throws ReflectiveOperationException {
+        CraftingCpuLogic.class.getDeclaredMethod("writeToNBT", CompoundTag.class);
+        CraftingCpuLogic.class.getDeclaredMethod("readFromNBT", CompoundTag.class);
+        Method save = declaredMethod("aco$saveExactJob");
+        Method load = declaredMethod("aco$loadExactJob");
+        assertArrayEquals(
+                new Class<?>[] {CompoundTag.class, CallbackInfo.class},
+                save.getParameterTypes());
+        assertArrayEquals(
+                new Class<?>[] {CompoundTag.class, CallbackInfo.class},
+                load.getParameterTypes());
+    }
+
+    @Test
+    void lifecycleTicksAndClearsTheStandardManager() {
+        String source = read(JAVA.resolve(Path.of(
+                "lifecycle", "ACOServerLifecycle.java")));
+        assertTrue(source.contains("Ae2BigCraftingExecutionManager.tick(event.getServer())"));
+        assertTrue(source.contains("Ae2BigCraftingExecutionManager.clear()"));
+    }
+
+    private static Method declaredMethod(String name) {
+        // Mixinのprivate handlerから、指定した注入点だけを一意に取得する。
+        return Arrays.stream(Ae2ExactCraftingLogicMixin.class.getDeclaredMethods())
+                .filter(method -> method.getName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing mixin handler: " + name));
+    }
+
+    private static String read(Path path) {
+        try {
+            return Files.readString(path);
+        } catch (IOException exception) {
+            throw new UncheckedIOException(path.toString(), exception);
+        }
+    }
+}


### PR DESCRIPTION
## 概要

Issue #115で実装した標準AE2 `CraftingCPUCluster`向けBigInteger物理実行を、Forge 1.20.1 / AE2 15.4.10へ移植します。

標準AE2 CPUが受理したACO exact planだけを既存の`PhysicalCraftingTreeTransaction`へ接続します。通常long計画、BigCapacity-only計画、AE2が拒否したジョブ、端末・バス・共有在庫一覧は変更しません。

## 主な変更

- 標準AE2用のexact job / exact logic共通契約を追加
- `ExecutingCraftingJob`と`TaskProgress`へ正確なBigInteger Sidecarを追加
- 標準AE2向け提出境界Mixinとexact実行Mixinを追加
- `Ae2BigCraftingExecutionManager`で物理Transaction、Receipt、取消、隔離、NBT復旧を管理
- Advanced AE / InsaneAE固有クラスへ依存しない境界試験を追加
- Issue #109の通常AE2非介入境界を維持

## Forge固有差分

- AE2 15.4.10の`writeToNBT/readFromNBT(CompoundTag)`へMixin handlerを一致させました。
- Forge側に存在しないtransaction revision診断には依存せず、exact実行tickごとに会計と復旧NBTを同期します。
- 実AE2クラスのNBTメソッドとMixin handler引数をReflection試験で照合します。

## 試験

- `gradlew clean build --no-daemon`: 成功
- JUnit: 383件中381件成功、2件skip、失敗0件、エラー0件
- `git diff --check`: 成功
- JAR: `aco1.5.23_1.20.1.jar`
- 起動試験 / GameTest: 未実施

Refs #115
