### PR TITLE
fix(1.20.1): Dedicated ServerのSoundInstance誤ロードを止める

### DIFF
--- a/docs/REGRESSION_HISTORY.md
+++ b/docs/REGRESSION_HISTORY.md
@@ -13,6 +13,7 @@
 | [#102](https://github.com/syarukasu/ae2-crafting-optimizer/issues/102) | 小規模ジョブが初回probeへ縮小されPattern Provider配送が遅延する | 1.5.19 | 1.5.20 | [ISSUE-102.md](issues/ISSUE-102.md) |
 | [#103](https://github.com/syarukasu/ae2-crafting-optimizer/issues/103) | wide計画の実行裏付け不足がCPU容量不足と誤報される | 1.5.19 | 1.5.20 | [ISSUE-103.md](issues/ISSUE-103.md) |
 | [#109](https://github.com/syarukasu/ae2-crafting-optimizer/issues/109) | BigInteger API連携が通常AE2の責務境界を越える | 1.5.20 | 1.5.21 | [ISSUE-109.md](issues/ISSUE-109.md) |
+| [#140](https://github.com/syarukasu/ae2-crafting-optimizer/issues/140) | Mekanism入力探索がDedicated Serverでclient-only音声型を毎tick解決する | 1.5.25 | 未リリース | [ISSUE-140.md](issues/ISSUE-140.md) |
 | 外部コンシューマ回帰 | 実経路でsidecarが消える、またはQuantum Bulkが`maxPatterns=1`へ誤って制限される | 1.5.18系 | 作業中 | [ISSUE-BIGINT-EXTERNAL-CONSUMER.md](ISSUE-BIGINT-EXTERNAL-CONSUMER.md) |
 
 ## 運用

--- a/docs/issues/ISSUE-140.md
+++ b/docs/issues/ISSUE-140.md
@@ -1,0 +1,65 @@
+# Issue #140: Mekanism Recipe IntentがDedicated ServerでSoundInstanceを毎tick誤ロードする
+
+- GitHub Issue: https://github.com/syarukasu/ae2-crafting-optimizer/issues/140
+- 状態: Fixed in branch
+- 対象版: 1.5.25
+- 対象ローダー: Forge 1.20.1 / NeoForge 1.21.1
+- 関連Issue・PR: Issue #129
+
+## 問題
+
+Mekanism Recipe Intent高速化がMekanism機械の全フィールド型をDedicated Serverで解決し、
+client-onlyの`SoundInstance`を読み込もうとしてRuntimeDistCleanerエラーを毎tick出力します。
+実環境では約20件/tick、合計137万件以上を確認しました。
+
+## 再現と証拠
+
+- `enableMekanismRecipeIntentFastPath = true`でMekanism機械へRecipe Intentを配信する
+- `TileEntityMekanism`の`activeSound`フィールドへ`Field#getType()`が到達する
+- `ClassValue`初期化が完了せず、対象機械ごとに次tickも同じ型解決を再試行する
+- ログ: `Attempted to load class net/minecraft/client/resources/sounds/SoundInstance for invalid dist DEDICATED_SERVER`
+
+## 期待結果
+
+入力ハンドラー候補だけをReflection対象にし、レシピ結果と通常Fallbackを変えず、
+Dedicated Serverではクライアント専用フィールド型を解決しません。
+
+## 所有権
+
+- Mekanismが機械・入力ハンドラー・レシピ成立判定を所有する
+- ACOはProvider Intentに対応する候補の索引とキャッシュだけを所有する
+- ACOが候補を証明できなければMekanism標準探索へ戻す
+
+## 維持する不変条件
+
+- 入力ハンドラーの優先順、配列判定、Recipe Intent候補、レシピ結果を変更しない
+- Reflection失敗時はレシピを捏造せず、既存どおり標準探索へ戻す
+
+## やってはいけないこと
+
+- Log4jフィルターだけでエラーを隠す
+- Mekanism本体JARを改変する
+- フィールド名で候補を限定する前に`Field#getType()`を呼ぶ
+- Recipe Intent高速化の成立条件を緩和する
+
+## 修正方針
+
+`buildInputFieldAccessors`で`inputHandler`を含まない名前を先に除外し、候補フィールドにだけ
+`Field#getType()`を実行します。処理結果は変えず、危険な型解決順序だけを修正します。
+
+## 試験計画
+
+- JUnitで名前ゲートが型解決より前に存在することを固定する
+- Forge 1.20.1とNeoForge 1.21.1で`clean build`を実行する
+- 起動試験はユーザー指示により実施しない
+
+## 実装結果
+
+- `MekanismRecipeIntentFastPath`の型解決順序を修正
+- `MekanismRecipeIntentDedicatedServerSafetyTest`を追加
+
+## 検証結果
+
+- Forge 1.20.1: `gradlew.bat clean build --no-daemon` 成功
+- JUnit: 395件中393件成功、既存2件skip、失敗0件
+- 起動試験: ユーザー指示により未実施

--- a/docs/issues/REGRESSION_MATRIX.tsv
+++ b/docs/issues/REGRESSION_MATRIX.tsv
@@ -1,5 +1,5 @@
 # repository=https://github.com/syarukasu/ae2-crafting-optimizer
-# synchronized_through_issue=123
+# synchronized_through_issue=140
 # runtime_status: NOT_REQUIRED, VERIFIED, PENDING
 issue	kind	loaders	required	automated_evidence	runtime_status	runtime_evidence	summary
 1	COMPATIBILITY	NEOFORGE_1_21_1	STATIC	.github/workflows/build.yml	NOT_REQUIRED	-	NeoForge 1.21.1 port
@@ -48,3 +48,4 @@ issue	kind	loaders	required	automated_evidence	runtime_status	runtime_evidence	s
 119	REGRESSION	NEOFORGE_1_21_1	GAMETEST	src/test/java/com/syaru/ae2craftingoptimizer/integration/Issues118To120RegressionTest.java	PENDING	-	Shutdown exact job NBT loss
 120	REGRESSION	NEOFORGE_1_21_1	RUNTIME	src/test/java/com/syaru/ae2craftingoptimizer/integration/Issues118To120RegressionTest.java	PENDING	-	Advanced AE mixin startup self contradiction
 123	DOCUMENTATION	BOTH	UNIT	src/test/java/com/syaru/ae2craftingoptimizer/integration/IssueRegressionManifestTest.java	NOT_REQUIRED	-	Machine readable regression release gate
+140	REGRESSION	BOTH	UNIT	src/test/java/com/syaru/ae2craftingoptimizer/mekanism/MekanismRecipeIntentDedicatedServerSafetyTest.java	NOT_REQUIRED	-	Dedicated Server client-only SoundInstance reflection spam

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mekanism/MekanismRecipeIntentFastPath.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mekanism/MekanismRecipeIntentFastPath.java
@@ -306,6 +306,10 @@ public final class MekanismRecipeIntentFastPath {
                 if (lowerName.contains("output") || lowerName.contains("energy")) {
                     continue;
                 }
+                // Issue #140: Dedicated Serverで無関係なclient-onlyフィールド型を解決しないため、名前を先に絞ります。
+                if (!lowerName.contains("inputhandler")) {
+                    continue;
+                }
                 boolean array = field.getType().isArray();
                 if (array ? !lowerName.contains("inputhandlers") : !lowerName.contains("inputhandler")) {
                     continue;

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/IssueRegressionManifestTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/IssueRegressionManifestTest.java
@@ -24,7 +24,7 @@ class IssueRegressionManifestTest {
     private static final Set<Integer> EXPECTED_ISSUES = Set.of(
             1, 3, 5, 7, 8, 9, 10, 11, 12, 13, 14, 28, 29, 30, 32, 35, 37, 39, 42, 44, 46, 51, 53,
             55, 58, 61, 64, 71, 74, 75, 77, 79, 84, 87, 90, 93, 98, 101, 102, 103, 109, 115, 118,
-            119, 120, 123);
+            119, 120, 123, 140);
     private static final Set<String> KINDS =
             Set.of("COMPATIBILITY", "REGRESSION", "FEATURE", "RELEASE", "ROADMAP", "DOCUMENTATION");
     private static final Set<String> LOADERS = Set.of("FORGE_1_20_1", "NEOFORGE_1_21_1", "BOTH");
@@ -35,7 +35,7 @@ class IssueRegressionManifestTest {
     void registersEveryKnownIssueWithValidEvidence() throws IOException {
         Manifest manifest = readManifest();
 
-        assertEquals(123, manifest.synchronizedThroughIssue(), "同期済みIssue番号が古くなっています");
+        assertEquals(140, manifest.synchronizedThroughIssue(), "同期済みIssue番号が古くなっています");
         assertEquals(HEADER, manifest.header(), "TSVの列定義が変わっています");
         assertEquals(EXPECTED_ISSUES.size(), manifest.rows().size(), "Issue行数が一致しません");
 

--- a/src/test/java/com/syaru/ae2craftingoptimizer/mekanism/MekanismRecipeIntentDedicatedServerSafetyTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/mekanism/MekanismRecipeIntentDedicatedServerSafetyTest.java
@@ -1,0 +1,32 @@
+package com.syaru.ae2craftingoptimizer.mekanism;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/** Issue #140で発生したDedicated Server上のclient-only型解決スパムを固定する。 */
+class MekanismRecipeIntentDedicatedServerSafetyTest {
+    private static final Path SOURCE = Path.of(
+            "src/main/java/com/syaru/ae2craftingoptimizer/mekanism/MekanismRecipeIntentFastPath.java");
+
+    @Test
+    void inputHandlerNameGatePrecedesFieldTypeResolution() throws IOException {
+        String source = Files.readString(SOURCE, StandardCharsets.UTF_8);
+        int methodStart = source.indexOf("private static List<InputFieldAccessor> buildInputFieldAccessors");
+        int methodEnd = source.indexOf("private static void addInputHandler", methodStart);
+        String method = source.substring(methodStart, methodEnd);
+
+        int nameGate = method.indexOf("if (!lowerName.contains(\"inputhandler\"))");
+        int typeResolution = method.indexOf("field.getType().isArray()");
+
+        assertTrue(nameGate >= 0, "入力ハンドラー名による事前選別が必要です");
+        assertTrue(typeResolution >= 0, "配列入力ハンドラーの判定は維持します");
+        assertTrue(
+                nameGate < typeResolution,
+                "Dedicated Serverでは無関係フィールドの型を解決する前に名前で除外する必要があります");
+    }
+}


### PR DESCRIPTION
## 原因

Mekanism Recipe Intentの入力ハンドラー探索が、フィールド名を確認する前に全非staticフィールドへ`Field#getType()`を呼んでいました。Mekanism共通BlockEntityの`activeSound: SoundInstance`までDedicated Serverで型解決され、RuntimeDistCleanerエラーと`ClassValue`再試行が毎tick発生していました。

## 修正

- `inputHandler`候補名を先に選別
- 候補にだけ`Field#getType()`を実行
- レシピ候補、入力優先順、成立判定、標準Fallbackは変更なし
- Issue #140の仕様書、回帰台帳、順序固定JUnitを追加

## 検証

- `gradlew.bat clean build --no-daemon`: 成功
- JUnit: 395件中393件成功、既存2件skip、失敗0件

Closes #140