### PR TITLE
release: ACO 1.5.25 for Forge 1.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.25] - 2026-08-23
+
+### Fixed
+
+- Allowed an ACO-approved wide plan to pass the standard `long` CPU-capacity
+  gate without weakening the capacity checks for ordinary AE2 plans.
+- Promoted exact BigInteger capacity reservations before an optional add-on
+  registers its facade, preventing valid wide submissions from being reported
+  as `CPU_TOO_SMALL` during integration startup.
+- Proved that exact inputs can be released and the final exact output can be
+  accepted before ACO takes execution ownership. Unsupported routes remain
+  available to registered external BigInteger plan consumers.
+
+### Diagnostics
+
+- Added explicit diagnostics for capacity promotion declines and for the CPU
+  that rejects a plan at the standard `long` capacity gate.
+
+### Verification
+
+- Passed the complete Forge test suite and clean build against upstream AE2
+  15.4.10 and AE2 UELM 15.5.0 profiles.
+
 ## [1.5.24] - 2026-08-21
 
 ### Fixed

--- a/RELEASE_NOTES_1.5.25.md
+++ b/RELEASE_NOTES_1.5.25.md
@@ -1,0 +1,40 @@
+# AE2 Crafting Optimizer 1.5.25
+
+## English
+
+### Fixed
+
+- Wide BigInteger plans approved by ACO can now pass AE2's standard `long`
+  CPU-capacity gate. Ordinary AE2 plans keep their original capacity checks.
+- Exact capacity reservations can be promoted before an optional add-on
+  registers its facade, avoiding false `CPU_TOO_SMALL` results during
+  integration startup.
+- ACO now proves the exact-storage boundary before taking execution ownership:
+  required inputs must be releasable and the final output must be acceptable.
+  Plans that ACO cannot own remain available to a registered external
+  BigInteger plan consumer.
+- Capacity rejection logs now identify the deciding CPU and the exact reason
+  an attempted BigInteger capacity promotion was declined.
+
+### Verification
+
+- `clean build` and the complete automated test suite passed with upstream
+  AE2 15.4.10 and AE2 UELM 15.5.0 build profiles.
+
+## 日本語
+
+### 修正
+
+- ACOが承認したBigInteger計画が、AE2標準の`long` CPU容量判定を通過できるように
+  しました。通常のAE2計画には従来の容量判定をそのまま適用します。
+- OptionalアドオンがFacadeを登録する前でもexact容量予約を昇格できるようにし、
+  連携初期化中の誤った`CPU_TOO_SMALL`を防止しました。
+- ACOが実行所有権を取得する前に、必要入力を解放でき、最終成果物をexact経路へ
+  搬入できることを証明します。ACOが所有できない計画は、登録済みの外部BigInteger
+  計画Consumerへ引き続き渡せます。
+- 容量拒否ログへ、判定したCPUとBigInteger容量昇格を辞退した正確な理由を追加しました。
+
+### 検証
+
+- upstream AE2 15.4.10とAE2 UELM 15.5.0の両ビルドプロファイルで、
+  `clean build`と全自動テストが成功しました。

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.24
+mod_version=1.5.25
 minecraft_version=1.20.1
 mod_group=com.syaru.ae2craftingoptimizer


### PR DESCRIPTION
## 目的

取り込み済みのwide容量判定・exact境界route修正を、Forge 1.20.1向けACO 1.5.25としてリリースします。

## 内容

- ACO承認済みwide計画をAE2標準`long`容量gateから安全に引き継ぐ
- Optional連携Facade登録前でもexact容量予約を昇格可能にする
- 実行所有権の取得前に入力解放と最終出力搬入のexact境界routeを証明する
- 通常AE2計画の容量判定と外部BigInteger Consumerの所有権を維持する
- 英語・日本語のリリースノートを追加する
- バージョンを1.5.25へ更新する

## 検証

- `gradlew.bat clean build --no-daemon`: 成功
- JUnit/test classes: 93、failure/errorなし
- GitHub CI: upstream AE2 15.4.10 / UELM 15.5.0をPR上で確認

Minecraft起動試験はこのPRでは実施しません。
