### PR TITLE
fix: log standard AE2 exact-job wait reasons (Forge 1.20.1)

### DIFF
--- a/docs/CLASS_RESPONSIBILITIES.md
+++ b/docs/CLASS_RESPONSIBILITIES.md
@@ -352,6 +352,7 @@ mixin + access  ->  integration  ->  optimization / scheduler
 | `com.syaru.ae2craftingoptimizer.engine.craftingtable.ExactCountMap` | 正のBigInteger数量Mapの検証、順序付き複製、包含判定、exact加算を行う副作用なし共通部品。 |
 | `com.syaru.ae2craftingoptimizer.engine.craftingtable.ExactCraftingEscrow` | 一注文が所有する境界素材、中間素材、最終成果物をBigIntegerのまま原子的に増減する。 |
 | `com.syaru.ae2craftingoptimizer.engine.craftingtable.ExactMutationReconciler` | 保存済みbefore/afterと現在値を照合し、まだ適用していないキーだけを返す。 |
+| `com.syaru.ae2craftingoptimizer.engine.craftingtable.CraftingTableBatchTargetResolver` | AE2のPattern Provider候補から、ACO汎用Batch Targetを解決し、未ロードと未登録を区別する。 |
 | `com.syaru.ae2craftingoptimizer.engine.craftingtable.PhysicalCraftingTreeTransaction` | 作業台ツリーの所有権移転後state machine。予約、Worker Receipt、取消、返却、隔離、NBT復元を統括する。 |
 
 ### `com.syaru.ae2craftingoptimizer.engine.vector`

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -143,6 +143,22 @@ persisted Neo ECO state; ordinary progress polling is direct lookup.
 
 ## Exact Storage Mutation
 
