### PR TITLE
fix: AQE の BigInteger 量子コアが常に CPU_TOO_SMALL になるのを直す

### DIFF
--- a/docs/CLASS_RESPONSIBILITIES.md
+++ b/docs/CLASS_RESPONSIBILITIES.md
@@ -380,6 +380,7 @@ mixin + access  ->  integration  ->  optimization / scheduler
 | `com.syaru.ae2craftingoptimizer.integration.Ae2BigCraftingExecutionManager` | 標準AE2クラスタが受理したexact Jobだけを既存PhysicalCraftingTreeTransactionへ接続するIssue #115の実行境界。 |
 | `com.syaru.ae2craftingoptimizer.integration.BigIntegerStorageSnapshotBridge` | Plannerが一つのmountを読む時だけ、AE2用long FacadeとBigInteger正本を分離する。通常NetworkStorageへは介入しない。 |
 | `com.syaru.ae2craftingoptimizer.integration.ExactBigIntegerCellConsistency` | ACOが直接更新したExtendedAE Plus在庫Mapと、同MODの保存用総量を結ぶ弱Sidecar。 |
+| `com.syaru.ae2craftingoptimizer.integration.ExactSubmissionScope` | ACOが正確な容量台帳で承認済みの提出を同じスレッドの下流へ伝え、CPUのlong容量ゲートに測り直させない。 |
 | `com.syaru.ae2craftingoptimizer.integration.ExactBoundaryRoutePreflight` | exact Jobの所有権を取る前に境界ME操作の成立を証明し、不成立時の委譲か拒否を決める (Issue #125)。 |
 | `com.syaru.ae2craftingoptimizer.integration.ExactNetworkStorageBridge` | ME storageへのexact snapshot、reserve、insert、rollbackをAE2権限境界内で行う。 |
 | `com.syaru.ae2craftingoptimizer.integration.ExactNetworkStorageSnapshotCache` | 旧共有Snapshot実装。Issue #109再発防止のためMixin未登録で、通常AE2からは使用しない。 |

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRuntime.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRuntime.java
@@ -1,5 +1,6 @@
 package com.syaru.ae2craftingoptimizer.api.big;
 
+import com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer;
 import com.syaru.ae2craftingoptimizer.engine.BigCountMath;
 import com.syaru.ae2craftingoptimizer.engine.BigCraftingJob;
 import com.syaru.ae2craftingoptimizer.engine.BigCraftingKeyCodec;
@@ -140,11 +141,21 @@ public final class BigCraftingHostRuntime<K> implements AutoCloseable {
         BigInteger previous = externalReservations.get(jobId);
         // AdvancedAEが先に作成した互換予約が存在しないJobは、別Jobとの取り違えを防ぐため拒否する。
         if (previous == null || externalExecutions.containsKey(jobId)) {
-            return false;
+            return declinePromotion(
+                    jobId,
+                    previous == null
+                            ? "the host holds no compatibility reservation for this CPU"
+                            : "the host already runs an exact execution for this CPU");
         }
         // BigInteger昇格対象は、AE2へ見せたLong.MAX_VALUEより真の容量が大きいJobだけに限定する。
         if (!previous.equals(LONG_MAX) || checked.compareTo(LONG_MAX) <= 0) {
-            return false;
+            return declinePromotion(
+                    jobId,
+                    !previous.equals(LONG_MAX)
+                            ? "the compatibility reservation is " + previous
+                                    + " instead of Long.MAX_VALUE"
+                            : "the exact plan needs only " + checked
+                                    + " bytes, which fits the long ledger");
         }
 
         BigInteger reservedWithoutPrevious = reserved().subtract(previous);
@@ -156,7 +167,13 @@ public final class BigCraftingHostRuntime<K> implements AutoCloseable {
         // 真の容量または保存用カウント予算を超える場合は、既存予約を一切変更せず失敗する。
         if (availableForReplacement.compareTo(checked) < 0
                 || projectedCountBytes > maximumRuntimeCountBytes) {
-            return false;
+            return declinePromotion(
+                    jobId,
+                    availableForReplacement.compareTo(checked) < 0
+                            ? "the host offers " + availableForReplacement
+                                    + " bytes but the plan needs " + checked
+                            : "the persisted-count budget would reach " + projectedCountBytes
+                                    + " of " + maximumRuntimeCountBytes + " bytes");
         }
 
         externalReservations.put(jobId, checked);
@@ -168,6 +185,21 @@ public final class BigCraftingHostRuntime<K> implements AutoCloseable {
         externalCountBytes = projectedCountBytes;
         rebalanceBigRuntimeCapacity();
         return true;
+    }
+
+    /**
+     * 昇格を断った理由を残す。
+     *
+     * <p>呼出側はここがfalseを返すとCPUごと取消してCPU_TOO_SMALLを返すが、
+     * 画面にも従来のlogにも「容量不足」としか出ないため、
+     * <b>互換予約が無いのか・真に容量が足りないのか</b>を利用者が区別できない。</p>
+     */
+    private boolean declinePromotion(UUID jobId, String reason) {
+        AE2CraftingOptimizer.LOGGER.warn(
+                "Declined the exact BigInteger capacity promotion for CPU {}: {}",
+                jobId,
+                reason);
+        return false;
     }
 
     /**

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRuntime.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRuntime.java
@@ -139,28 +139,47 @@ public final class BigCraftingHostRuntime<K> implements AutoCloseable {
         Objects.requireNonNull(jobId, "jobId");
         BigInteger checked = checkedPositive(exactAmount, "promoted external reservation", maximumBits);
         BigInteger previous = externalReservations.get(jobId);
-        // AdvancedAEが先に作成した互換予約が存在しないJobは、別Jobとの取り違えを防ぐため拒否する。
-        if (previous == null || externalExecutions.containsKey(jobId)) {
+        // 既にexact実行が走っているJobは、別Jobとの取り違えを防ぐため昇格しない。
+        if (externalExecutions.containsKey(jobId)) {
             return declinePromotion(
                     jobId,
-                    previous == null
-                            ? "the host holds no compatibility reservation for this CPU"
-                            : "the host already runs an exact execution for this CPU");
+                    "the host already runs an exact execution for this CPU");
         }
-        // BigInteger昇格対象は、AE2へ見せたLong.MAX_VALUEより真の容量が大きいJobだけに限定する。
-        if (!previous.equals(LONG_MAX) || checked.compareTo(LONG_MAX) <= 0) {
+        /*
+         * 互換予約がまだ無い場合もここで作る。
+         *
+         * <p>互換予約はCPUを所有するアドオン (AQE等) が自分の再集計契機で
+         * 入れるため、<b>提出の直後にはまだ存在しないことがある</b>。
+         * 以前はそれを取り違えとみなして拒否しており、結果として
+         * 「大きいCPUなのに CPU_TOO_SMALL」になっていた。
+         * 取り違えの防止には「exact実行が走っていないこと」で足りる。
+         * アドオンが後からLong.MAX_VALUEで再集計しても、
+         * replaceExternalReservationsが真値を優先するので上書きされない。</p>
+         */
+        // 互換予約があるなら、AE2へ見せたLong.MAX_VALUEからの昇格だけを認める。
+        if (previous != null && !previous.equals(LONG_MAX)) {
             return declinePromotion(
                     jobId,
-                    !previous.equals(LONG_MAX)
-                            ? "the compatibility reservation is " + previous
-                                    + " instead of Long.MAX_VALUE"
-                            : "the exact plan needs only " + checked
-                                    + " bytes, which fits the long ledger");
+                    "the compatibility reservation is " + previous
+                            + " instead of Long.MAX_VALUE");
+        }
+        // longで足りる計画はBigInteger台帳へ載せない。
+        if (checked.compareTo(LONG_MAX) <= 0) {
+            return declinePromotion(
+                    jobId,
+                    "the exact plan needs only " + checked
+                            + " bytes, which fits the long ledger");
+        }
+        // 新規に作る場合だけ、予約表の件数上限を確認する。
+        if (previous == null && externalReservations.size() >= MAX_EXTERNAL_RESERVATIONS) {
+            return declinePromotion(jobId, "the external reservation table is full");
         }
 
-        BigInteger reservedWithoutPrevious = reserved().subtract(previous);
+        BigInteger reservedWithoutPrevious = previous == null
+                ? reserved()
+                : reserved().subtract(previous);
         BigInteger availableForReplacement = physicalCapacity.subtract(reservedWithoutPrevious);
-        long previousBytes = BigCountMath.encodedBytes(previous);
+        long previousBytes = previous == null ? 0L : BigCountMath.encodedBytes(previous);
         long replacementBytes = BigCountMath.encodedBytes(checked);
         long projectedCountBytes = Math.addExact(
                 Math.subtractExact(externalCountBytes, previousBytes), replacementBytes);
@@ -178,7 +197,7 @@ public final class BigCraftingHostRuntime<K> implements AutoCloseable {
 
         externalReservations.put(jobId, checked);
         externalReserved = BigCountMath.add(
-                externalReserved.subtract(previous),
+                previous == null ? externalReserved : externalReserved.subtract(previous),
                 checked,
                 "host/externalReserved",
                 maximumBits);

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExactSubmissionScope.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/ExactSubmissionScope.java
@@ -1,0 +1,41 @@
+package com.syaru.ae2craftingoptimizer.integration;
+
+import appeng.api.networking.crafting.ICraftingPlan;
+import java.util.Objects;
+
+/**
+ * ACOが正確なBigInteger台帳で承認済みの提出だけを指す、呼出し一回分の目印。
+ *
+ * <p>CPUのlong容量ゲートは{@code CraftingCpuLogic#trySubmitJob}
+ * (およびAdvanced AEの複製) の中にあり、
+ * {@code cpu.getAvailableStorage() < plan.bytes()}を見る。
+ * wide計画のlong Facadeは常に{@code Long.MAX_VALUE}なので、
+ * 残容量がlong上限ぴったりでない限り<b>必ず不成立</b>になり、
+ * 理由の出ないCPU_TOO_SMALLとして返る。</p>
+ *
+ * <p>wide計画の容量判定は提出前に正確なBigInteger台帳へ対して済ませてあり、
+ * 不足なら所有権を取る前に拒否している。ここではその「済んでいる」事実だけを
+ * 同じスレッドの下流へ渡し、long Facadeで測り直させない。</p>
+ */
+public final class ExactSubmissionScope {
+    private static final ThreadLocal<ICraftingPlan> CURRENT = new ThreadLocal<>();
+
+    private ExactSubmissionScope() {
+    }
+
+    /** これから{@code trySubmitJob}へ渡す計画を、ACO承認済みとして記録する。 */
+    public static void enter(ICraftingPlan plan) {
+        CURRENT.set(Objects.requireNonNull(plan, "plan"));
+    }
+
+    /** 呼出しが終わったら必ず外す。残すと無関係な提出まで容量検査を素通りする。 */
+    public static void exit() {
+        CURRENT.remove();
+    }
+
+    /** この計画が、いま実行中のACO承認済み提出そのものかどうか。 */
+    public static boolean owns(ICraftingPlan plan) {
+        // 同一インスタンスだけを一致させる。等価な別計画は承認の対象外。
+        return plan != null && CURRENT.get() == plan;
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeBigCapacityPlanSubmissionMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeBigCapacityPlanSubmissionMixin.java
@@ -21,6 +21,7 @@ import com.syaru.ae2craftingoptimizer.engine.BigIntegerCraftingPlan;
 import com.syaru.ae2craftingoptimizer.engine.ExactPlanPatternRevalidator;
 import com.syaru.ae2craftingoptimizer.integration.AqeBigCraftingExecutionContext;
 import com.syaru.ae2craftingoptimizer.integration.ExactBoundaryRoutePreflight;
+import com.syaru.ae2craftingoptimizer.integration.ExactSubmissionScope;
 import com.syaru.ae2craftingoptimizer.optimization.BigIntegerPlanDeclineReason;
 import com.syaru.ae2craftingoptimizer.optimization.BigIntegerPlanDiagnostics;
 import java.math.BigDecimal;
@@ -261,12 +262,11 @@ public abstract class AdvancedAeBigCapacityPlanSubmissionMixin
                     source,
                     requester);
         }
+        ICraftingPlan facade = aco$singleExecutionFacade(attempt.bigIntegerPlan());
         try {
-            return logic.trySubmitJob(
-                    grid,
-                    aco$singleExecutionFacade(attempt.bigIntegerPlan()),
-                    source,
-                    requester);
+            // 容量はBigInteger台帳で承認済み。下流のlongゲートへ測り直させない。
+            ExactSubmissionScope.enter(facade);
+            return logic.trySubmitJob(grid, facade, source, requester);
         } catch (RuntimeException | LinkageError failure) {
             /*
              * Advanced AEが実CPU生成途中で失敗した場合は、この提出だけが追加したCPUを閉じる。
@@ -281,6 +281,8 @@ public abstract class AdvancedAeBigCapacityPlanSubmissionMixin
             ACO_SUBMISSION.remove();
             attempt.bigIntegerPlan().releaseSubmissionClaim();
             throw failure;
+        } finally {
+            ExactSubmissionScope.exit();
         }
     }
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeBigCapacityPlanSubmissionMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeBigCapacityPlanSubmissionMixin.java
@@ -23,7 +23,9 @@ import com.syaru.ae2craftingoptimizer.integration.AqeBigCraftingExecutionContext
 import com.syaru.ae2craftingoptimizer.integration.ExactBoundaryRoutePreflight;
 import com.syaru.ae2craftingoptimizer.optimization.BigIntegerPlanDeclineReason;
 import com.syaru.ae2craftingoptimizer.optimization.BigIntegerPlanDiagnostics;
+import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.MathContext;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -129,6 +131,10 @@ public abstract class AdvancedAeBigCapacityPlanSubmissionMixin
             var host = BigCraftingHostRegistry.find(this).orElse(null);
             if (host == null
                     || host.available().compareTo(bigIntegerPlan.exactBytes()) < 0) {
+                aco$reportTooSmall(
+                        "BigInteger",
+                        host == null ? null : host.available(),
+                        bigIntegerPlan.exactBytes());
                 cir.setReturnValue(CraftingSubmitResult.CPU_TOO_SMALL);
                 return;
             }
@@ -183,6 +189,10 @@ public abstract class AdvancedAeBigCapacityPlanSubmissionMixin
                         && !parentOwnedAllowance.equals(bigPlan.exactBytes()))
                 || (!parentOwnedWindow
                         && host.available().compareTo(bigPlan.exactBytes()) < 0)) {
+            aco$reportTooSmall(
+                    parentOwnedWindow ? "Big-capacity child window" : "Big-capacity",
+                    host == null ? null : host.available(),
+                    bigPlan.exactBytes());
             cir.setReturnValue(CraftingSubmitResult.CPU_TOO_SMALL);
             return;
         }
@@ -192,6 +202,37 @@ public abstract class AdvancedAeBigCapacityPlanSubmissionMixin
                 Set.copyOf(activeCpus.keySet()),
                 parentOwnedWindow,
                 null));
+    }
+
+    /**
+     * Advanced AE自身のlong容量チェックを、ACOが所有するwide計画に対してだけ無効化する。
+     *
+     * <p>{@code AdvCraftingCPUCluster#submitJob}は本体の先頭で
+     * {@code getAvailableStorage() < plan.bytes()}を見る。wide計画のlong Facadeは
+     * {@code Long.MAX_VALUE}固定なので、<b>クラスタの残容量がlong上限ぴったりでない限り
+     * 必ず不成立</b>になり、CPU_TOO_SMALLが<b>理由も出さずに</b>返る。
+     * AE2本体のクラスタには同じ検査が無いため、この症状は
+     * <b>Advanced AE系のCPU (AQEのBigInteger量子コアを含む) でだけ</b>表に出る。</p>
+     *
+     * <p>wide計画の容量判定はHEADで正確なBigInteger台帳に対して既に済ませてあり、
+     * 不足なら所有権を取る前に拒否している。ここで測り直す意味は無いので、
+     * <b>ACOのSidecarを持つ計画だけ</b>0バイトとして通す。通常計画のlong Facadeには
+     * 一切触れない。</p>
+     */
+    @Redirect(
+            method = "submitJob",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lappeng/api/networking/crafting/ICraftingPlan;bytes()J",
+                    ordinal = 0),
+            require = 1)
+    private long aco$skipLongCapacityGateForWidePlans(ICraftingPlan plan) {
+        // ACOが正本を持つ計画だけ、long上限のFacadeで測り直させない。
+        if (Ae2CraftingPlanSidecars.bigInteger(plan).isPresent()
+                || Ae2CraftingPlanSidecars.bigCapacity(plan).isPresent()) {
+            return 0L;
+        }
+        return plan.bytes();
     }
 
     /**
@@ -371,6 +412,46 @@ public abstract class AdvancedAeBigCapacityPlanSubmissionMixin
                 new KeyCounter(),
                 new KeyCounter(),
                 Map.copyOf(oneExecution));
+    }
+
+    /**
+     * 容量不足でCPU_TOO_SMALLを返す理由を残す。
+     *
+     * <p>AE2の画面には「選択したCPUのストレージが足りません」としか出せず、
+     * <b>Hostが登録されていない</b>のか<b>本当に容量が足りない</b>のかを
+     * 利用者が区別できない。前者はアドオン側のHost登録漏れや構造再形成の取りこぼしで、
+     * 後者は注文が大きすぎるだけなので、対処が正反対になる。</p>
+     */
+    @Unique
+    private static void aco$reportTooSmall(
+            String planKind,
+            BigInteger available,
+            BigInteger required) {
+        // Hostが無い場合は容量比較すら行われていないため、そう明記する。
+        if (available == null) {
+            AE2CraftingOptimizer.LOGGER.warn(
+                    "Refusing a wide Advanced AE {} plan: no BigInteger crafting host is registered"
+                            + " for this cluster (needs {} bytes)",
+                    planKind,
+                    aco$describeAmount(required));
+            return;
+        }
+        AE2CraftingOptimizer.LOGGER.warn(
+                "Refusing a wide Advanced AE {} plan: the cluster host offers {} bytes"
+                        + " but the plan needs {} bytes",
+                planKind,
+                aco$describeAmount(available),
+                aco$describeAmount(required));
+    }
+
+    /** 正確値は10進で数千桁になりうるので、桁感だけを残す。 */
+    @Unique
+    private static String aco$describeAmount(BigInteger amount) {
+        // long内なら丸めずそのまま読める。
+        if (amount.abs().bitLength() < Long.SIZE) {
+            return amount.toString();
+        }
+        return new BigDecimal(amount).round(new MathContext(4)).toEngineeringString();
     }
 
     /** 世代再検証の拒否理由を、設定可能なBigInteger診断へ集約する。 */

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeExactCraftingLogicMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeExactCraftingLogicMixin.java
@@ -1,5 +1,8 @@
 package com.syaru.ae2craftingoptimizer.mixin;
 
+import org.spongepowered.asm.mixin.injection.Redirect;
+import com.syaru.ae2craftingoptimizer.integration.ExactSubmissionScope;
+import appeng.api.networking.crafting.ICraftingPlan;
 import appeng.api.config.Actionable;
 import appeng.api.networking.energy.IEnergyService;
 import appeng.api.stacks.AEKey;
@@ -147,5 +150,29 @@ public abstract class AdvancedAeExactCraftingLogicMixin
         aco$finishExactJob(false);
         cpu.updateOutput(null);
         ci.cancel();
+    }
+
+    /**
+     * ACOが承認済みのwide提出だけ、CPUのlong容量ゲートを通す。
+     *
+     * <p>{@code trySubmitJob}は先頭で{@code getAvailableStorage() < plan.bytes()}を見る。
+     * wide計画のlong Facadeは常に{@code Long.MAX_VALUE}なので、残容量がlong上限
+     * ぴったりでない限り<b>必ず不成立</b>になり、理由の出ないCPU_TOO_SMALLで返る。
+     * 正確な容量判定は提出前にBigInteger台帳へ対して済ませてあるので、ここでは測り直さない。
+     * ACOの提出でない計画には一切触れない。</p>
+     */
+    @Redirect(
+            method = "trySubmitJob",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lappeng/api/networking/crafting/ICraftingPlan;bytes()J",
+                    ordinal = 0),
+            require = 1)
+    private long aco$skipLongCapacityGateForApprovedPlans(ICraftingPlan plan) {
+        // ACO承認済みの一回分Facadeだけ0バイト扱いにする。
+        if (ExactSubmissionScope.owns(plan)) {
+            return 0L;
+        }
+        return plan.bytes();
     }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeExactCraftingLogicMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AdvancedAeExactCraftingLogicMixin.java
@@ -1,5 +1,6 @@
 package com.syaru.ae2craftingoptimizer.mixin;
 
+import com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import com.syaru.ae2craftingoptimizer.integration.ExactSubmissionScope;
 import appeng.api.networking.crafting.ICraftingPlan;
@@ -173,6 +174,20 @@ public abstract class AdvancedAeExactCraftingLogicMixin
         if (ExactSubmissionScope.owns(plan)) {
             return 0L;
         }
-        return plan.bytes();
+        long required = plan.bytes();
+        long available = cpu.getAvailableStorage();
+        /*
+         * このゲートは理由を一切出さずCPU_TOO_SMALLを返す。wide計画のlong Facadeは
+         * Long.MAX_VALUE固定なので、利用者からは「大きいCPUなのに容量不足と言われる」
+         * としか見えない。どのCPUがどれだけ足りないと言っているのかを残す。
+         */
+        if (available < required) {
+            AE2CraftingOptimizer.LOGGER.warn(
+                    "Advanced AE CPU capacity gate refused a job: available={} required={} cpu={}",
+                    available,
+                    required,
+                    cpu);
+        }
+        return required;
     }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/Ae2BigCapacityPlanSubmissionMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/Ae2BigCapacityPlanSubmissionMixin.java
