### PR TITLE
fix(mixin): 任意連携 Mixin を対象クラスの実在で選択する (ExtendedAE Plus で全クラフトが落ちる)

### DIFF
--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/ModPresenceMixinConfigPlugin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/ModPresenceMixinConfigPlugin.java
@@ -31,14 +31,26 @@ public abstract class ModPresenceMixinConfigPlugin implements IMixinConfigPlugin
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
-        String markerClass = dependencyMarkerClass();
-        boolean loaded = markerClass.isBlank()
-                ? isDependencyLoadedByModList()
-                : isClassResourcePresent(
-                        markerClass,
-                        Thread.currentThread().getContextClassLoader(),
-                        getClass().getClassLoader());
+        ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader ownLoader = getClass().getClassLoader();
+        boolean loaded = isDependencyLoadedByModList();
         String version = dependencyVersion();
+
+        String markerClass = dependencyMarkerClass();
+        // ModListが未完成な段階では、連携先の実クラスで在否を判定する。
+        if (!loaded && !markerClass.isBlank()) {
+            loaded = isClassResourcePresent(markerClass, contextLoader, ownLoader);
+        }
+        /*
+         * Issue #120の続き: markerClassを持たない連携は、ModListが未完成なまま
+         * shouldApplyMixinへ来ると一律applied=falseになり、連携Mixinが黙って
+         * 全て外れる。この@Pseudo Mixin自身の対象クラスが実在するかどうかは
+         * ModListに依存せず確認でき、対象が無ければ適用しても何も起きないため、
+         * 最後の判定材料として使う。
+         */
+        if (!loaded) {
+            loaded = isClassResourcePresent(targetClassName, contextLoader, ownLoader);
+        }
         // Mixin初期化中はModListが未完成でも、実クラスが見つかった事実を診断へ残す。
         if (loaded && "absent".equals(version)) {
             version = "classpath-present";
@@ -60,7 +72,7 @@ public abstract class ModPresenceMixinConfigPlugin implements IMixinConfigPlugin
                     .getModContainerById(
                             dependencyId())
                     .isPresent();
-        } catch (RuntimeException failure) {
+        } catch (RuntimeException | LinkageError failure) {
             return false;
         }
     }
@@ -72,7 +84,7 @@ public abstract class ModPresenceMixinConfigPlugin implements IMixinConfigPlugin
                             dependencyId())
                     .map(value -> value.getModInfo().getVersion().toString())
                     .orElse("absent");
-        } catch (RuntimeException failure) {
+        } catch (RuntimeException | LinkageError failure) {
             return "unknown";
         }
     }

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/Issues118To120RegressionTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/Issues118To120RegressionTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.syaru.ae2craftingoptimizer.api.vector.ExactStorageMutationResult;
+import com.syaru.ae2craftingoptimizer.mixin.ExtendedAeMixinConfigPlugin;
 import com.syaru.ae2craftingoptimizer.mixin.ModPresenceMixinConfigPlugin;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -71,6 +72,24 @@ class Issues118To120RegressionTest {
         assertFalse(ModPresenceMixinConfigPlugin.isClassResourcePresent(
                 "missing.aco.DependencyMarker",
                 loader));
+    }
+
+    @Test
+    void optionalIntegrationAppliesWhenOnlyItsTargetClassIsOnTheClasspath() {
+        /*
+         * ModListが未完成なままshouldApplyMixinへ来る環境では、markerClassを
+         * 持たない連携が全てapplied=falseになっていた。ExtendedAE連携が外れると
+         * ExtendedAE PlusのBigIntegerセルにAccessorが付かず、ACOはfail-closedで
+         * 「BigInteger inventory sidecar is incomplete」として全ての広域計画を降りる。
+         */
+        ExtendedAeMixinConfigPlugin plugin = new ExtendedAeMixinConfigPlugin();
+        assertTrue(plugin.shouldApplyMixin(
+                "com.syaru.ae2craftingoptimizer.integration.Issues118To120RegressionTest",
+                "com.syaru.ae2craftingoptimizer.mixin.ExtendedAePlusBigIntegerCellInventoryAccessor"));
+        // 連携先が未導入なら、対象クラスが無いので従来どおり選択しない。
+        assertFalse(plugin.shouldApplyMixin(
+                "com.extendedae_plus.api.storage.InfinityBigIntegerCellInventory",
+                "com.syaru.ae2craftingoptimizer.mixin.ExtendedAePlusBigIntegerCellInventoryAccessor"));
     }
 
     @Test


### PR DESCRIPTION
## 症状

ExtendedAE Plus を入れると、そのネットワークで**あらゆる広域 (BigInteger) クラフトが計画できなくなります**。

```
com.syaru.ae2craftingoptimizer.engine.WidePlanUnavailableException:
  BigInteger inventory sidecar is incomplete
    at Ae2AuthoritativeCraftingPlanner.declineOrThrow(...)
```

セルの中身とは無関係で、Mod を入れただけで再現します。

## 原因

`ModPresenceMixinConfigPlugin#shouldApplyMixin` は連携先の在否を `ModList.get()` で見ますが、**Mixin 選択の時点では ModList がまだ構築されておらず例外になります**。そのため `markerClass` を持たない連携プラグイン (ExtendedAE / GTCEu / Mekanism / NeoEcoAE / AE2 Overclocked) は一律 `applied=false` になり、連携 Mixin が全て黙って外れます。

診断行にもこうとしか出ないため、Mod 側の非対応と区別が付きません:

```
ACO Mixin: feature=integration.extendedae,
  target=com.extendedae_plus.api.storage.InfinityBigIntegerCellInventory,
  mixin=...ExtendedAePlusBigIntegerCellInventoryAccessor,
  applied=false, dependency=expatternprovider unknown, policy=fail-closed
```

`dependency=... unknown` は「Mod が無い」(`absent`) ではなく **ModList 参照が例外になった**印です。Issue #120 で `dependencyMarkerClass()` を貰った `AdvancedAeMixinConfigPlugin` だけが `advanced_ae unknown` でも `applied=true` になっており、そこだけ生き残っていました。

ExtendedAE 連携が外れると ExtendedAE Plus の `InfinityBigIntegerCellInventory` に Accessor が付かず、`BigIntegerStorageSnapshotBridge` は**クラス名では認識するのに Accessor が無い**状態を fail-closed で不完全スナップショットにします。結果が冒頭の例外です。

## 修正

`shouldApplyMixin` は対象クラス名を受け取ります。`@Pseudo` Mixin の**対象クラスの実在**は ModList に依存せず確認でき、対象が無ければ適用しても何も起きないため、ModList → markerClass → 対象クラス、の順に OR で判定します。

あわせて `ModList` 参照の catch へ `LinkageError` を追加しました (同じく無言で false になる経路です)。

## テスト

- `Issues118To120RegressionTest` に回帰テストを追加 (対象クラスがあれば選択され、無ければ従来どおり選択しない)
- `./gradlew build` 緑
- 実機 (NeoForge 1.21.1 / AE2 19.2.17 / ExtendedAE Plus 1.6.1) で、修正前は上記例外で全滅、修正後は `applied=true` になりクラフトが通ることを確認

Issue #120 の続きです。
