### PR TITLE
fix(1.21.1): 1.5.23のexact実行・停止保存・Advanced AE連携回帰を修正

### DIFF
--- a/docs/REGRESSION_HISTORY.md
+++ b/docs/REGRESSION_HISTORY.md
@@ -14,6 +14,9 @@
 | [#93](https://github.com/syarukasu/ae2-crafting-optimizer/issues/93) | Java 25でBigInteger在庫Sidecarの可視コピー中にJVMが終了する | 1.5.18 | 1.5.20 | [ISSUE-93.md](issues/ISSUE-93.md) |
 | [#103](https://github.com/syarukasu/ae2-crafting-optimizer/issues/103) | wide計画の非同期compile競合と実行裏付け不足の誤診断 | 1.5.19 | 1.5.20 | [ISSUE-103.md](issues/ISSUE-103.md) |
 | [#109](https://github.com/syarukasu/ae2-crafting-optimizer/issues/109) | BigInteger API連携が通常AE2の責務境界を越える | 1.5.20 | 1.5.21 | [ISSUE-109.md](issues/ISSUE-109.md) |
+| [#118](https://github.com/syarukasu/ae2-crafting-optimizer/issues/118) | 正常な空Journalを成功量0として扱いexact物理実行が自己隔離する | 1.5.23 | 次回修正 | [ISSUE-118.md](issues/ISSUE-118.md) |
+| [#119](https://github.com/syarukasu/ae2-crafting-optimizer/issues/119) | 停止時にRegistry Providerを先に破棄しexact JobとBlock EntityのNBT保存が失敗する | 1.5.23 | 次回修正 | [ISSUE-119.md](issues/ISSUE-119.md) |
+| [#120](https://github.com/syarukasu/ae2-crafting-optimizer/issues/120) | Mixin初期化中のModList判定でAdvanced AE変換を自己無効化する | 1.5.23 | 次回修正 | [ISSUE-120.md](issues/ISSUE-120.md) |
 
 ## 運用
 

--- a/docs/issues/ISSUE-118.md
+++ b/docs/issues/ISSUE-118.md
@@ -1,0 +1,37 @@
+# Issue #118: exact在庫変更が正常な空Journalで自己隔離する
+
+- GitHub Issue: https://github.com/syarukasu/ae2-crafting-optimizer/issues/118
+- 状態: Implemented
+- 影響版: ACO 1.5.23
+- 対象ローダー: Forge 1.20.1 / NeoForge 1.21.1
+
+## 問題
+
+標準AE2 exact物理実行が入力取得前に`successful exact storage mutation must apply a
+positive amount`で隔離される。実変更前のJournal復旧確認が、復旧対象なしを
+`ExactStorageMutationResult.success(0)`として返していた。
+
+## 不変条件
+
+- 成功した実在庫変更量は必ず正数とする。
+- 復旧対象なしは在庫変更成功として扱わず、次の変更へ進める制御結果とする。
+- 復旧不能または状態不明だけ現在の変更を拒否・隔離する。
+
+## やってはいけないこと
+
+- `success(0)`を許可して実変更結果の契約を弱める。
+- Journal異常を正常扱いして新しい変更を開始する。
+- 隔離済み操作を推測で再実行する。
+
+## 修正
+
+`recoverPendingInterruption`を`Optional<ExactStorageMutationResult>`へ分離した。空は続行可、
+値ありは現在の変更を止める結果であり、正常な空Journalは実変更結果を生成しない。
+復旧を実施したtickも待機へ戻し、復旧前の古いbefore状態を使った二重変更を防ぐ。
+
+## 回帰試験
+
+- 成功量0は引き続き例外になる。
+- 復旧完了経路に`success(BigInteger.ZERO)`が存在しない。
+- 復旧を一件でも実施した呼出しは新規変更を重ねず、次tickの再照合を待つ。
+- 正常な復旧確認後は実際のprepare/commitへ進む。

--- a/docs/issues/ISSUE-119.md
+++ b/docs/issues/ISSUE-119.md
@@ -1,0 +1,36 @@
+# Issue #119: 停止時のexact Job保存がRegistry Provider消失で失敗する
+
+- GitHub Issue: https://github.com/syarukasu/ae2-crafting-optimizer/issues/119
+- 状態: Implemented
+- 影響版: ACO 1.5.23
+- 対象ローダー: Forge 1.20.1 / NeoForge 1.21.1
+
+## 問題
+
+`ServerStopping`でグローバルRegistry Providerを破棄した後にBlock Entityの最終保存が走り、
+exact SidecarのAEKey符号化が失敗する。例外がAE2の`CraftingBlockEntity`全体のNBT保存まで
+中断させ、通常AE2状態も保存できなくなる。
+
+## 不変条件
+
+- exact SidecarはAE2の保存メソッドが渡した実Registry Providerで保存・読込する。
+- Registry Providerはサーバー停止完了まで有効とする。
+- exact Sidecarだけを黙って捨て、AE2の一回分Facadeだけを保存してはならない。
+
+## やってはいけないこと
+
+- 保存例外を握り潰してSidecarなしのJobを復元可能にする。
+- `ServerStopping`でRegistry Providerを破棄する。
+- AEKeyを文字列IDへ近似変換してData Componentを失う。
+
+## 修正
+
+`ExactCraftingJobState`のsave/loadへ`HolderLookup.Provider`を必須引数として渡し、
+AE2およびAdvanced AEの`writeToNBT`/`readFromNBT`引数をそのまま使用する。グローバルProviderは
+`ServerStopped`でのみ破棄する。
+
+## 回帰試験
+
+- `ExactCraftingJobState`は`ACORegistryAccess.require()`を参照しない。
+- 両実Job MixinがAE2から受け取ったProviderをSidecarへ渡す。
+- `ACORegistryAccess.clear()`は`onServerStopped`より後にだけ存在する。

--- a/docs/issues/ISSUE-120.md
+++ b/docs/issues/ISSUE-120.md
@@ -1,0 +1,37 @@
+# Issue #120: Advanced AE Mixinが自分で無効化され監査だけが失敗する
+
+- GitHub Issue: https://github.com/syarukasu/ae2-crafting-optimizer/issues/120
+- 状態: Implemented
+- 影響版: ACO 1.5.23
+- 対象ローダー: NeoForge 1.21.1
+- 対象依存: Advanced AE 1.6.x
+
+## 問題
+
+Mixin config pluginがMixin初期化中に未完成の`ModList`を参照し、Advanced AE導入済みでも
+全連携Mixinを無効化する。サーバー開始後の監査は完成済み`ModList`を見てMixin欠落を検出し、
+自己矛盾した起動失敗になる。
+
+## 不変条件
+
+- Mixin適用可否はMixin初期化時点で利用可能な実クラス資源から決める。
+- サーバー開始後の監査は、導入済み連携先に必要な変換が欠ければFail-fastする。
+- Advanced AE未導入環境では連携Mixinを選択しない。
+
+## やってはいけないこと
+
+- 監査をWARNへ落として欠落した変換のまま実行する。
+- Mixin初期化時の`ModList`だけを任意依存の存在判定に使う。
+- 対象クラスを初期化してクライアント専用依存や静的初期化を発火させる。
+
+## 修正
+
+Advanced AE pluginへ`AdvCraftingCPUCluster.class`の資源マーカーを追加し、ClassLoaderの
+`getResource`で副作用なく存在を判定する。バージョン範囲と必須Interface監査は、
+ModList完成後の既存Validatorで継続する。
+
+## 回帰試験
+
+- 実在するclass resourceはModListなしでも検出できる。
+- 存在しないclass resourceは選択されない。
+- Advanced AE pluginが実在するClusterクラスをマーカーとして宣言する。

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -25,3 +25,6 @@
 - [Issue #103](ISSUE-103.md): wide計画の非同期compile競合と実行裏付け不足の誤診断
 - [Issue #109](ISSUE-109.md): BigInteger API連携が通常AE2の責務境界を越える
 - [Issue #115](ISSUE-115.md): 標準AE2クラスタでBigInteger物理実行を所有する
+- [Issue #118](ISSUE-118.md): 正常な空Journalを成功量0として自己隔離する
+- [Issue #119](ISSUE-119.md): 停止時のRegistry Provider消失でexact Job保存が失敗する
+- [Issue #120](ISSUE-120.md): Advanced AE連携Mixinが初期化順で自己無効化する

--- a/src/main/java/com/syaru/ae2craftingoptimizer/access/ExactCraftingJobAccess.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/access/ExactCraftingJobAccess.java
@@ -6,6 +6,7 @@ import com.syaru.ae2craftingoptimizer.engine.BigIntegerCraftingPlan;
 import com.syaru.ae2craftingoptimizer.engine.ExactCraftingJobState;
 import java.math.BigInteger;
 import java.util.Map;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,9 +14,13 @@ import org.jetbrains.annotations.Nullable;
 public interface ExactCraftingJobAccess {
     void aco$installExactState(BigIntegerCraftingPlan plan);
 
-    void aco$loadExactState(CompoundTag owner);
+    void aco$loadExactState(
+            CompoundTag owner,
+            HolderLookup.Provider registries);
 
-    void aco$writeExactState(CompoundTag owner);
+    void aco$writeExactState(
+            CompoundTag owner,
+            HolderLookup.Provider registries);
 
     boolean aco$isExactJob();
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/ExactCraftingJobState.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/ExactCraftingJobState.java
@@ -6,6 +6,7 @@ import java.math.BigInteger;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
@@ -103,14 +104,16 @@ public final class ExactCraftingJobState {
 
     public static ExactCraftingJobState load(
             CompoundTag owner,
-            int maximumBits) {
+            int maximumBits,
+            HolderLookup.Provider registries) {
         Objects.requireNonNull(owner, "owner");
+        Objects.requireNonNull(registries, "registries");
         // 未対応schemaを推測変換せず、重複実行を防ぐため復元を拒否する。
         if (owner.getInt("schema") != SCHEMA_VERSION) {
             throw new IllegalArgumentException(
                     "unsupported exact crafting-job schema");
         }
-        AEKey requestedKey = AEKey.fromTagGeneric(com.syaru.ae2craftingoptimizer.lifecycle.ACORegistryAccess.require(),
+        AEKey requestedKey = AEKey.fromTagGeneric(registries,
                 owner.getCompound("requestedKey"));
         // 登録解除された出力キーを別アイテムへ置換せず、Job復元を止める。
         if (requestedKey == null) {
@@ -118,9 +121,9 @@ public final class ExactCraftingJobState {
                     "exact crafting job contains an unknown requested key");
         }
         Map<AEItemKey, BigInteger> totals =
-                readPatternCounts(owner, "taskTotals", maximumBits);
+                readPatternCounts(owner, "taskTotals", maximumBits, registries);
         Map<AEItemKey, BigInteger> dispatched =
-                readPatternCounts(owner, "dispatchedTasks", maximumBits);
+                readPatternCounts(owner, "dispatchedTasks", maximumBits, registries);
         CompoundTag physicalExecution = owner.contains(
                         "physicalExecution",
                         Tag.TAG_COMPOUND)
@@ -135,7 +138,8 @@ public final class ExactCraftingJobState {
                 readKeyCounts(
                         owner,
                         "plannedInventory",
-                        maximumBits),
+                        maximumBits,
+                        registries),
                 owner.getLong("patternGeneration"),
                 owner.getLong("recipeGeneration"),
                 owner.getString("planningEpoch"),
@@ -145,16 +149,19 @@ public final class ExactCraftingJobState {
                         readKeyCounts(
                                 owner,
                                 "initialWaiting",
-                                maximumBits),
+                                maximumBits,
+                                registries),
                         dispatched,
                         readKeyCounts(
                                 owner,
                                 "introducedOutputs",
-                                maximumBits),
+                                maximumBits,
+                                registries),
                         readKeyCounts(
                                 owner,
                                 "creditedOutputs",
-                                maximumBits),
+                                maximumBits,
+                                registries),
                         BigIntegerNbtCodec.getNonNegative(
                                 owner,
                                 "requestedAmount",
@@ -168,10 +175,13 @@ public final class ExactCraftingJobState {
                 owner.getBoolean("quarantined"));
     }
 
-    public synchronized CompoundTag save(int maximumBits) {
+    public synchronized CompoundTag save(
+            int maximumBits,
+            HolderLookup.Provider registries) {
+        Objects.requireNonNull(registries, "registries");
         CompoundTag owner = new CompoundTag();
         owner.putInt("schema", SCHEMA_VERSION);
-        owner.put("requestedKey", requestedKey.toTagGeneric(com.syaru.ae2craftingoptimizer.lifecycle.ACORegistryAccess.require()));
+        owner.put("requestedKey", requestedKey.toTagGeneric(registries));
         BigIntegerNbtCodec.putNonNegative(
                 owner,
                 "reservedBytes",
@@ -189,26 +199,26 @@ public final class ExactCraftingJobState {
                 maximumBits);
         owner.put(
                 "plannedInventory",
-                writeKeyCounts(plannedInventory, maximumBits));
+                writeKeyCounts(plannedInventory, maximumBits, registries));
         owner.putLong("patternGeneration", patternGeneration);
         owner.putLong("recipeGeneration", recipeGeneration);
         owner.putString("planningEpoch", planningEpoch);
         owner.putString("programFingerprint", programFingerprint);
         owner.put(
                 "taskTotals",
-                writePatternCounts(ledger.taskTotals(), maximumBits));
+                writePatternCounts(ledger.taskTotals(), maximumBits, registries));
         owner.put(
                 "dispatchedTasks",
-                writePatternCounts(ledger.dispatchedTasks(), maximumBits));
+                writePatternCounts(ledger.dispatchedTasks(), maximumBits, registries));
         owner.put(
                 "initialWaiting",
-                writeKeyCounts(ledger.initialWaiting(), maximumBits));
+                writeKeyCounts(ledger.initialWaiting(), maximumBits, registries));
         owner.put(
                 "introducedOutputs",
-                writeKeyCounts(ledger.introducedOutputs(), maximumBits));
+                writeKeyCounts(ledger.introducedOutputs(), maximumBits, registries));
         owner.put(
                 "creditedOutputs",
-                writeKeyCounts(ledger.creditedOutputs(), maximumBits));
+                writeKeyCounts(ledger.creditedOutputs(), maximumBits, registries));
         // 空Compoundは未開始を表す。開始後だけ保存して旧Jobとの区別を明確にする。
         if (!physicalExecution.isEmpty()) {
             owner.put("physicalExecution", physicalExecution.copy());
@@ -374,12 +384,13 @@ public final class ExactCraftingJobState {
 
     private static ListTag writePatternCounts(
             Map<AEItemKey, BigInteger> counts,
-            int maximumBits) {
+            int maximumBits,
+            HolderLookup.Provider registries) {
         checkEntryCount(counts.size());
         ListTag list = new ListTag();
         counts.forEach((key, amount) -> {
             CompoundTag entry = new CompoundTag();
-            entry.put("key", key.toTag(com.syaru.ae2craftingoptimizer.lifecycle.ACORegistryAccess.require()));
+            entry.put("key", key.toTag(registries));
             BigIntegerNbtCodec.putNonNegative(
                     entry,
                     "amount",
@@ -393,13 +404,14 @@ public final class ExactCraftingJobState {
     private static Map<AEItemKey, BigInteger> readPatternCounts(
             CompoundTag owner,
             String name,
-            int maximumBits) {
+            int maximumBits,
+            HolderLookup.Provider registries) {
         ListTag list = requireCompoundList(owner, name);
         Map<AEItemKey, BigInteger> result = new LinkedHashMap<>();
         // NBT件数は固有Pattern数に比例し、注文数量ぶんのentryは作らない。
         for (int index = 0; index < list.size(); index++) {
             CompoundTag entry = list.getCompound(index);
-            AEItemKey key = AEItemKey.fromTag(com.syaru.ae2craftingoptimizer.lifecycle.ACORegistryAccess.require(), entry.getCompound("key"));
+            AEItemKey key = AEItemKey.fromTag(registries, entry.getCompound("key"));
             BigInteger amount = BigIntegerNbtCodec.getNonNegative(
                     entry,
                     "amount",
@@ -417,12 +429,13 @@ public final class ExactCraftingJobState {
 
     private static ListTag writeKeyCounts(
             Map<AEKey, BigInteger> counts,
-            int maximumBits) {
+            int maximumBits,
+            HolderLookup.Provider registries) {
         checkEntryCount(counts.size());
         ListTag list = new ListTag();
         counts.forEach((key, amount) -> {
             CompoundTag entry = new CompoundTag();
-            entry.put("key", key.toTagGeneric(com.syaru.ae2craftingoptimizer.lifecycle.ACORegistryAccess.require()));
+            entry.put("key", key.toTagGeneric(registries));
             BigIntegerNbtCodec.putNonNegative(
                     entry,
                     "amount",
@@ -436,13 +449,14 @@ public final class ExactCraftingJobState {
     private static Map<AEKey, BigInteger> readKeyCounts(
             CompoundTag owner,
             String name,
-            int maximumBits) {
+            int maximumBits,
+            HolderLookup.Provider registries) {
         ListTag list = requireCompoundList(owner, name);
         Map<AEKey, BigInteger> result = new LinkedHashMap<>();
         // Item、Fluid、Chemicalを同じAEKey汎用タグから損失なく復元する。
         for (int index = 0; index < list.size(); index++) {
             CompoundTag entry = list.getCompound(index);
-            AEKey key = AEKey.fromTagGeneric(com.syaru.ae2craftingoptimizer.lifecycle.ACORegistryAccess.require(), entry.getCompound("key"));
+            AEKey key = AEKey.fromTagGeneric(registries, entry.getCompound("key"));
             BigInteger amount = BigIntegerNbtCodec.getNonNegative(
                     entry,
                     "amount",

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExactNetworkStorageBridge.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExactNetworkStorageBridge.java
@@ -312,9 +312,12 @@ public final class ExactNetworkStorageBridge {
                 checkedBatchAmounts(
                         amounts);
         synchronized (lockFor(grid)) {
-            ExactStorageMutationResult recovery = recoverPending(grid);
-            if (!recovery.successful()) {
-                return recovery;
+            Optional<ExactStorageMutationResult> recoveryInterruption =
+                    recoverPendingInterruption(
+                            grid);
+            // Issue #118: 復旧または復旧失敗があれば、同じ呼出しで新規変更を重ねない。
+            if (recoveryInterruption.isPresent()) {
+                return recoveryInterruption.orElseThrow();
             }
             PreparedMutation prepared =
                     prepareBatch(grid, checked, source, direction);
@@ -381,9 +384,12 @@ public final class ExactNetworkStorageBridge {
             IActionSource source,
             Direction direction) {
         synchronized (lockFor(grid)) {
-            ExactStorageMutationResult recovery = recoverPending(grid);
-            if (!recovery.successful()) {
-                return recovery;
+            Optional<ExactStorageMutationResult> recoveryInterruption =
+                    recoverPendingInterruption(
+                            grid);
+            // Issue #118: 「復旧対象なし」だけ新規変更へ進み、復旧実施時は再照合を待つ。
+            if (recoveryInterruption.isPresent()) {
+                return recoveryInterruption.orElseThrow();
             }
             PreparedMutation prepared =
                     prepareBatch(
@@ -621,17 +627,19 @@ public final class ExactNetworkStorageBridge {
      * matching neither before nor after is quarantined; unrelated network totals are
      * never used as proof.
      */
-    private static ExactStorageMutationResult recoverPending(IGrid grid) {
+    private static Optional<ExactStorageMutationResult> recoverPendingInterruption(IGrid grid) {
         ExactStorageMutationJournal journal =
                 ExactStorageMutationJournal.forGrid(grid);
         if (journal == null || !journal.isHealthy()) {
-            return ExactStorageMutationResult.rejected(
-                    "exact storage journal is unavailable or malformed");
+            return Optional.of(
+                    ExactStorageMutationResult.rejected(
+                            "exact storage journal is unavailable or malformed"));
         }
         MEStorage networkInventory = grid.getStorageService().getInventory();
         if (!(networkInventory instanceof NetworkStorageMountsAccess mountsAccess)) {
-            return ExactStorageMutationResult.rejected(
-                    "exact storage mounts are unavailable during recovery");
+            return Optional.of(
+                    ExactStorageMutationResult.rejected(
+                            "exact storage mounts are unavailable during recovery"));
         }
         List<ResolvedMount> mounts = resolveMounts(
                 mountsAccess.aco$getPriorityInventory());
@@ -643,6 +651,7 @@ public final class ExactNetworkStorageBridge {
                 cells.putIfAbsent(storageId, mount.resolved().accessor());
             }
         }
+        boolean recoveredAny = false;
         for (ExactStorageMutationJournal.Entry entry : journal.pending()) {
             boolean belongsToThisGrid = false;
             for (ExactStorageMutationJournal.Step step : entry.steps()) {
@@ -712,6 +721,7 @@ public final class ExactNetworkStorageBridge {
                 }
                 journal.acknowledge(entry.operationId());
                 grid.getStorageService().invalidateCache();
+                recoveredAny = true;
             } catch (RuntimeException | LinkageError failure) {
                 journal.quarantine(
                         entry.operationId(),
@@ -720,11 +730,25 @@ public final class ExactNetworkStorageBridge {
                         "ACO quarantined exact storage operation {} during recovery",
                         entry.operationId(),
                         failure);
-                return ExactStorageMutationResult.uncertain(
-                        "exact storage recovery could not be proven");
+                return Optional.of(
+                        ExactStorageMutationResult.uncertain(
+                                "exact storage recovery could not be proven"));
             }
         }
-        return ExactStorageMutationResult.success(BigInteger.ZERO);
+        /*
+         * 復旧直前に呼出し元が読んだbefore状態は既に古い。ここで新規変更を続けず、
+         * 次tickにafter状態を再取得して親TransactionのReceiptだけを確定させる。
+         */
+        if (recoveredAny) {
+            return Optional.of(
+                    ExactStorageMutationResult.rejected(
+                            "exact storage recovery completed; retry after reconciliation"));
+        }
+        /*
+         * 復旧対象なしは在庫変更結果ではなく「次の変更へ進める」状態。
+         * 成功した実変更量は常に正数というExactStorageMutationResultの契約を維持する。
+         */
+        return Optional.empty();
     }
 
     private static Object lockFor(IGrid grid) {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACORegistryAccess.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACORegistryAccess.java
@@ -21,7 +21,7 @@ public final class ACORegistryAccess {
         HolderLookup.Provider current = provider;
         if (current == null) {
             throw new IllegalStateException(
-                    "ACO registry access is unavailable before the Minecraft server starts");
+                    "ACO registry access is unavailable outside the active server lifecycle");
         }
         return current;
     }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOServerLifecycle.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOServerLifecycle.java
@@ -33,6 +33,7 @@ import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.OnDatapackSyncEvent;
 import net.neoforged.neoforge.event.server.ServerAboutToStartEvent;
 import net.neoforged.neoforge.event.server.ServerStartedEvent;
+import net.neoforged.neoforge.event.server.ServerStoppedEvent;
 import net.neoforged.neoforge.event.server.ServerStoppingEvent;
 import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import net.neoforged.bus.api.EventPriority;
@@ -59,6 +60,8 @@ public final class ACOServerLifecycle {
         NeoForge.EVENT_BUS.addListener(
                 EventPriority.HIGHEST,
                 ACOServerLifecycle::onServerStopping);
+        NeoForge.EVENT_BUS.addListener(
+                ACOServerLifecycle::onServerStopped);
     }
 
     private static void onServerAboutToStart(ServerAboutToStartEvent event) {
@@ -127,11 +130,15 @@ public final class ACOServerLifecycle {
         BigCraftingStatusInbox.clear();
         Ae2BigCraftingExecutionManager.clear();
         OptionalAqeBigCraftingExecution.clear();
-        /*
-         * AQE側の未送信窓を先に戻してからRegistryを破棄する。
-         * 順序を逆にするとManagerがHostへ到達できず、prepared leaseだけが残る。
-         */
+        // AQE側の未送信窓を先に戻し、prepared leaseを停止後へ残さない。
         BigCraftingHostRegistry.clear();
+    }
+
+    private static void onServerStopped(ServerStoppedEvent event) {
+        /*
+         * Issue #119: ServerStoppingではBlock Entityの最終NBT保存がまだ走り得る。
+         * 全停止完了後だけグローバルRegistry参照を破棄する。
+         */
         ACORegistryAccess.clear();
     }
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeExactCraftingLogicMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeExactCraftingLogicMixin.java
@@ -97,7 +97,9 @@ public abstract class AdvancedAeExactCraftingLogicMixin
             return;
         }
         CompoundTag jobTag = owner.getCompound("job");
-        exact.aco$writeExactState(jobTag);
+        exact.aco$writeExactState(
+                jobTag,
+                registries);
         owner.put("job", jobTag);
     }
 
@@ -110,7 +112,9 @@ public abstract class AdvancedAeExactCraftingLogicMixin
             HolderLookup.Provider registries,
             CallbackInfo ci) {
         if (job instanceof AdvancedAeExactCraftingJobAccess exact) {
-            exact.aco$loadExactState(owner.getCompound("job"));
+            exact.aco$loadExactState(
+                    owner.getCompound("job"),
+                    registries);
         }
     }
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeExecutingCraftingJobTransactionAccessMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeExecutingCraftingJobTransactionAccessMixin.java
@@ -18,6 +18,7 @@ import java.math.BigInteger;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import org.spongepowered.asm.mixin.Final;
@@ -93,7 +94,8 @@ public abstract class AdvancedAeExecutingCraftingJobTransactionAccessMixin
 
     @Override
     public void aco$loadExactState(
-            CompoundTag owner) {
+            CompoundTag owner,
+            HolderLookup.Provider registries) {
         if (!owner.contains(
                 ACO_EXACT_JOB_NBT,
                 Tag.TAG_COMPOUND)) {
@@ -102,13 +104,15 @@ public abstract class AdvancedAeExecutingCraftingJobTransactionAccessMixin
         }
         aco$exactState = ExactCraftingJobState.load(
                 owner.getCompound(ACO_EXACT_JOB_NBT),
-                ACOConfig.getBigIntegerMaximumBits());
+                ACOConfig.getBigIntegerMaximumBits(),
+                registries);
         aco$applyExactRuntimeCounters();
     }
 
     @Override
     public void aco$writeExactState(
-            CompoundTag owner) {
+            CompoundTag owner,
+            HolderLookup.Provider registries) {
         if (aco$exactState == null) {
             return;
         }
@@ -123,7 +127,8 @@ public abstract class AdvancedAeExecutingCraftingJobTransactionAccessMixin
         owner.put(
                 ACO_EXACT_JOB_NBT,
                 aco$exactState.save(
-                        ACOConfig.getBigIntegerMaximumBits()));
+                        ACOConfig.getBigIntegerMaximumBits(),
+                        registries));
     }
 
     @Override

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeMixinConfigPlugin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeMixinConfigPlugin.java
@@ -10,4 +10,9 @@ public final class AdvancedAeMixinConfigPlugin extends ModPresenceMixinConfigPlu
     protected String dependencyId() {
         return "advanced_ae";
     }
+
+    @Override
+    protected String dependencyMarkerClass() {
+        return "net.pedroksl.advanced_ae.common.cluster.AdvCraftingCPUCluster";
+    }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/Ae2ExactCraftingLogicMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/Ae2ExactCraftingLogicMixin.java
@@ -70,7 +70,9 @@ public abstract class Ae2ExactCraftingLogicMixin implements ExactCraftingLogicAc
             return;
         }
         CompoundTag jobTag = owner.getCompound("job");
-        exact.aco$writeExactState(jobTag);
+        exact.aco$writeExactState(
+                jobTag,
+                registries);
         owner.put("job", jobTag);
     }
 
@@ -82,7 +84,9 @@ public abstract class Ae2ExactCraftingLogicMixin implements ExactCraftingLogicAc
         if (!(job instanceof ExactCraftingJobAccess exact)) {
             return;
         }
-        exact.aco$loadExactState(owner.getCompound("job"));
+        exact.aco$loadExactState(
+                owner.getCompound("job"),
+                registries);
         // 保存済みexact Jobだけを再登録し、通常Jobのtick経路を増やさない。
         if (exact.aco$isExactJob()) {
             Ae2BigCraftingExecutionManager.register(cluster);

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/ExecutingCraftingJobTransactionAccessMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/ExecutingCraftingJobTransactionAccessMixin.java
@@ -19,6 +19,7 @@ import java.math.BigInteger;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import org.spongepowered.asm.mixin.Final;
@@ -86,7 +87,9 @@ public abstract class ExecutingCraftingJobTransactionAccessMixin
     }
 
     @Override
-    public void aco$loadExactState(CompoundTag owner) {
+    public void aco$loadExactState(
+            CompoundTag owner,
+            HolderLookup.Provider registries) {
         // exactタグが無い通常JobはSidecarを作らず、AE2本来のlong会計だけを使う。
         if (!owner.contains(ACO_EXACT_JOB_NBT, Tag.TAG_COMPOUND)) {
             aco$exactState = null;
@@ -94,12 +97,15 @@ public abstract class ExecutingCraftingJobTransactionAccessMixin
         }
         aco$exactState = ExactCraftingJobState.load(
                 owner.getCompound(ACO_EXACT_JOB_NBT),
-                ACOConfig.getBigIntegerMaximumBits());
+                ACOConfig.getBigIntegerMaximumBits(),
+                registries);
         aco$applyExactRuntimeCounters();
     }
 
     @Override
-    public void aco$writeExactState(CompoundTag owner) {
+    public void aco$writeExactState(
+            CompoundTag owner,
+            HolderLookup.Provider registries) {
         if (aco$exactState == null) {
             return;
         }
@@ -110,7 +116,9 @@ public abstract class ExecutingCraftingJobTransactionAccessMixin
                 aco$getExactRemainingOutput());
         owner.put(
                 ACO_EXACT_JOB_NBT,
-                aco$exactState.save(ACOConfig.getBigIntegerMaximumBits()));
+                aco$exactState.save(
+                        ACOConfig.getBigIntegerMaximumBits(),
+                        registries));
     }
 
     @Override

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/ModPresenceMixinConfigPlugin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/ModPresenceMixinConfigPlugin.java
@@ -1,6 +1,7 @@
 package com.syaru.ae2craftingoptimizer.mixin;
 
 import com.syaru.ae2craftingoptimizer.integration.MixinTransformationReport;
+import java.net.URL;
 import java.util.List;
 import java.util.Set;
 import net.neoforged.fml.ModList;
@@ -14,6 +15,11 @@ public abstract class ModPresenceMixinConfigPlugin implements IMixinConfigPlugin
 
     protected abstract String dependencyId();
 
+    /** Mixin選択時にModListより先に確認できる、任意連携先の実クラス。 */
+    protected String dependencyMarkerClass() {
+        return "";
+    }
+
     @Override
     public void onLoad(String mixinPackage) {
     }
@@ -25,15 +31,17 @@ public abstract class ModPresenceMixinConfigPlugin implements IMixinConfigPlugin
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
-        boolean loaded;
-        String version;
-        try {
-            var container = ModList.get().getModContainerById(dependencyId());
-            loaded = container.isPresent();
-            version = container.map(value -> value.getModInfo().getVersion().toString()).orElse("absent");
-        } catch (RuntimeException failure) {
-            loaded = false;
-            version = "unknown";
+        String markerClass = dependencyMarkerClass();
+        boolean loaded = markerClass.isBlank()
+                ? isDependencyLoadedByModList()
+                : isClassResourcePresent(
+                        markerClass,
+                        Thread.currentThread().getContextClassLoader(),
+                        getClass().getClassLoader());
+        String version = dependencyVersion();
+        // Mixin初期化中はModListが未完成でも、実クラスが見つかった事実を診断へ残す。
+        if (loaded && "absent".equals(version)) {
+            version = "classpath-present";
         }
         MixinTransformationReport.record(
                 feature(),
@@ -44,6 +52,48 @@ public abstract class ModPresenceMixinConfigPlugin implements IMixinConfigPlugin
                 loaded,
                 true);
         return loaded;
+    }
+
+    private boolean isDependencyLoadedByModList() {
+        try {
+            return ModList.get()
+                    .getModContainerById(
+                            dependencyId())
+                    .isPresent();
+        } catch (RuntimeException failure) {
+            return false;
+        }
+    }
+
+    private String dependencyVersion() {
+        try {
+            return ModList.get()
+                    .getModContainerById(
+                            dependencyId())
+                    .map(value -> value.getModInfo().getVersion().toString())
+                    .orElse("absent");
+        } catch (RuntimeException failure) {
+            return "unknown";
+        }
+    }
+
+    public static boolean isClassResourcePresent(
+            String className,
+            ClassLoader... classLoaders) {
+        String resourceName = className.replace('.', '/') + ".class";
+        // Issue #120: ModList完成前でも、各候補ClassLoaderへ副作用なしで実クラスを照会する。
+        for (ClassLoader classLoader : classLoaders) {
+            // nullのContext ClassLoaderは候補から外し、次の実Loaderを確認する。
+            if (classLoader == null) {
+                continue;
+            }
+            URL resource = classLoader.getResource(resourceName);
+            // 一つでも対象class resourceがあれば、任意連携Mixinを選択する。
+            if (resource != null) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/Issues118To120RegressionTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/Issues118To120RegressionTest.java
@@ -1,0 +1,91 @@
+package com.syaru.ae2craftingoptimizer.integration;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.syaru.ae2craftingoptimizer.api.vector.ExactStorageMutationResult;
+import com.syaru.ae2craftingoptimizer.mixin.ModPresenceMixinConfigPlugin;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/** Issues #118から#120で判明した起動・保存・在庫変更回帰を固定する。 */
+class Issues118To120RegressionTest {
+    private static final Path JAVA = Path.of(
+            "src", "main", "java", "com", "syaru", "ae2craftingoptimizer");
+
+    @Test
+    void successfulMutationStillRequiresPositiveCommittedStock() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ExactStorageMutationResult.success(BigInteger.ZERO));
+    }
+
+    @Test
+    void emptyRecoveryIsNotRepresentedAsSuccessfulZeroMutation() {
+        String source = read(JAVA.resolve(Path.of(
+                "integration", "ExactNetworkStorageBridge.java")));
+        assertTrue(source.contains("recoverPendingInterruption"));
+        assertTrue(source.contains("return Optional.empty();"));
+        assertTrue(source.contains(
+                "exact storage recovery completed; retry after reconciliation"));
+        assertFalse(source.contains("ExactStorageMutationResult.success(BigInteger.ZERO)"));
+    }
+
+    @Test
+    void exactJobPersistenceUsesTheRegistryProviderFromAe2() {
+        String state = read(JAVA.resolve(Path.of(
+                "engine", "ExactCraftingJobState.java")));
+        String ae2Mixin = read(JAVA.resolve(Path.of(
+                "mixin", "Ae2ExactCraftingLogicMixin.java")));
+        String advancedAeMixin = read(JAVA.resolve(Path.of(
+                "mixin", "AdvancedAeExactCraftingLogicMixin.java")));
+        assertTrue(state.contains("HolderLookup.Provider registries"));
+        assertFalse(state.contains("ACORegistryAccess.require()"));
+        assertTrue(ae2Mixin.contains("jobTag,\n                registries"));
+        assertTrue(advancedAeMixin.contains("jobTag,\n                registries"));
+    }
+
+    @Test
+    void registryProviderIsClearedOnlyAfterServerStopped() {
+        String lifecycle = read(JAVA.resolve(Path.of(
+                "lifecycle", "ACOServerLifecycle.java")));
+        int stopping = lifecycle.indexOf("private static void onServerStopping");
+        int stopped = lifecycle.indexOf("private static void onServerStopped");
+        int clear = lifecycle.indexOf("ACORegistryAccess.clear()");
+        assertTrue(stopping >= 0);
+        assertTrue(stopped > stopping);
+        assertTrue(clear > stopped);
+    }
+
+    @Test
+    void optionalMixinClassProbeWorksBeforeModListIsReady() {
+        ClassLoader loader = getClass().getClassLoader();
+        assertTrue(ModPresenceMixinConfigPlugin.isClassResourcePresent(
+                "com.syaru.ae2craftingoptimizer.integration.Issues118To120RegressionTest",
+                loader));
+        assertFalse(ModPresenceMixinConfigPlugin.isClassResourcePresent(
+                "missing.aco.DependencyMarker",
+                loader));
+    }
+
+    @Test
+    void advancedAePluginUsesARealClasspathMarker() {
+        String source = read(JAVA.resolve(Path.of(
+                "mixin", "AdvancedAeMixinConfigPlugin.java")));
+        assertTrue(source.contains(
+                "net.pedroksl.advanced_ae.common.cluster.AdvCraftingCPUCluster"));
+    }
+
+    private static String read(Path path) {
+        try {
+            return Files.readString(path);
+        } catch (IOException exception) {
+            throw new UncheckedIOException(path.toString(), exception);
+        }
+    }
+}


### PR DESCRIPTION
## 概要

取り下げたACO 1.5.23で報告されたIssue #118、#119、#120を修正します。
既存のexact会計、停止時永続化、Advanced AE連携の安全契約は緩和していません。

## 原因と修正

### Issue #118

- 空の復旧Journalを`success(0)`として返していたため、正数だけを許す実在庫変更結果が自己隔離していました。
- 復旧制御を実在庫変更結果から分離しました。
- 復旧を実施したtickは新しい変更を重ねず、次tickのbefore/after再照合を待ちます。
- `success(0)`禁止は維持します。

### Issue #119

- AE2の`writeToNBT`が渡すRegistry Providerを使わず、停止途中で破棄されるグローバルProviderへ取り直していました。
- exact Jobのsave/loadへAE2由来のProviderを明示的に渡します。
- グローバルProviderの破棄は`ServerStopped`まで遅らせます。
- Sidecar保存失敗を握り潰す処理は追加していません。

### Issue #120

- Mixin初期化中の未完成な`ModList`でAdvanced AEを未導入と誤判定していました。
- `AdvCraftingCPUCluster.class`のresourceを副作用なく確認してMixinを選択します。
- サーバー開始後のバージョン監査と必須InterfaceのFail-fastは維持します。

## 再発防止

- `docs/issues/ISSUE-118.md`
- `docs/issues/ISSUE-119.md`
- `docs/issues/ISSUE-120.md`
- `docs/REGRESSION_HISTORY.md`
- `Issues118To120RegressionTest`

## 検証

- `gradlew clean test --no-daemon`: 401件成功、失敗0件
- `gradlew clean build --no-daemon`: 成功
- `git diff --check`: 問題なし
- 起動テスト: ユーザー指示により未実施

Closes #118
Closes #119
Closes #120