@@ -14,6 +14,7 @@ import com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer;
 import com.syaru.ae2craftingoptimizer.access.CraftingLogicTransactionAccess;
 import com.syaru.ae2craftingoptimizer.access.ExactCraftingJobAccess;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
+import com.syaru.ae2craftingoptimizer.integration.ExactSubmissionScope;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
 import com.syaru.ae2craftingoptimizer.engine.BigIntegerCraftingPlan;
 import com.syaru.ae2craftingoptimizer.engine.ExactPlanPatternRevalidator;
@@ -141,16 +142,17 @@ public abstract class Ae2BigCapacityPlanSubmissionMixin {
                 || attempt.originalPlan() != plan) {
             return logic.trySubmitJob(grid, plan, source, requester);
         }
+        ICraftingPlan facade = aco$singleExecutionFacade(attempt.exactPlan());
         try {
-            return logic.trySubmitJob(
-                    grid,
-                    aco$singleExecutionFacade(attempt.exactPlan()),
-                    source,
-                    requester);
+            // 容量はBigInteger台帳で承認済み。下流のlongゲートへ測り直させない。
+            ExactSubmissionScope.enter(facade);
+            return logic.trySubmitJob(grid, facade, source, requester);
         } catch (RuntimeException | LinkageError failure) {
             ACO_SUBMISSION.remove();
             attempt.exactPlan().releaseSubmissionClaim();
             throw failure;
+        } finally {
+            ExactSubmissionScope.exit();
         }
     }
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/Ae2ExactCraftingLogicMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/Ae2ExactCraftingLogicMixin.java
@@ -10,6 +10,7 @@ import appeng.crafting.execution.CraftingCpuLogic;
 import appeng.crafting.execution.ExecutingCraftingJob;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
 import appeng.me.service.CraftingService;
