### PR TITLE
feat(api): 容量上限 API と AEKey 台帳 API を mc/1.21.1 へ移植する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,6 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
-### Added
-
-- Added a versioned public capacity-limit query for BigInteger CPU add-ons.
-- Added AEKey amount-ledger factories so optional integrations do not need to
-  resolve ACO's internal codec type.
-
 ### Fixed
 
 - Issue #125: exact jobs no longer stall forever without a word when the
@@ -27,6 +21,11 @@ All notable changes to this project are documented here.
 - `exactVectorCrafting.logExecutionStalls` (default on): when an owned exact
   job makes no progress, the waiting reason is logged once per reason change
   and once per 600 ticks, so silent stalls become diagnosable in the field.
+- Added a versioned public capacity-limit query for BigInteger CPU add-ons
+  (`CAPACITY_LIMIT_API_VERSION` / `maximumSupportedAmount()`), already present
+  on the 1.20.1 line.
+- Added AEKey amount-ledger factories so optional integrations do not need to
+  resolve ACO's internal codec type (`AMOUNT_LEDGER_API_VERSION` 2).
 
 ## [1.5.24] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- Added a versioned public capacity-limit query for BigInteger CPU add-ons.
+- Added AEKey amount-ledger factories so optional integrations do not need to
+  resolve ACO's internal codec type.
+
 ### Fixed
 
 - Issue #125: exact jobs no longer stall forever without a word when the

--- a/docs/EXPERIMENTAL_ENGINE.md
+++ b/docs/EXPERIMENTAL_ENGINE.md
@@ -271,6 +271,11 @@ return to AE2 before source ownership changes.
 It does not automatically patch standard AE2 or Advanced AE CPUs.
 
 - API version: `3`.
+- Amount-ledger API version: `2`. AE2 add-ons use
+  `createAeKeyAmountLedger()` and `loadAeKeyAmountLedger()` without resolving
+  ACO's internal codec types.
+- Capacity-limit API version: `1`. `maximumSupportedAmount()` returns the
+  exact configured BigInteger bound after applying ACO's hard safety limit.
 - One shared host reconciles external signed-long job reservations and native
   BigInteger jobs against the same physical capacity.
 - Runtime NBT schema: `2`, including a persistent runtime UUID.

--- a/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApi.java
@@ -2,6 +2,7 @@ package com.syaru.ae2craftingoptimizer.api.big;
 
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import com.syaru.ae2craftingoptimizer.engine.BigCraftingKeyCodec;
+import com.syaru.ae2craftingoptimizer.engine.BigCountMath;
 import com.syaru.ae2craftingoptimizer.engine.OverflowPromotingCraftingPlanner;
 import com.syaru.ae2craftingoptimizer.engine.Ae2CraftingPlanSidecars;
 import com.syaru.ae2craftingoptimizer.engine.BigCapacityCraftingPlan;
