### PR TITLE
docs: 1.5.23再公開版の回帰修正履歴を確定

### DIFF
--- a/docs/REGRESSION_HISTORY.md
+++ b/docs/REGRESSION_HISTORY.md
@@ -14,9 +14,9 @@
 | [#93](https://github.com/syarukasu/ae2-crafting-optimizer/issues/93) | Java 25でBigInteger在庫Sidecarの可視コピー中にJVMが終了する | 1.5.18 | 1.5.20 | [ISSUE-93.md](issues/ISSUE-93.md) |
 | [#103](https://github.com/syarukasu/ae2-crafting-optimizer/issues/103) | wide計画の非同期compile競合と実行裏付け不足の誤診断 | 1.5.19 | 1.5.20 | [ISSUE-103.md](issues/ISSUE-103.md) |
 | [#109](https://github.com/syarukasu/ae2-crafting-optimizer/issues/109) | BigInteger API連携が通常AE2の責務境界を越える | 1.5.20 | 1.5.21 | [ISSUE-109.md](issues/ISSUE-109.md) |
-| [#118](https://github.com/syarukasu/ae2-crafting-optimizer/issues/118) | 正常な空Journalを成功量0として扱いexact物理実行が自己隔離する | 1.5.23 | 次回修正 | [ISSUE-118.md](issues/ISSUE-118.md) |
-| [#119](https://github.com/syarukasu/ae2-crafting-optimizer/issues/119) | 停止時にRegistry Providerを先に破棄しexact JobとBlock EntityのNBT保存が失敗する | 1.5.23 | 次回修正 | [ISSUE-119.md](issues/ISSUE-119.md) |
-| [#120](https://github.com/syarukasu/ae2-crafting-optimizer/issues/120) | Mixin初期化中のModList判定でAdvanced AE変換を自己無効化する | 1.5.23 | 次回修正 | [ISSUE-120.md](issues/ISSUE-120.md) |
+| [#118](https://github.com/syarukasu/ae2-crafting-optimizer/issues/118) | 正常な空Journalを成功量0として扱いexact物理実行が自己隔離する | 1.5.23初回Draft | 1.5.23再公開 | [ISSUE-118.md](issues/ISSUE-118.md) |
+| [#119](https://github.com/syarukasu/ae2-crafting-optimizer/issues/119) | 停止時にRegistry Providerを先に破棄しexact JobとBlock EntityのNBT保存が失敗する | 1.5.23初回Draft | 1.5.23再公開 | [ISSUE-119.md](issues/ISSUE-119.md) |
+| [#120](https://github.com/syarukasu/ae2-crafting-optimizer/issues/120) | Mixin初期化中のModList判定でAdvanced AE変換を自己無効化する | 1.5.23初回Draft | 1.5.23再公開 | [ISSUE-120.md](issues/ISSUE-120.md) |
 
 ## 運用
 

--- a/docs/issues/ISSUE-118.md
+++ b/docs/issues/ISSUE-118.md
@@ -1,7 +1,8 @@
 # Issue #118: exact在庫変更が正常な空Journalで自己隔離する
 
 - GitHub Issue: https://github.com/syarukasu/ae2-crafting-optimizer/issues/118
-- 状態: Implemented
+- 状態: Verified
+- 修正版: ACO 1.5.23再公開ビルド
 - 影響版: ACO 1.5.23
 - 対象ローダー: Forge 1.20.1 / NeoForge 1.21.1
 

--- a/docs/issues/ISSUE-119.md
+++ b/docs/issues/ISSUE-119.md
@@ -1,7 +1,8 @@
 # Issue #119: 停止時のexact Job保存がRegistry Provider消失で失敗する
 
 - GitHub Issue: https://github.com/syarukasu/ae2-crafting-optimizer/issues/119
-- 状態: Implemented
+- 状態: Verified
+- 修正版: ACO 1.5.23再公開ビルド
 - 影響版: ACO 1.5.23
 - 対象ローダー: Forge 1.20.1 / NeoForge 1.21.1
 

--- a/docs/issues/ISSUE-120.md
+++ b/docs/issues/ISSUE-120.md
@@ -1,7 +1,8 @@
 # Issue #120: Advanced AE Mixinが自分で無効化され監査だけが失敗する
 
 - GitHub Issue: https://github.com/syarukasu/ae2-crafting-optimizer/issues/120
-- 状態: Implemented
+- 状態: Verified
+- 修正版: ACO 1.5.23再公開ビルド
 - 影響版: ACO 1.5.23
 - 対象ローダー: NeoForge 1.21.1
 - 対象依存: Advanced AE 1.6.x


### PR DESCRIPTION
## 概要

PR #121で修正済みのIssue #118、#119、#120について、取り下げ中の1.5.23を
修正版として再公開する前に回帰履歴を確定します。

## 変更

- 三つのIssue仕様書を`Verified`へ更新
- 修正版を`ACO 1.5.23再公開ビルド`と明記
- 回帰履歴で初回Draftと再公開版を区別

コードおよびゲーム挙動の変更はありません。

## 検証

- `git diff --check`: 問題なし
- PR #121のJUnit 401件とCI 2系統は成功済み
- 起動テストはユーザー指示により未実施