+import com.syaru.ae2craftingoptimizer.AE2CraftingOptimizer;
 import com.syaru.ae2craftingoptimizer.access.ExactCraftingJobAccess;
 import com.syaru.ae2craftingoptimizer.access.ExactCraftingLogicAccess;
 import com.syaru.ae2craftingoptimizer.integration.Ae2BigCraftingExecutionManager;
@@ -140,6 +141,20 @@ public abstract class Ae2ExactCraftingLogicMixin implements ExactCraftingLogicAc
         if (ExactSubmissionScope.owns(plan)) {
             return 0L;
         }
-        return plan.bytes();
+        long required = plan.bytes();
+        long available = cluster.getAvailableStorage();
+        /*
+         * このゲートは理由を一切出さずCPU_TOO_SMALLを返す。wide計画のlong Facadeは
+         * Long.MAX_VALUE固定なので、利用者からは「大きいCPUなのに容量不足と言われる」
+         * としか見えない。どのCPUがどれだけ足りないと言っているのかを残す。
+         */
+        if (available < required) {
+            AE2CraftingOptimizer.LOGGER.warn(
+                    "AE2 CPU capacity gate refused a job: available={} required={} cluster={}",
+                    available,
+                    required,
+                    cluster);
+        }
+        return required;
     }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/Ae2ExactCraftingLogicMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/Ae2ExactCraftingLogicMixin.java