@@ -28,9 +29,11 @@ public final class BigCraftingEngineApi {
     /** 既存AQEホストAPIの契約番号。既存アドオンの互換性を維持する。 */
     public static final int API_VERSION = 3;
     /** アドオン向け正確なBigInteger会計APIの契約番号。 */
-    public static final int AMOUNT_LEDGER_API_VERSION = 1;
+    public static final int AMOUNT_LEDGER_API_VERSION = 2;
     /** AE2計算プロファイル照会APIの契約番号。 */
     public static final int CALCULATION_PROFILE_API_VERSION = 1;
+    /** アドオンがACOの正確なBigInteger上限を照会するAPIの契約番号。 */
+    public static final int CAPACITY_LIMIT_API_VERSION = 1;
     /** 外部CPUが正確なBigInteger計画の提出境界を所有するAPIの契約番号。 */
     public static final int EXTERNAL_CONSUMER_API_VERSION = 1;
     private static final AtomicInteger EXTERNAL_CONSUMER_COUNT = new AtomicInteger();
@@ -54,6 +57,32 @@ public final class BigCraftingEngineApi {
     /** 外部CPUがBigInteger計画を引き受ける登録を済ませたか返す。 */
     public static boolean hasExternalBigIntegerPlanConsumer() {
         return EXTERNAL_CONSUMER_COUNT.get() > 0;
+    }
+
+    /**
+     * 現在のACO設定で計画・会計・NBTへ保存できる正確な最大値を返す。
+     *
+     * <p>アドオンはこの値をCPU容量の上限や表示に利用できる。BigIntegerは不変なので、
+     * 呼び出し側へ同じ値を返してもACO内部状態は変更されない。</p>
+     */
+    public static BigInteger maximumSupportedAmount() {
+        return maximumSupportedAmount(ACOConfig.getBigIntegerMaximumBits());
+    }
+
+    static BigInteger maximumSupportedAmount(int configuredMaximumBits) {
+        // ACOの設定境界外の値を、公開API経由で有効な上限として扱わせない。
+        if (configuredMaximumBits < 1
+                || configuredMaximumBits > BigCountMath.HARD_MAXIMUM_BITS) {
+            throw new IllegalArgumentException(
+                    "configuredMaximumBits must be between 1 and "
+                            + BigCountMath.HARD_MAXIMUM_BITS);
+        }
+
+        BigInteger binaryLimit = BigInteger.ONE
+                .shiftLeft(configuredMaximumBits)
+                .subtract(BigInteger.ONE);
+        // bit上限の端が16,385桁へ届く場合は、ACOの10進16,384桁上限を正本にする。
+        return binaryLimit.min(BigCountMath.hardMaximumValue());
     }
 
     /**
@@ -217,11 +246,28 @@ public final class BigCraftingEngineApi {
                 ACOConfig.getBigIntegerMaximumBits());
     }
 
+    /**
+     * AE2のitem、fluid、chemicalキーを扱うアドオン向け台帳を作成する。
+     *
+     * <p>アドオンがACO内部の{@code BigCraftingKeyCodec}型を解決しなくて済むよう、
+     * 公開APIだけで完結する固定型ファクトリとして提供する。</p>
+     */
+    public static BigIntegerAmountLedger<AEKey> createAeKeyAmountLedger() {
+        return createAmountLedger(AeKeyBigCraftingCodec.INSTANCE);
+    }
+
     /** Restores an add-on amount ledger using the current server-side bit limit. */
     public static <K> BigIntegerAmountLedger<K> loadAmountLedger(
             CompoundTag saved,
             BigCraftingKeyCodec<K> keyCodec) {
         BigIntegerAmountLedger<K> ledger = createAmountLedger(keyCodec);
+        ledger.load(Objects.requireNonNull(saved, "saved"));
+        return ledger;
+    }
+
+    /** AEKey用の保存済み台帳を、ACO内部型を公開せず復元する。 */
+    public static BigIntegerAmountLedger<AEKey> loadAeKeyAmountLedger(CompoundTag saved) {
+        BigIntegerAmountLedger<AEKey> ledger = createAeKeyAmountLedger();
         ledger.load(Objects.requireNonNull(saved, "saved"));
         return ledger;
     }

--- a/src/test/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApiCapacityTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/api/big/BigCraftingEngineApiCapacityTest.java
@@ -1,0 +1,50 @@
+package com.syaru.ae2craftingoptimizer.api.big;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import appeng.api.stacks.AEKey;
+import com.syaru.ae2craftingoptimizer.engine.BigCountMath;
+import java.lang.reflect.Method;
+import java.math.BigInteger;
+import org.junit.jupiter.api.Test;
+
+class BigCraftingEngineApiCapacityTest {
+    @Test
+    void returnsExactConfiguredBinaryLimit() {
+        assertEquals(
+                BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE),
+                BigCraftingEngineApi.maximumSupportedAmount(64));
+    }
+
+    @Test
+    void clampsMaximumBitsToDecimalImplementationLimit() {
+        assertEquals(
+                BigCountMath.hardMaximumValue(),
+                BigCraftingEngineApi.maximumSupportedAmount(
+                        BigCountMath.HARD_MAXIMUM_BITS));
+    }
+
+    @Test
+    void rejectsBitsOutsideAcoBoundary() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> BigCraftingEngineApi.maximumSupportedAmount(0));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> BigCraftingEngineApi.maximumSupportedAmount(
+                        BigCountMath.HARD_MAXIMUM_BITS + 1));
+    }
+
+    @Test
+    void exposesAeKeyLedgerFactoryWithoutInternalCodecParameter() throws Exception {
+        Method factory = BigCraftingEngineApi.class.getMethod("createAeKeyAmountLedger");
+
+        assertEquals(BigIntegerAmountLedger.class, factory.getReturnType());
+        assertEquals(0, factory.getParameterCount());
+        assertTrue(BigCraftingEngineApi.AMOUNT_LEDGER_API_VERSION >= 2);
+        // ジェネリック戻り値にもAEKeyが残り、アドオン側の型契約を文書化できる。
+        assertTrue(factory.getGenericReturnType().getTypeName().contains(AEKey.class.getName()));
+    }
+}


