### PR TITLE
release: ACO 1.5.25 for NeoForge 1.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.25] - 2026-08-23
+
 ### Fixed
 
 - Issue #125: exact jobs no longer stall forever without a word when the

--- a/RELEASE_NOTES_1.5.25.md
+++ b/RELEASE_NOTES_1.5.25.md
@@ -1,0 +1,50 @@
+# AE2 Crafting Optimizer 1.5.25
+
+## English
+
+### Fixed
+
+- Wide BigInteger plans approved by ACO can now pass AE2's standard `long`
+  CPU-capacity gate. Ordinary AE2 plans keep their original capacity checks.
+- Exact capacity reservations can be promoted before an optional add-on
+  registers its facade, avoiding false `CPU_TOO_SMALL` results during
+  integration startup.
+- Optional integration Mixins are now selected by the target class owned by
+  each integration. An unrelated installed add-on no longer suppresses a
+  compatible integration Mixin.
+- ACO proves the exact-storage boundary before taking execution ownership.
+  Unsupported routes remain available to registered external BigInteger plan
+  consumers instead of becoming an owned stalled job.
+
+### API
+
+- Added the versioned BigInteger capacity-limit query used by CPU add-ons.
+- Added AEKey amount-ledger factories so optional integrations no longer need
+  ACO's internal key codec type.
+
+### Verification
+
+- `clean build` and the complete automated NeoForge test suite passed.
+
+## 日本語
+
+### 修正
+
+- ACOが承認したBigInteger計画が、AE2標準の`long` CPU容量判定を通過できるように
+  しました。通常のAE2計画には従来の容量判定をそのまま適用します。
+- OptionalアドオンがFacadeを登録する前でもexact容量予約を昇格できるようにし、
+  連携初期化中の誤った`CPU_TOO_SMALL`を防止しました。
+- Optional連携Mixinを、それぞれの連携が所有する対象クラスで選択するようにしました。
+  無関係なアドオンの導入によって互換Mixinが抑止される問題を解消します。
+- ACOが実行所有権を取得する前にexactストレージ境界を証明します。対応できない経路は
+  ACO所有の停止ジョブにせず、登録済みの外部BigInteger計画Consumerへ渡せます。
+
+### API
+
+- CPUアドオン向けのバージョン付きBigInteger容量上限照会APIを追加しました。
+- Optional連携がACO内部のキーCodec型へ依存せずに使えるAEKey数量Ledger Factoryを
+  追加しました。
+
+### 検証
+
+- `clean build`とNeoForge版の全自動テストが成功しました。

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ minecraft_version=1.21.1
 neo_version=21.1.247
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.24
+mod_version=1.5.25
 mod_group=com.syaru.ae2craftingoptimizer


### PR DESCRIPTION
## 目的

取り込み済みのwide容量判定・exact境界route・Optional連携修正を、NeoForge 1.21.1向けACO 1.5.25としてリリースします。

## 内容

- ACO承認済みwide計画をAE2標準`long`容量gateから安全に引き継ぐ
- Optional連携Facade登録前でもexact容量予約を昇格可能にする
- Optional連携Mixinを各連携の対象クラスで選択する
- 実行所有権の取得前にexactストレージ境界routeを証明する
- BigInteger容量上限照会APIとAEKey数量Ledger Factoryの版差を解消する
- 英語・日本語のリリースノートを追加する
- バージョンを1.5.25へ更新する

## 検証

- `gradlew.bat clean build --no-daemon`: 成功
- JUnit/test classes: 100、failure/errorなし

Minecraft起動試験はこのPRでは実施しません。