@@ -1,5 +1,8 @@
 package com.syaru.ae2craftingoptimizer.mixin;
 
+import org.spongepowered.asm.mixin.injection.Redirect;
+import com.syaru.ae2craftingoptimizer.integration.ExactSubmissionScope;
+import appeng.api.networking.crafting.ICraftingPlan;
 import appeng.api.config.Actionable;
 import appeng.api.networking.energy.IEnergyService;
 import appeng.api.stacks.AEKey;
@@ -114,5 +117,29 @@ public abstract class Ae2ExactCraftingLogicMixin implements ExactCraftingLogicAc
         cluster.updateOutput(null);
         Ae2BigCraftingExecutionManager.unregister(cluster);
         ci.cancel();
+    }
+
+    /**
+     * ACOが承認済みのwide提出だけ、CPUのlong容量ゲートを通す。
+     *
+     * <p>{@code trySubmitJob}は先頭で{@code getAvailableStorage() < plan.bytes()}を見る。
+     * wide計画のlong Facadeは常に{@code Long.MAX_VALUE}なので、残容量がlong上限
+     * ぴったりでない限り<b>必ず不成立</b>になり、理由の出ないCPU_TOO_SMALLで返る。
+     * 正確な容量判定は提出前にBigInteger台帳へ対して済ませてあるので、ここでは測り直さない。
+     * ACOの提出でない計画には一切触れない。</p>
+     */
+    @Redirect(
+            method = "trySubmitJob",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lappeng/api/networking/crafting/ICraftingPlan;bytes()J",
+                    ordinal = 0),
+            require = 1)
+    private long aco$skipLongCapacityGateForApprovedPlans(ICraftingPlan plan) {
+        // ACO承認済みの一回分Facadeだけ0バイト扱いにする。
+        if (ExactSubmissionScope.owns(plan)) {
+            return 0L;
+        }
+        return plan.bytes();
     }
 }

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRuntimeTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingHostRuntimeTest.java
@@ -189,6 +189,28 @@ class BigCraftingHostRuntimeTest {
     }
 
     @Test