+### Issue #125 standard AE2 boundary
+
+ACO does not claim a plan merely because a BigInteger sidecar exists. A plan
+whose exact bytes, pattern counts, inventory counters, and output counters all
+fit in signed `long` is returned to AE2's original submission and execution
+path. A genuinely wide plan is claimed only when a generic
+`CraftingTableBatchTarget` can be resolved for every deterministic workbench
+step. If no such target exists, the job is closed before input ownership is
+taken and `SUBMISSION_BACKING_MISSING` is recorded; an unloaded target is
+retryable and is logged as such.
+
+The standard exact manager records the job, CPU, transaction, step, pattern,
+receipt, wait reason, budget, consumed operations, exact remaining operations,
+remaining physical steps, and exact final output remaining. The same wait
+reason is emitted on change and at most once per 600 ticks.
+
 `ExactNetworkStorageBridge` accesses only audited storage mounts whose complete
 quantity is available as `BigInteger`.
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
@@ -215,6 +215,7 @@ public final class ACOConfig {
     private static final ForgeConfigSpec.IntValue EXACT_VECTOR_MAXIMUM_ACTIVE_PER_GRID;
     private static final ForgeConfigSpec.IntValue EXACT_VECTOR_GRID_TIME_BUDGET_MILLIS;
     private static final ForgeConfigSpec.BooleanValue LOG_EXACT_VECTOR_DIAGNOSTICS;
+    private static final ForgeConfigSpec.BooleanValue LOG_EXACT_EXECUTION_STALLS;
 
     static {
         ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
@@ -939,8 +940,14 @@ public final class ACOConfig {
                         "Timing begins at the first Exact Vector operation, not at server tick START.")
                 .defineInRange("gridTimeBudgetMillis", 2, 1, 45);
         LOG_EXACT_VECTOR_DIAGNOSTICS = builder
-                .comment("Log bounded physical crafting-tree acceptance, recovery, and quarantine diagnostics.")
+                .comment(
+                        "Log bounded physical crafting-tree acceptance, recovery, and quarantine diagnostics.")
                 .define("logVectorDiagnostics", false);
+        LOG_EXACT_EXECUTION_STALLS = builder
+                .comment(
+                        "Log the waiting reason when an owned exact job makes no progress.",
+                        "One line when the reason changes, then one line per 600 ticks per CPU.")
+                .define("logExecutionStalls", true);
         builder.pop();
 
         builder.push("diagnostics");
@@ -1850,6 +1857,10 @@ public final class ACOConfig {
     public static boolean logExactVectorDiagnostics() {
         return enableExactVectorCrafting()
                 && LOG_EXACT_VECTOR_DIAGNOSTICS.get();
+    }
+
+    public static boolean logExactExecutionStalls() {
+        return LOG_EXACT_EXECUTION_STALLS.get();
     }
 
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerCraftingPlan.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/BigIntegerCraftingPlan.java
@@ -114,6 +114,18 @@ public final class BigIntegerCraftingPlan implements WideCraftingPlan {
         return preparedRoot.reservedBytes();
     }
 
+    /**
+     * AE2標準のlong計算へ委譲できるかを、投影済み表示値ではなく正本で判定する。
+     *
+     * <p>ACOがwide専用実行を取得するのは、個別の数量またはCPU容量がsigned longを
+     * 超える場合だけである。ここがtrueの計画をACOが横取りすると、標準AE2が安全に
+     * 実行できる通常注文まで物理Target待ちのまま停止する。</p>
+     */
+    public boolean fitsStandardLongExecution() {
+        return exactBytes().compareTo(BigInteger.valueOf(Long.MAX_VALUE)) <= 0
+                && !containsWideCounter(exactPlan, exactPatternTimes);
+    }
+
     public BigCraftingPlan<AEKey> exactPlan() {
         return exactPlan;
     }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/CraftingTableBatchTargetResolver.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/CraftingTableBatchTargetResolver.java
@@ -1,0 +1,122 @@
+package com.syaru.ae2craftingoptimizer.engine.craftingtable;
+
+import appeng.api.crafting.IPatternDetails;
+import appeng.api.networking.crafting.ICraftingProvider;
+import appeng.me.service.CraftingService;
+import com.syaru.ae2craftingoptimizer.access.PatternProviderTransactionAccess;
+import com.syaru.ae2craftingoptimizer.api.batch.v2.ProviderOwnedPatternBatchTarget;
+import com.syaru.ae2craftingoptimizer.api.craftingtable.CraftingTableBatchTarget;
+import com.syaru.ae2craftingoptimizer.scheduler.PatternProviderRoutingCache;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+/**
+ * ACOの汎用CraftingTableBatchTargetをAE2 Pattern Providerから解決する正本。
+ *
+ * <p>特定アドオンのBlockEntityやmod IDを参照せず、Providerが公開する所有Targetまたは
+ * Provider接続方向だけを使う。これにより外部実装も同じAPIで利用できる。</p>
+ */
+public final class CraftingTableBatchTargetResolver {
+    private CraftingTableBatchTargetResolver() {
+    }
+
+    public static Resolution resolve(
+            CraftingService service,
+            IPatternDetails pattern,
+            Level level) {
+        Objects.requireNonNull(service, "service");
+        Objects.requireNonNull(pattern, "pattern");
+        Objects.requireNonNull(level, "level");
+        Map<Long, BlockEntity> targets = new LinkedHashMap<>();
+        boolean sawUnloadedTarget = false;
+        // AE2の世代付き候補だけを巡回し、同じProviderを毎tick全探索しない。
+        for (ICraftingProvider provider : PatternProviderRoutingCache.candidates(
+                service,
+                pattern)) {
+            // Provider自身が永続Targetを公開していれば、その契約を最優先で使う。
+            if (provider instanceof ProviderOwnedPatternBatchTarget owned) {
+                BlockEntity target = owned.aco$getProviderOwnedBatchTarget();
+                sawUnloadedTarget |= addLoadedOrKnownTarget(
+                        targets,
+                        target,
+                        level);
+            }
+            // 接続方向から解決できないProviderは、別の実装経路を持たないため除外する。
+            if (!(provider instanceof PatternProviderTransactionAccess access)) {
+                continue;
+            }
+            BlockEntity providerEntity = access.aco$getProviderBlockEntity();
+            // ProviderのBlockEntityが別ワールドまたは未生成なら、隣接Targetを推測しない。
+            if (providerEntity == null
+                    || providerEntity.getLevel() != level) {
+                continue;
+            }
+            // Providerが公開した接続方向の隣接BlockEntityだけをTarget候補にする。
+            for (Direction direction : access.aco$getProviderTargets()) {
+                BlockPos targetPosition = providerEntity.getBlockPos().relative(direction);
+                // 未ロードチャンクは強制ロードせず、次tickの再試行理由として残す。
+                if (!level.isLoaded(targetPosition)) {
+                    sawUnloadedTarget = true;
+                    continue;
+                }
+                BlockEntity target = level.getBlockEntity(targetPosition);
+                // ACOの汎用Target契約を実装しない隣接機械は、物理Batch先にしない。
+                if (target instanceof CraftingTableBatchTarget) {
+                    targets.putIfAbsent(targetPosition.asLong(), target);
+                }
+            }
+        }
+        return new Resolution(
+                List.copyOf(new ArrayList<>(targets.values())),
+                sawUnloadedTarget);
+    }
+
+    private static boolean addLoadedOrKnownTarget(
+            Map<Long, BlockEntity> targets,
+            BlockEntity target,
+            Level level) {
+        if (!(target instanceof CraftingTableBatchTarget)) {
+            return false;
+        }
+        BlockPos position = target.getBlockPos();
+        // 別LevelのTargetは現在Jobへ使えないため、未ロード扱いで永久再試行しない。
+        if (target.getLevel() != level) {
+            return false;
+        }
+        // 同じLevelの未ロードTargetだけは、次tickで復帰する一時待機として返す。
+        if (!level.isLoaded(position)) {
+            return true;
+        }
+        targets.putIfAbsent(position.asLong(), target);
+        return false;
+    }
+
+    public record Resolution(
+            List<BlockEntity> targets,
+            boolean sawUnloadedTarget) {
+        public Resolution {
+            targets = List.copyOf(Objects.requireNonNull(targets, "targets"));
+        }
+
+        public boolean ready() {
+            return !targets.isEmpty();
+        }
+
+        public String waitReason() {
+            if (ready()) {
+                return "";
+            }
+            if (sawUnloadedTarget) {
+                return "waiting for a loaded crafting-table batch target";
+            }
+            return "no generic CraftingTableBatchTarget is registered for the pattern";
+        }
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/PhysicalCraftingTreeTransaction.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/craftingtable/PhysicalCraftingTreeTransaction.java
@@ -2,13 +2,11 @@ package com.syaru.ae2craftingoptimizer.engine.craftingtable;
 
 import appeng.api.crafting.IPatternDetails;
 import appeng.api.networking.IGrid;
-import appeng.api.networking.crafting.ICraftingProvider;
 import appeng.api.networking.security.IActionSource;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
 import appeng.me.service.CraftingService;
 import com.syaru.ae2craftingoptimizer.api.batch.ExactPatternFormula;
-import com.syaru.ae2craftingoptimizer.api.batch.v2.ProviderOwnedPatternBatchTarget;
 import com.syaru.ae2craftingoptimizer.api.craftingtable.CraftingTableBatchMode;
 import com.syaru.ae2craftingoptimizer.api.craftingtable.CraftingTableBatchRequest;
 import com.syaru.ae2craftingoptimizer.api.craftingtable.CraftingTableBatchSnapshot;
@@ -20,7 +18,6 @@ import com.syaru.ae2craftingoptimizer.api.vector.ExactVectorStorageService;
 import com.syaru.ae2craftingoptimizer.api.vector.PreparedVectorBatch;
 import com.syaru.ae2craftingoptimizer.api.vector.PreparedVectorBatchCodec;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CompiledCraftingGraphCache;
-import com.syaru.ae2craftingoptimizer.scheduler.PatternProviderRoutingCache;
 import com.syaru.ae2craftingoptimizer.util.StableFingerprint;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -38,9 +35,9 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 /**
- * BigInteger親注文を、依存順に実行されるNeoECO作業台仕事として所有する正本状態。
+ * BigInteger親注文を、依存順に実行される汎用作業台Batch仕事として所有する正本状態。
  *
- * <p>InsaneAEの「一回だけ実assembleして係数を掛ける」方式と、NeoECOの
+ * <p>InsaneAEの「一回だけ実assembleして係数を掛ける」方式と、外部Targetの
  * Pattern Bus・Worker・Thread・電力・物理進捗を組み合わせる。各段の実出力は
  * 永続Escrowへ入った後でのみ次段の入力として使えるため、最終成果物を直接変換しない。</p>
  *
@@ -515,6 +512,38 @@ public final class PhysicalCraftingTreeTransaction {
         return state;
     }
 
+    /** Issue #125: 待機ログへ渡す現在Stepと正確な残り物理操作を一度に返す。 */
+    public ExecutionDiagnostics executionDiagnostics() {
+        int activeStep = -1;
+        String receiptState = "NONE";
+        BigInteger remainingOperations = BigInteger.ZERO;
+        // 注文数ではなく、まだ物理Receiptが終端へ到達していない固有Stepだけを集計する。
+        for (int index = 0; index < steps.size(); index++) {
+            StepReceipt receipt = steps.get(index);
+            if (receipt.state() == StepState.OUTPUT_OBSERVED
+                    || receipt.state() == StepState.OUTPUT_CREDITED
+                    || receipt.state() == StepState.ACKNOWLEDGED
+                    || receipt.state() == StepState.CANCELLED) {
+                continue;
+            }
+            if (activeStep < 0) {
+                activeStep = index;
+                receiptState = receipt.state().name();
+            }
+            remainingOperations = remainingOperations.add(
+                    plan.craftingSteps().get(index).executions());
+        }
+        String patternId = activeStep < 0
+                ? "NONE"
+                : plan.craftingSteps().get(activeStep).patternId();
+        return new ExecutionDiagnostics(
+                activeStep,
+                patternId,
+                receiptState,
+                remainingOperations,
+                activeStep < 0 ? 0 : steps.size() - activeStep);
+    }
+
     public int lastConsumedOperations() {
         return lastConsumedOperations;
     }
@@ -598,7 +627,7 @@ public final class PhysicalCraftingTreeTransaction {
                 finalOutputReturned);
     }
 
-    /** GUIへ渡す進捗は、実NeoECO Threadと完了済み物理段から求める。 */
+    /** GUIへ渡す進捗は、実BatchTargetの進捗と完了済み物理段から求める。 */
     public int progressNumerator() {
         int total =
                 progressDenominator();
@@ -817,7 +846,7 @@ public final class PhysicalCraftingTreeTransaction {
                 ? TickOutcome.changed()
                 : TickOutcome.waiting(
                         detail.isBlank()
-                                ? "waiting for recipe dependencies or NeoECO workers"
+                                ? "waiting for recipe dependencies or crafting-table workers"
                                 : detail);
     }
 
@@ -851,6 +880,7 @@ public final class PhysicalCraftingTreeTransaction {
             SelectedTarget selected =
                     selectTarget(
                             grid,
+                            level,
                             resolved.pattern(),
                             receipt.routeCursor(),
                             receipt.transactionId(),
@@ -858,7 +888,7 @@ public final class PhysicalCraftingTreeTransaction {
             // 現在利用できる実設備がない場合も、予約入力をEscrow外で保持して待つ。
             if (selected == null) {
                 detail =
-                        "waiting for a NeoECO crafting-table Pattern Bus";
+                        "waiting for a crafting-table batch target";
                 return StepAdvance.waiting();
             }
             receipt.selectTarget(
@@ -929,7 +959,7 @@ public final class PhysicalCraftingTreeTransaction {
              */
             receipt.retryAnotherTarget();
             detail =
-                    "all NeoECO crafting-table workers are busy";
+                    "crafting-table batch workers are busy";
             return StepAdvance.updated();
         }
 
@@ -947,12 +977,12 @@ public final class PhysicalCraftingTreeTransaction {
                         receipt.transactionId(),
                         receipt.payloadDigest())) {
                     detail =
-                            "waiting for NeoECO Thread snapshot";
+                            "waiting for a crafting-table batch snapshot";
                     return StepAdvance.waiting();
                 }
                 receipt.retryAnotherTarget();
                 detail =
-                        "NeoECO Thread was released before output";
+                        "crafting-table batch target was released before output";
                 return StepAdvance.updated();
             }
             CraftingTableBatchSnapshot physicalState =
@@ -977,7 +1007,7 @@ public final class PhysicalCraftingTreeTransaction {
                             .equals(
                                     resolved.expectedOutputs())) {
                         yield StepAdvance.quarantined(
-                                "NeoECO physical output differs from the compiled formula");
+                                "crafting-table physical output differs from the compiled formula");
                     }
                     receipt.observeOutput(
                             physicalState.exactOutputs(),
@@ -1003,7 +1033,7 @@ public final class PhysicalCraftingTreeTransaction {
                             .equals(
                                     resolved.expectedOutputs())) {
                         yield StepAdvance.quarantined(
-                                "NeoECO terminal receipt differs from the compiled formula");
+                                "crafting-table terminal receipt differs from the compiled formula");
                     }
                     receipt.observeOutput(
                             physicalState.exactOutputs(),
@@ -1079,7 +1109,7 @@ public final class PhysicalCraftingTreeTransaction {
                             .equals(
                                     resolved.expectedOutputs())) {
                 return StepAdvance.quarantined(
-                        "NeoECO terminal receipt changed after output accounting");
+                        "crafting-table terminal receipt changed after output accounting");
             }
             boolean forgotten =
                     target.aco$forgetCraftingTableBatch(
@@ -1098,7 +1128,7 @@ public final class PhysicalCraftingTreeTransaction {
                 return StepAdvance.updated();
             }
             detail =
-                    "waiting for NeoECO output acknowledgement";
+                    "waiting for crafting-table output acknowledgement";
             return StepAdvance.waiting();
         }
 
@@ -1210,7 +1240,7 @@ public final class PhysicalCraftingTreeTransaction {
             if (!level.isLoaded(
                     targetPosition)) {
                 detail =
-                        "cancellation waits for the NeoECO target to load";
+                        "cancellation waits for the crafting-table target to load";
                 continue;
             }
             BlockEntity targetEntity =
@@ -1288,7 +1318,7 @@ public final class PhysicalCraftingTreeTransaction {
                                 receipt.transactionId(),
                                 receipt.payloadDigest())) {
                     detail =
-                            "cancellation waits for the NeoECO Thread snapshot";
+                            "cancellation waits for the crafting-table batch snapshot";
                     continue;
                 }
                 // 所有を失った未完成仕事は、予約入力だけを正確に戻す。
@@ -1840,7 +1870,7 @@ public final class PhysicalCraftingTreeTransaction {
             case TARGET_SELECTED, ACCEPTED -> {
                 receipt.retryAnotherTarget();
                 detail =
-                        "physical target was removed; retrying on another NeoECO worker";
+                        "physical target was removed; retrying on another crafting-table worker";
                 yield StepAdvance.updated();
             }
             case OUTPUT_OBSERVED -> {
@@ -1945,6 +1975,7 @@ public final class PhysicalCraftingTreeTransaction {
 
     private static SelectedTarget selectTarget(
             IGrid grid,
+            Level level,
             IPatternDetails pattern,
             int routeCursor,
             UUID transactionId,
@@ -1954,36 +1985,16 @@ public final class PhysicalCraftingTreeTransaction {
                 instanceof CraftingService service)) {
             return null;
         }
-        Map<Long, BlockEntity> targets =
-                new LinkedHashMap<>();
-        // 同じPattern Busが重複Providerとして見えても位置ごとに一件へ畳み込む。
-        for (ICraftingProvider provider :
-                PatternProviderRoutingCache.candidates(
+        CraftingTableBatchTargetResolver.Resolution resolution =
+                CraftingTableBatchTargetResolver.resolve(
                         service,
-                        pattern)) {
-            // Pattern所有Providerではない候補を、物理Targetとして推測しない。
-            if (!(provider
-                    instanceof ProviderOwnedPatternBatchTarget owned)) {
-                continue;
-            }
-            BlockEntity target =
-                    owned.aco$getProviderOwnedBatchTarget();
-            // 永続化できるBlock EntityのTarget契約だけを候補にする。
-            if (target
-                    instanceof CraftingTableBatchTarget) {
-                targets.putIfAbsent(
-                        target.getBlockPos()
-                                .asLong(),
-                        target);
-            }
-        }
+                        pattern,
+                        level);
+        List<BlockEntity> ordered = resolution.targets();
         // 対応設備がない場合は、呼出側で入力予約を維持して待つ。
-        if (targets.isEmpty()) {
+        if (ordered.isEmpty()) {
             return null;
         }
-        List<BlockEntity> ordered =
-                List.copyOf(
-                        targets.values());
         /*
          * 親保存前にTargetだけが受理済みとなった停止復旧では、
          * 既存所有者を通常のラウンドロビン候補より優先する。
@@ -3070,7 +3081,7 @@ public final class PhysicalCraftingTreeTransaction {
                     || state == StepState.ACKNOWLEDGED) {
                 return PROGRESS_UNITS_PER_STEP;
             }
-            // 受理済みThreadだけNeoECO実進捗を割合換算する。
+            // 受理済みBatchだけ外部Targetの実進捗を割合換算する。
             if (state == StepState.ACCEPTED
                     && maximumProgress > 0) {
                 return Math.min(
@@ -3436,6 +3447,23 @@ public final class PhysicalCraftingTreeTransaction {
                     Objects.requireNonNull(
                             detail,
                             "detail"));
+        }
+    }
+
+    /** 物理実行の待機箇所を、表示用longへ丸めず診断する不変値。 */
+    public record ExecutionDiagnostics(
+            int activeStep,
+            String patternId,
+            String receiptState,
+            BigInteger remainingOperations,
+            int remainingPhysicalSteps) {
+        public ExecutionDiagnostics {
+            Objects.requireNonNull(patternId, "patternId");
+            Objects.requireNonNull(receiptState, "receiptState");
+            Objects.requireNonNull(remainingOperations, "remainingOperations");
+            if (remainingOperations.signum() < 0 || remainingPhysicalSteps < 0) {
+                throw new IllegalArgumentException("execution diagnostics must be non-negative");
+            }
         }
     }
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/Ae2BigCraftingExecutionManager.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/Ae2BigCraftingExecutionManager.java
@@ -2,7 +2,6 @@ package com.syaru.ae2craftingoptimizer.integration;
 
 import appeng.api.crafting.IPatternDetails;
 import appeng.api.networking.IGrid;
-import appeng.api.networking.crafting.ICraftingProvider;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.GenericStack;
@@ -14,8 +13,6 @@ import com.syaru.ae2craftingoptimizer.access.CraftingLogicTransactionAccess;
 import com.syaru.ae2craftingoptimizer.access.ExactCraftingJobAccess;
 import com.syaru.ae2craftingoptimizer.access.ExactCraftingLogicAccess;
 import com.syaru.ae2craftingoptimizer.api.batch.ExactPatternFormula;
-import com.syaru.ae2craftingoptimizer.api.batch.v2.ProviderOwnedPatternBatchTarget;
-import com.syaru.ae2craftingoptimizer.api.craftingtable.CraftingTableBatchTarget;
 import com.syaru.ae2craftingoptimizer.api.vector.ExactVectorDiagnostics;
 import com.syaru.ae2craftingoptimizer.api.vector.PreparedVectorBatch;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
@@ -27,19 +24,21 @@ import com.syaru.ae2craftingoptimizer.engine.ExactCraftingJobState;
 import com.syaru.ae2craftingoptimizer.engine.PlanningRuntimeEpoch;
 import com.syaru.ae2craftingoptimizer.engine.RecipeGenerationTracker;
 import com.syaru.ae2craftingoptimizer.engine.craftingtable.PhysicalCraftingTreeTransaction;
+import com.syaru.ae2craftingoptimizer.engine.craftingtable.CraftingTableBatchTargetResolver;
 import com.syaru.ae2craftingoptimizer.engine.vector.VectorBatchPlanValidator;
+import com.syaru.ae2craftingoptimizer.optimization.BigIntegerPlanDeclineReason;
+import com.syaru.ae2craftingoptimizer.optimization.BigIntegerPlanDiagnostics;
 import com.syaru.ae2craftingoptimizer.engine.vector.VectorBatchPlanner;
 import com.syaru.ae2craftingoptimizer.optimization.ProviderPatternGenerationTracker;
-import com.syaru.ae2craftingoptimizer.scheduler.PatternProviderRoutingCache;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.world.level.block.entity.BlockEntity;
 
 /**
  * Issue #115: 標準AE2 CraftingCPUCluster上のexact Jobを物理Receipt経路で進める。
@@ -168,6 +167,10 @@ public final class Ae2BigCraftingExecutionManager {
             try {
                 restoreOrStart(context, grid, graphSnapshot);
             } catch (PhysicalCraftingTreeTransaction.PatternUnavailableException deferred) {
+                reportWaitingReason(
+                        context,
+                        "waiting for an unloaded pattern provider: " + deferred.getMessage(),
+                        0);
                 return true;
             } catch (RuntimeException | LinkageError failure) {
                 if (!state.hasPhysicalExecution()) {
@@ -183,6 +186,10 @@ public final class Ae2BigCraftingExecutionManager {
             }
             // WorkerやConfig待ちではまだ物理所有権がないため、同じJobをそのまま維持する。
             if (transaction == null) {
+                reportWaitingReason(
+                        context,
+                        "physical execution has not started",
+                        0);
                 return true;
             }
             if (state.cancellationRequested()) {
@@ -285,14 +292,25 @@ public final class Ae2BigCraftingExecutionManager {
             lastReportedWaitingJobId = jobId;
             lastReportedWaitingReason = reason;
             waitingTicksSinceLog = 0;
+            PhysicalCraftingTreeTransaction.ExecutionDiagnostics diagnostics = transaction == null
+                    ? null
+                    : transaction.executionDiagnostics();
+            BigInteger exactRemaining = context.exactJob().aco$getExactRemainingOutput();
             AE2CraftingOptimizer.LOGGER.info(
-                    "ACO standard AE2 exact job waiting: jobId={}, transactionId={}, state={}, reason={}, operationBudget={}, consumedOperations={}",
+                    "ACO standard AE2 exact job waiting: jobId={}, cpu={}, transactionId={}, state={}, stepId={}, patternId={}, receiptState={}, reason={}, operationBudget={}, consumedOperations={}, remainingOperations={}, remainingPhysicalSteps={}, finalOutputRemaining={}",
                     jobId,
-                    transaction.transactionId(),
-                    transaction.state(),
+                    stableKey(),
+                    transaction == null ? "not-started" : transaction.transactionId(),
+                    transaction == null ? "NOT_STARTED" : transaction.state(),
+                    diagnostics == null ? "not-started" : diagnostics.activeStep(),
+                    diagnostics == null ? "not-started" : diagnostics.patternId(),
+                    diagnostics == null ? "NONE" : diagnostics.receiptState(),
                     reason,
                     operationBudget,
-                    transaction.lastConsumedOperations());
+                    transaction == null ? 0 : transaction.lastConsumedOperations(),
+                    diagnostics == null ? "unknown" : diagnostics.remainingOperations(),
+                    diagnostics == null ? "unknown" : diagnostics.remainingPhysicalSteps(),
+                    exactRemaining);
         }
 
         private void clearWaitingReport() {
@@ -340,6 +358,11 @@ public final class Ae2BigCraftingExecutionManager {
             }
             /* Issue #115: 新規開始が無効でも、開始済みTransactionの復元・取消は上で継続する。 */
             if (!ACOConfig.enableExactBigIntegerPhysicalExecution()) {
+                reportWaitingReason(
+                        context,
+                        "exact physical execution is disabled by config",
+                        0);
+                finish(context, false);
                 return;
             }
             // 入力所有権取得前の世代不一致だけは、同じAE2 Jobを通常取消経路で閉じられる。
@@ -348,7 +371,25 @@ public final class Ae2BigCraftingExecutionManager {
                 return;
             }
             PreparedVectorBatch plan = prepare(context.jobId(), context.state(), graphSnapshot);
-            if (!supportsPhysicalPlan(grid, graphSnapshot, plan)) {
+            PhysicalPlanSupport support = physicalPlanSupport(grid, graphSnapshot, plan);
+            if (!support.ready()) {
+                reportWaitingReason(context, support.reason(), 0);
+                if (support.retryable()) {
+                    return;
+                }
+                BigIntegerPlanDiagnostics.record(
+                        BigIntegerPlanDeclineReason.SUBMISSION_BACKING_MISSING,
+                        context.state().requestedKey().getId().toString(),
+                        context.state().requestedAmount(),
+                        context.state().patternGeneration(),
+                        context.state().recipeGeneration(),
+                        support.reason());
+                AE2CraftingOptimizer.LOGGER.warn(
+                        "Declined standard AE2 exact job before physical ownership: jobId={}, cpu={}, reason={}",
+                        context.jobId(),
+                        stableKey(),
+                        support.reason());
+                finish(context, false);
                 return;
             }
             ExactVectorGridTickBudget startBudget = ExactVectorGridTickBudget.forGrid(grid);
@@ -414,12 +455,13 @@ public final class Ae2BigCraftingExecutionManager {
             return plan;
         }
 
-        private boolean supportsPhysicalPlan(
+        private PhysicalPlanSupport physicalPlanSupport(
                 IGrid grid,
                 Ae2CompiledCraftingGraphCache.Snapshot snapshot,
                 PreparedVectorBatch plan) {
             if (!(grid.getCraftingService() instanceof CraftingService service)) {
-                return false;
+                return PhysicalPlanSupport.unsupported(
+                        "AE2 CraftingService is unavailable for exact physical execution");
             }
             // 全固有Patternについて、決定的作業台式と永続物理Targetを開始前に証明する。
             for (var step : plan.craftingSteps()) {
@@ -430,27 +472,22 @@ public final class Ae2BigCraftingExecutionManager {
                                         cluster.getLevel(),
                                         step.selectedInputs())
                                 .isEmpty()) {
-                    return false;
+                    return PhysicalPlanSupport.unsupported(
+                            "pattern has no deterministic crafting-table formula: "
+                                    + step.patternId());
                 }
-                boolean found = false;
-                // このPatternを所有するProvider候補だけを一巡する。
-                for (ICraftingProvider provider : PatternProviderRoutingCache.candidates(
+                CraftingTableBatchTargetResolver.Resolution resolution =
+                        CraftingTableBatchTargetResolver.resolve(
                         service,
-                        pattern)) {
-                    if (!(provider instanceof ProviderOwnedPatternBatchTarget owned)) {
-                        continue;
-                    }
-                    BlockEntity target = owned.aco$getProviderOwnedBatchTarget();
-                    if (target instanceof CraftingTableBatchTarget) {
-                        found = true;
-                        break;
-                    }
-                }
-                if (!found) {
-                    return false;
+                        pattern,
+                        cluster.getLevel());
+                if (!resolution.ready()) {
+                    return resolution.sawUnloadedTarget()
+                            ? PhysicalPlanSupport.retryable(resolution.waitReason())
+                            : PhysicalPlanSupport.unsupported(resolution.waitReason());
                 }
             }
-            return true;
+            return PhysicalPlanSupport.available();
         }
 
         private void validate(
@@ -558,6 +595,27 @@ public final class Ae2BigCraftingExecutionManager {
             transaction = null;
             transactionJobId = null;
             lastExactJob = null;
+        }
+
+        private record PhysicalPlanSupport(
+                boolean ready,
+                boolean retryable,
+                String reason) {
+            private PhysicalPlanSupport {
+                Objects.requireNonNull(reason, "reason");
+            }
+
+            private static PhysicalPlanSupport available() {
+                return new PhysicalPlanSupport(true, false, "");
+            }
+
+            private static PhysicalPlanSupport retryable(String reason) {
+                return new PhysicalPlanSupport(false, true, reason);
+            }
+
+            private static PhysicalPlanSupport unsupported(String reason) {
+                return new PhysicalPlanSupport(false, false, reason);
+            }
         }
     }
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/Ae2BigCraftingExecutionManager.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/Ae2BigCraftingExecutionManager.java
@@ -121,6 +121,12 @@ public final class Ae2BigCraftingExecutionManager {
         private PhysicalCraftingTreeTransaction transaction;
         private UUID transactionJobId;
         private ExactCraftingJobAccess lastExactJob;
+        /** 直前にログへ出した待機理由のジョブ。理由が変わるまで同じ行を繰り返さない。 */
+        private UUID lastReportedWaitingJobId;
+        /** 直前にログへ出した待機理由。状態変化の境界だけを診断ログへ出す。 */
+        private String lastReportedWaitingReason;
+        /** 同じ待機理由を再通知するまでのサーバーtick数。1 tick = 50 ms。 */
+        private int waitingTicksSinceLog;
 
         private Controller(CraftingCPUCluster cluster) {
             this.cluster = cluster;
@@ -186,6 +192,10 @@ public final class Ae2BigCraftingExecutionManager {
                     grid,
                     Math.max(1, transaction.plan().craftingSteps().size()));
             if (operationBudget == 0) {
+                reportWaitingReason(
+                        context,
+                        "waiting for the exact physical execution tick budget",
+                        operationBudget);
                 return true;
             }
             long startedNanos = System.nanoTime();
@@ -204,6 +214,10 @@ public final class Ae2BigCraftingExecutionManager {
                         transaction.lastConsumedOperations());
             }
             ExactVectorDiagnostics.activeTick(System.nanoTime() - startedNanos);
+            reportWaitingOutcome(
+                    context,
+                    outcome,
+                    operationBudget);
             /*
              * Forge 1.20.1のTransactionにはrevision診断がないため、実行tickごとに
              * Receipt会計と復旧NBTを同期する。Issue #115のexact Jobだけがこの経路へ入る。
@@ -229,6 +243,62 @@ public final class Ae2BigCraftingExecutionManager {
                 quarantine(outcome.detail(), null);
             }
             return true;
+        }
+
+        /**
+         * 標準AE2 CPUの物理Transactionが待機した理由を、理由の変化ごとに一度だけ記録する。
+         * 同一理由を毎tick出さないため、サーバーログを待機状態の証拠として使える。
+         */
+        private void reportWaitingOutcome(
+                Context context,
+                PhysicalCraftingTreeTransaction.TickOutcome outcome,
+                int operationBudget) {
+            if (outcome.kind() != PhysicalCraftingTreeTransaction.Kind.WAITING) {
+                clearWaitingReport();
+                return;
+            }
+            reportWaitingReason(context, outcome.detail(), operationBudget);
+        }
+
+        /**
+         * Issue #125: 標準AE2 CPUが進めない区間の理由を、状態変化ごとに診断ログへ出す。
+         * 同じ理由が続く場合は600 tickごとに一度だけ再通知し、ログスパムを避ける。
+         */
+        private void reportWaitingReason(
+                Context context,
+                String rawReason,
+                int operationBudget) {
+            if (!ACOConfig.logExactExecutionStalls()) {
+                return;
+            }
+            UUID jobId = context.jobId();
+            String reason = rawReason == null || rawReason.isBlank()
+                    ? "waiting reason was not provided"
+                    : rawReason;
+            boolean changedReason = !jobId.equals(lastReportedWaitingJobId)
+                    || !reason.equals(lastReportedWaitingReason);
+            waitingTicksSinceLog++;
+            // 同じジョブ・同じ理由の連続tickは抑制し、状態変化または600 tickごとに記録する。
+            if (!changedReason && waitingTicksSinceLog < 600) {
+                return;
+            }
+            lastReportedWaitingJobId = jobId;
+            lastReportedWaitingReason = reason;
+            waitingTicksSinceLog = 0;
+            AE2CraftingOptimizer.LOGGER.info(
+                    "ACO standard AE2 exact job waiting: jobId={}, transactionId={}, state={}, reason={}, operationBudget={}, consumedOperations={}",
+                    jobId,
+                    transaction.transactionId(),
+                    transaction.state(),
+                    reason,
+                    operationBudget,
+                    transaction.lastConsumedOperations());
+        }
+
+        private void clearWaitingReport() {
+            lastReportedWaitingJobId = null;
+            lastReportedWaitingReason = null;
+            waitingTicksSinceLog = 0;
         }
 
         private Context context() {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/Ae2BigCapacityPlanSubmissionMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/Ae2BigCapacityPlanSubmissionMixin.java
@@ -57,8 +57,8 @@ public abstract class Ae2BigCapacityPlanSubmissionMixin {
             CallbackInfoReturnable<ICraftingSubmitResult> cir) {
         ACO_SUBMISSION.remove();
         BigIntegerCraftingPlan exact = Ae2CraftingPlanSidecars.bigInteger(plan).orElse(null);
-        // 通常long計画と合計容量だけwideな計画は、AE2本来の提出経路へ完全に委譲する。
-        if (exact == null) {
+        // 通常long計画は、ACOが物理Targetを要求せずAE2本来の提出経路へ完全に委譲する。
+        if (exact == null || exact.fitsStandardLongExecution()) {
             return;
         }
         // 自動要求のExact最終出力転送は未対応なので、手動注文だけを対象にする。

--- a/src/test/java/com/syaru/ae2craftingoptimizer/issue125/Issue125RegressionSourceTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/issue125/Issue125RegressionSourceTest.java
@@ -1,0 +1,68 @@
+package com.syaru.ae2craftingoptimizer.issue125;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/** Issue #125の「標準long経路の回帰」と「wideの無言待機」をソース契約で固定する。 */
+class Issue125RegressionSourceTest {
+    private static final Path ROOT = Path.of("src", "main", "java");
+
+    @Test
+    void standardLongPlansAreReturnedToAe2BeforeAcoOwnership() {
+        String source = read("com/syaru/ae2craftingoptimizer/mixin/Ae2BigCapacityPlanSubmissionMixin.java");
+
+        assertTrue(source.contains("exact == null || exact.fitsStandardLongExecution()"));
+        assertTrue(source.contains("return;"));
+    }
+
+    @Test
+    void unsupportedWidePlansAreClosedInsteadOfBeingHeldForever() {
+        String source = read(
+                "com/syaru/ae2craftingoptimizer/integration/Ae2BigCraftingExecutionManager.java");
+
+        assertTrue(source.contains("PhysicalPlanSupport"));
+        assertTrue(source.contains("SUBMISSION_BACKING_MISSING"));
+        assertTrue(source.contains("finish(context, false)"));
+        assertFalse(source.contains("if (!supportsPhysicalPlan(grid, graphSnapshot, plan))"));
+    }
+
+    @Test
+    void stallDiagnosticsCarryExactExecutionState() {
+        String manager = read(
+                "com/syaru/ae2craftingoptimizer/integration/Ae2BigCraftingExecutionManager.java");
+        String transaction = read(
+                "com/syaru/ae2craftingoptimizer/engine/craftingtable/PhysicalCraftingTreeTransaction.java");
+
+        assertTrue(manager.contains("remainingOperations"));
+        assertTrue(manager.contains("remainingPhysicalSteps"));
+        assertTrue(manager.contains("finalOutputRemaining"));
+        assertTrue(transaction.contains("ExecutionDiagnostics"));
+        assertTrue(transaction.contains("CraftingTableBatchTargetResolver"));
+        assertFalse(transaction.contains("waiting for a NeoECO crafting-table Pattern Bus"));
+    }
+
+    @Test
+    void targetResolutionUsesOnlyTheGenericAcoContract() {
+        String source = read(
+                "com/syaru/ae2craftingoptimizer/engine/craftingtable/CraftingTableBatchTargetResolver.java");
+
+        assertTrue(source.contains("CraftingTableBatchTarget"));
+        assertTrue(source.contains("PatternProviderTransactionAccess"));
+        assertTrue(source.contains("ProviderOwnedPatternBatchTarget"));
+        assertFalse(source.contains("NeoECO"));
+    }
+
+    private static String read(String relativePath) {
+        try {
+            return Files.readString(ROOT.resolve(relativePath));
+        } catch (IOException exception) {
+            throw new UncheckedIOException(relativePath, exception);
+        }
+    }
+}


### PR DESCRIPTION
## 概要

Issue #125の標準AE2 CPUで、BigInteger作業台クラフトが受理後に完成品0個のまま無言で停止する問題を修正します。

## 原因

ACOがBigInteger sidecarを持つだけのlong安全な計画までexact経路へ寄せる余地があり、標準AE2の計算・実行経路を不必要に抑止していました。さらにwide計画で汎用の物理`CraftingTableBatchTarget`が存在しない場合、入力所有権取得後に実行先がないまま待ち続ける経路がありました。

## 変更内容

- `BigIntegerCraftingPlan.fitsStandardLongExecution()`を追加し、完全なBigInteger値でlong安全性を判定。
- long安全な計画は標準AE2へ委譲し、long超過計画だけをACOのwide経路で扱う。
- `CraftingTableBatchTargetResolver`を追加し、NeoECO固有名や固有BlockEntityに依存せず、Pattern Provider隣接の汎用targetを解決。
- wide計画にtargetがない場合は入力所有権取得前に辞退。未ロードtargetだけ再試行。
- 標準AE2 exact jobの待機理由にjobId、CPU、transactionId、step/pattern、state、receipt、operation budget、consumed、remaining、exact output残量を追加。
- 同一待機理由は抑制し、理由変更時と600 tickごとに記録。
- Issue #125の責務表、実装資料、ソース回帰テストを追加。

## 検証

- `.\gradlew.bat test --no-daemon`: 成功、397 tests。
- `.\gradlew.bat check --no-daemon`: 成功。
- `.\gradlew.bat clean build --no-daemon`: 成功。
- `git diff --check`: 成功。
- クライアント、専用サーバー、GameTestの実行は今回の指示どおり未実施。

Refs #125