### PR DESCRIPTION
## 概要

1.20.1 系にしか無い `70ecfbd` ("feat(api): expose BigInteger limits and AEKey ledger") を `mc/1.21.1` へ移植します。この 2 つの公開面が 1.21.1 に欠けています:

- `CAPACITY_LIMIT_API_VERSION` / `maximumSupportedAmount()`
- `AMOUNT_LEDGER_API_VERSION` 2 と `createAeKeyAmountLedger()` / `loadAeKeyAmountLedger()`

## 動機

ACO の設定上限からクラフト CPU の容量を決めるアドオンが、1.21.1 ではその値を読む手段を持ちません。

InsaneAE の BigInteger クラフトストレージがまさにこれで、`maximumSupportedAmount()` を反射で引き、引けなければ 1 ブロック `Long.MAX_VALUE` バイトへ退避します。**1.21.1 では常にこの退避が起きる**ため、ブロックは黙って 9.22e18 バイトの通常ストレージになり、long 超の注文が `CPU_TOO_SMALL` で弾かれます。素の ACO 1.5.24 + 既定の `bigIntegerMaximumBits = 54427` なら、本来の容量は 1 ブロックあたり 10^16384 - 1 バイトです。

台帳側も同じで、v2 の AEKey ファクトリはアドオンが ACO 内部の codec 型を名指しせずに済むためのものなので、1.21.1 のアドオンはローカル台帳へ退避することになります。

両ブランチとも移植に必要なもの (`AeKeyBigCraftingCodec`、`BigCountMath`) は既に持っているので、素直な移植です。

## 変更点

- `BigCraftingEngineApi`: 容量上限の照会と AEKey 台帳ファクトリを追加、`AMOUNT_LEDGER_API_VERSION` を 2 へ、`CAPACITY_LIMIT_API_VERSION` 1 を追加。元コミットの後に 1.21.1 側で入った `EXTERNAL_CONSUMER_API_VERSION` と外部コンシューマ登録はそのまま残しています (競合したのは隣接する定数と javadoc だけでした)。
- `BigCraftingEngineApiCapacityTest`: そのまま移植。
- ドキュメント: `EXPERIMENTAL_ENGINE.md` の節と CHANGELOG を既存の `[Unreleased] / Added` へ統合。

## 検証

- `mc/1.21.1` + このコミットで `./gradlew build`: 単体テスト全緑 (Java 21)
- InsaneAE のゲームテスト 1.21.1 で 94/94 緑。BigInteger クラフトストレージが signed long を超える容量を報告することを assert する新規プロットを含みます。このプロットは素の 1.5.24 では落ち、1.20.1 系では通ります — この非対称が本 PR で消えます。