+    void capacityPromotionWorksBeforeTheAddonRegistersItsFacadeReservation() {
+        /*
+         * 互換予約はCPUを所有するアドオンが自分の再集計契機で入れるため、
+         * 提出直後にはまだ存在しないことがある。以前はこれを取り違えとみなして
+         * 拒否しており、AQEのBigInteger量子コアが常にCPU_TOO_SMALLになっていた。
+         */
+        BigInteger exact = BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.TWO);
+        BigInteger capacity = exact.add(BigInteger.valueOf(1_000L));
+        UUID cpuId = UUID.randomUUID();
+        BigCraftingHostRuntime<String> host = host(capacity);
+
+        assertTrue(host.promoteExternalReservation(cpuId, exact));
+        assertEquals(Map.of(cpuId, exact), host.externalReservations());
+        assertEquals(exact, host.reserved());
+
+        // アドオンが後からLong.MAX_VALUEで再集計しても、真値が優先される。
+        host.replaceExternalReservations(Map.of(cpuId, BigInteger.valueOf(Long.MAX_VALUE)));
+        assertEquals(Map.of(cpuId, exact), host.externalReservations());
+        assertEquals(exact, host.reserved());
+    }
+
+    @Test
     void failedCapacityPromotionLeavesFacadeReservationUntouched() {
         BigInteger facade = BigInteger.valueOf(Long.MAX_VALUE);
         BigInteger capacity = facade.add(BigInteger.TEN);


### PR DESCRIPTION
## 症状

AQE の BigInteger 量子コアを選ぶと、**注文の大小に関係なく**必ず

```
The selected CPU does not have enough storage.
[AE2:S]: Couldn't submit crafting job for 1xitem: CPU_TOO_SMALL [Detail: null]
```

になります。ログには理由が一切出ません。

## 原因

2 種類あり、どちらも無音でした。

### 1. long の容量ゲートが wide 計画を測り直す

`CPU_TOO_SMALL` を返す箇所は 3 つあります:

- `AdvCraftingCPUCluster#submitJob`
- `CraftingCpuLogic#trySubmitJob` (AE2)
- `AdvCraftingCPULogic#trySubmitJob` (Advanced AE の複製)

いずれも `getAvailableStorage() < plan.bytes()` を見ますが、**wide 計画の long Facade は常に `Long.MAX_VALUE`** です。したがって残容量が long 上限ぴったりでない限り必ず不成立になります。ACO が HEAD で正確な BigInteger 台帳に対して承認しても、その後に本体のこの検査が走るため無効化されていました。

容量判定は提出前に BigInteger 台帳へ対して済ませてあり、不足なら所有権を取る前に拒否しています。ここで測り直す意味はありません。`ExactSubmissionScope` で「この呼出しは ACO が承認済み」を同じスレッドの下流へ渡し、`bytes()` の **ordinal=0 (ゲートの比較だけ)** を 0 として通します。`new AdvCraftingCPU(..., plan.bytes())` に渡す ordinal=1 の予約量には触れません。ACO の提出でない計画も一切変わりません。

### 2. 互換予約が入る前に昇格しようとしていた (本命)

ゲートを抜けた後、`promoteExternalReservation` が失敗して CPU ごと取り消されていました:

```
Declined the exact BigInteger capacity promotion for CPU <uuid>:
  the host holds no compatibility reservation for this CPU
ACO cancelled Advanced AE CPU <uuid> because its exact BigInteger capacity reservation failed
```

互換予約 (`Long.MAX_VALUE`) を入れるのは CPU を所有するアドオン側です。AQE は `recalculateStorageState()` の中でリビジョンが変わったときだけ `host.reconcile(...)` を呼ぶため、**ACO の `submitJob` RETURN 処理のほうが先に走り、予約がまだ存在しません**。ACO はそれを「別 Job との取り違え」とみなして拒否していました。

取り違えの防止には「その CPU で exact 実行が走っていないこと」で足ります。互換予約が無ければその場で作るようにしました (件数上限・真の容量・保存カウント予算の確認は従来どおり)。アドオンが後から `Long.MAX_VALUE` で再集計しても `replaceExternalReservations` が真値を優先するため上書きされません。

## 診断ログ

CPU_TOO_SMALL を返す全経路が無音だったため、理由を出すようにしました。「ホスト未登録」なのか「本当に容量不足」なのかで対処が正反対になるためです。

```
Refusing a wide Advanced AE BigInteger plan: the cluster host offers 1.000E+1023 bytes but the plan needs 4.000E+22 bytes
AE2 CPU capacity gate refused a job: available=... required=... cluster=...
Declined the exact BigInteger capacity promotion for CPU <uuid>: <理由>
```

正確値は 10 進で数千桁になりうるので、桁感だけを残す形にしています。

## テスト

- `BigCraftingHostRuntimeTest` に回帰テストを追加 (互換予約なしで昇格できること / 後続の `reconcile` で真値が残ること)
- `./gradlew build` 緑
- 実機 (NeoForge 1.21.1 / AE2 19.2.17 / AdvancedAE 1.6.12 / AQE 2.2.4) で、修正前は全注文が `CPU_TOO_SMALL`、修正後はクラフトが通ることを確認
