### PR TITLE
release: ACO 1.5.26 for NeoForge 1.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.26] - 2026-08-23
+
+### Fixed
+
+- Fixed Issue #140: Mekanism Recipe Intent no longer resolves unrelated
+  client-only field types on a dedicated server.
+- Stopped repeated `SoundInstance` invalid-dist errors caused by failed
+  `ClassValue` initialization being retried for active Mekanism machines.
+- Preserved the existing recipe candidates, input priority, validation, and
+  standard Mekanism fallback behavior.
+
+### Verification
+
+- Passed the complete build and JUnit regression suite for both maintained
+  Minecraft versions.
+
 ## [1.5.25] - 2026-08-23
 
 ### Fixed

--- a/RELEASE_NOTES_1.5.26.md
+++ b/RELEASE_NOTES_1.5.26.md
@@ -1,0 +1,35 @@
+# AE2 Crafting Optimizer 1.5.26
+
+## English
+
+### Fixed
+
+- Fixed dedicated-server log spam from Mekanism Recipe Intent optimization.
+- ACO now filters fields by the `inputHandler` naming contract before resolving
+  their Java types. This prevents Mekanism's client-only `SoundInstance` field
+  from being resolved on a dedicated server.
+- Prevented failed `ClassValue` initialization from being retried for every
+  affected machine on every tick.
+- Recipe candidates, input priority, recipe validation, and the standard
+  Mekanism fallback path remain unchanged.
+
+### Compatibility
+
+- Forge 1.20.1: Applied Energistics 2 15.4.x and AE2 UELM 15.5.x.
+- NeoForge 1.21.1: Applied Energistics 2 19.2.x.
+
+## 日本語
+
+### 修正
+
+- Mekanism Recipe Intent最適化がDedicated Serverのログを大量に汚染する問題を修正しました。
+- Javaの型を解決する前に、フィールド名が`inputHandler`規約へ一致するか判定します。
+  これにより、Mekanismのクライアント専用`SoundInstance`フィールドをDedicated Serverで
+  読み込まなくなります。
+- `ClassValue`の初期化失敗が、対象機械ごとに毎tick再試行される問題を解消しました。
+- レシピ候補、入力優先順、レシピ成立判定、Mekanism標準Fallbackは変更していません。
+
+### 対応環境
+
+- Forge 1.20.1: Applied Energistics 2 15.4.x / AE2 UELM 15.5.x
+- NeoForge 1.21.1: Applied Energistics 2 19.2.x

--- a/docs/REGRESSION_HISTORY.md
+++ b/docs/REGRESSION_HISTORY.md
@@ -17,7 +17,7 @@
 | [#118](https://github.com/syarukasu/ae2-crafting-optimizer/issues/118) | 正常な空Journalを成功量0として扱いexact物理実行が自己隔離する | 1.5.23初回Draft | 1.5.23再公開 | [ISSUE-118.md](issues/ISSUE-118.md) |
 | [#119](https://github.com/syarukasu/ae2-crafting-optimizer/issues/119) | 停止時にRegistry Providerを先に破棄しexact JobとBlock EntityのNBT保存が失敗する | 1.5.23初回Draft | 1.5.23再公開 | [ISSUE-119.md](issues/ISSUE-119.md) |
 | [#120](https://github.com/syarukasu/ae2-crafting-optimizer/issues/120) | Mixin初期化中のModList判定でAdvanced AE変換を自己無効化する | 1.5.23初回Draft | 1.5.23再公開 | [ISSUE-120.md](issues/ISSUE-120.md) |
-| [#140](https://github.com/syarukasu/ae2-crafting-optimizer/issues/140) | Mekanism入力探索がDedicated Serverでclient-only音声型を毎tick解決する | 1.5.25 | 未リリース | [ISSUE-140.md](issues/ISSUE-140.md) |
+| [#140](https://github.com/syarukasu/ae2-crafting-optimizer/issues/140) | Mekanism入力探索がDedicated Serverでclient-only音声型を毎tick解決する | 1.5.25 | 1.5.26 | [ISSUE-140.md](issues/ISSUE-140.md) |
 
 ## 運用
 

--- a/docs/issues/ISSUE-140.md
+++ b/docs/issues/ISSUE-140.md
@@ -1,8 +1,9 @@
 # Issue #140: Mekanism Recipe IntentがDedicated ServerでSoundInstanceを毎tick誤ロードする
 
 - GitHub Issue: https://github.com/syarukasu/ae2-crafting-optimizer/issues/140
-- 状態: Fixed in branch
+- 状態: Fixed in 1.5.26
 - 対象版: 1.5.25
+- 修正版: 1.5.26
 - 対象ローダー: Forge 1.20.1 / NeoForge 1.21.1
 - 関連Issue・PR: Issue #129
 
@@ -51,7 +52,6 @@ Dedicated Serverではクライアント専用フィールド型を解決しま�
 
 - JUnitで名前ゲートが型解決より前に存在することを固定する
 - Forge 1.20.1とNeoForge 1.21.1で`clean build`を実行する
-- 起動試験はユーザー指示により実施しない
 
 ## 実装結果
 
@@ -62,4 +62,3 @@ Dedicated Serverではクライアント専用フィールド型を解決しま�
 
 - NeoForge 1.21.1: `gradlew.bat clean build --no-daemon` 成功
 - JUnit: 412件成功、失敗0件
-- 起動試験: ユーザー指示により未実施

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ minecraft_version=1.21.1
 neo_version=21.1.247
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.25
+mod_version=1.5.26
 mod_group=com.syaru.ae2craftingoptimizer


### PR DESCRIPTION
## 1.5.26

Issue #140のDedicated Serverログスパム修正を1.5.26として公開するリリースPRです。

### 変更

- Mekanism Recipe Intentの入力フィールド探索で、名前を絞る前に全フィールド型を解決していた順序を修正
- `activeSound: SoundInstance`をDedicated Serverで誤解決しないように変更
- Recipe Intentの候補、優先順、成立判定、Fallbackは維持
- Changelog、回帰履歴、日英リリースノートを更新

### 検証

- `gradlew.bat clean build --no-daemon`: 成功
- JAR: `aco1.5.26_1.21.1.jar`
- Implementation-Version: `1.5.26`