### PR TITLE
1.5.27: Issue #129の安全境界を完成化 (Forge 1.20.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [1.5.27] - 2026-08-23
+
+### Changed
+
+- Completed the Issue #129 optimization architecture for Forge 1.20.1 and NeoForge 1.21.1.
+- Replaced the 64-feature diagnostic ceiling with a dynamically sized lock-free bit set.
+- Classified eleven unsafe legacy switches as retired compatibility keys and recorded their safe replacements.
+- Added build-time checks that every active feature is connected to the central Config gate or Mixin catalog.
+- Kept deprecated broad storage, GUI, packet, and Grid Tick rewrites disabled.
+
+### Compatibility
+
+- Clarified the conditional AE2-UELM long-amount Mixin boundary without changing upstream AE2 behavior.
+
 ## [1.5.26] - 2026-08-23
 
 ### Fixed

--- a/RELEASE_NOTES_1.5.27.md
+++ b/RELEASE_NOTES_1.5.27.md
@@ -1,0 +1,41 @@
+# AE2 Crafting Optimizer 1.5.27
+
+## English
+
+### Architecture
+
+- Completed the optimization-domain and safety-gate architecture introduced by Issue #129.
+- Added a central feature registry shared by Config, diagnostics, and the complete Mixin catalog.
+- Removed the 64-feature diagnostics ceiling. The lock-free diagnostic bit set now grows with the feature registry.
+- Added static release gates that reject active features without a Config or Mixin boundary.
+
+### Safety
+
+- Eleven unsafe legacy switches are now explicitly classified as retired compatibility keys.
+- Existing TOML files remain readable, but removed mutable inventory, GUI packet, and broad Grid Tick hooks cannot be re-enabled.
+- Each retired key records its reason and the active, narrowly scoped optimization that replaces it.
+
+### Compatibility
+
+- Forge 1.20.1: Applied Energistics 2 15.4.x and AE2 UELM 15.5.x.
+- NeoForge 1.21.1: Applied Energistics 2 19.2.x.
+
+## 日本語
+
+### アーキテクチャ
+
+- Issue #129で導入した最適化domainと安全gateの設計を完成させました。
+- Config、診断、全Mixin台帳が共有する中央機能レジストリを追加しました。
+- 診断機能数の64件上限を撤廃し、機能台帳に応じて増えるlock-free bit集合へ変更しました。
+- ACTIVE機能がConfigまたはMixin境界へ接続されていない場合、ビルドを失敗させる静的検査を追加しました。
+
+### 安全性
+
+- 危険だった旧11設定を、未完成ではなく廃止済み互換キーとして確定しました。
+- 既存TOMLは引き続き読み込めますが、撤去済みの可変在庫、GUI packet、広範囲Grid Tick hookは再有効化されません。
+- 各廃止キーへ理由と、現在稼働する限定的な代替最適化を記録しました。
+
+### 対応環境
+
+- Forge 1.20.1: Applied Energistics 2 15.4.x / AE2 UELM 15.5.x
+- NeoForge 1.21.1: Applied Energistics 2 19.2.x

--- a/docs/issues/ISSUE-129.md
+++ b/docs/issues/ISSUE-129.md
@@ -122,7 +122,7 @@ storage、pattern、topology、resource reload、server lifecycleを共通世代
 - 全登録Mixinを`MixinFeatureCatalog`へ対応付け、未登録Mixinをfail-closed化
 - 各機能へrisk、正本所有者、fallback境界、関連Issue、実装状態、失効イベントを宣言
 - server start/stopでgate診断を初期化し、`/aco stats`用summaryへ拒否理由を追加
-- 1.2.2で削除した可変Storage I/O・GUI・Grid Tick経路を`COMPATIBILITY_NOOP`へ固定
+- 1.2.2で削除した可変Storage I/O・GUI・Grid Tick経路を`RETIRED_COMPATIBILITY_KEY`へ固定
 - Export Busの安全な失敗クラフト要求backoffを、削除済みGrid Tick masterから分離
 - Import Busは直前成功slotを検査順のhintとしてだけ再利用し、抽出・挿入・rollbackはAE2へ維持
 - Export Busは設定世代ごとの候補keyだけをcacheし、未知のConfigInventory実装ではAE2の直接読取へfallback

--- a/docs/issues/ISSUE-145.md
+++ b/docs/issues/ISSUE-145.md
@@ -1,0 +1,26 @@
+# Issue #145: Issue #129完成化と安全境界の固定
+
+- GitHub Issue: https://github.com/syarukasu/ae2-crafting-optimizer/issues/145
+- 対象版: 1.5.27
+- 対象ローダー: Forge 1.20.1 / NeoForge 1.21.1
+
+## 問題
+
+Issue #129の中央台帳とgateは実装済みでしたが、診断bitが64機能固定で、廃止済み互換キーが未完成機能に見え、新しい非Mixin runtime入口のgate接続漏れを十分に検出できませんでした。ForgeのUELM依存ビルドには、実行時に除外されるMixinの`@Shadow`警告も残っていました。
+
+## 修正
+
+- 診断bit集合を機能数に追従する複数wordの`AtomicLongArray`へ変更
+- 130機能を仮定したword境界試験を追加
+- 旧11キーを`RETIRED_COMPATIBILITY_KEY`として確定
+- 全廃止キーへ廃止理由と安全な代替機能を宣言
+- ACTIVE機能がConfigまたはMixin台帳へ接続されることを静的検査
+- `OptimizationFeatureGate`の直接呼出しを`ACOConfig`へ限定
+- ForgeのUELM所有Mixinへ条件付きtargetであることを明示
+
+## 不変条件
+
+- 旧危険Mixinは再登録しない
+- 既存Configキーは読み込み可能なまま維持する
+- AE2の在庫、GUI、packet、レシピ成立、実行順を変更しない
+- BigIntegerと外部アドオンの所有権境界を変更しない

--- a/docs/issues/REGRESSION_MATRIX.tsv
+++ b/docs/issues/REGRESSION_MATRIX.tsv
@@ -1,5 +1,5 @@
 # repository=https://github.com/syarukasu/ae2-crafting-optimizer
-# synchronized_through_issue=140
+# synchronized_through_issue=145
 # runtime_status: NOT_REQUIRED, VERIFIED, PENDING
 issue	kind	loaders	required	automated_evidence	runtime_status	runtime_evidence	summary
 1	COMPATIBILITY	NEOFORGE_1_21_1	STATIC	.github/workflows/build.yml	NOT_REQUIRED	-	NeoForge 1.21.1 port
@@ -51,3 +51,4 @@ issue	kind	loaders	required	automated_evidence	runtime_status	runtime_evidence	s
 125	REGRESSION	BOTH	GAMETEST	src/test/java/com/syaru/ae2craftingoptimizer/issue125/Issue125RegressionSourceTest.java	PENDING	-	Exact physical crafting accepted but remains at zero output
 129	ARCHITECTURE	BOTH	UNIT	src/test/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationFeatureGateTest.java;src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue129ArchitectureSourceTest.java	NOT_REQUIRED	-	GTNH inspired optimization domains and fail closed ownership gates
 140	REGRESSION	BOTH	UNIT	src/test/java/com/syaru/ae2craftingoptimizer/mekanism/MekanismRecipeIntentDedicatedServerSafetyTest.java	NOT_REQUIRED	-	Dedicated Server client-only SoundInstance reflection spam
+145	ARCHITECTURE	BOTH	UNIT	src/test/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationFeatureGateTest.java;src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue129ArchitectureSourceTest.java	NOT_REQUIRED	-	Issue 129 completion hardening and 1.5.27 release

--- a/docs/optimization/FEATURE_DOMAINS.md
+++ b/docs/optimization/FEATURE_DOMAINS.md
@@ -1,6 +1,6 @@
 # ACO最適化ドメイン
 
-Issue #129以降、最適化は次の八領域へ分けます。個別機能は`OptimizationFeature`へ登録し、`OptimizationFeatureGate`を通過した場合だけ動作します。設定キーだけ残る機能は`OptimizationImplementationStatus.COMPATIBILITY_NOOP`とし、値が`true`でも実行しません。現在の稼働状況は[IMPLEMENTATION_STATUS.md](IMPLEMENTATION_STATUS.md)を正本とします。
+Issue #129以降、最適化は次の八領域へ分けます。個別機能は`OptimizationFeature`へ登録し、`OptimizationFeatureGate`を通過した場合だけ動作します。設定キーだけ残る廃止済み機能は`OptimizationImplementationStatus.RETIRED_COMPATIBILITY_KEY`とし、値が`true`でも実行しません。現在の稼働状況は[IMPLEMENTATION_STATUS.md](IMPLEMENTATION_STATUS.md)を正本とします。
 
 | Domain | 目的 | 正本 | 無効時 |
 |---|---|---|---|

--- a/docs/optimization/IMPLEMENTATION_STATUS.md
+++ b/docs/optimization/IMPLEMENTATION_STATUS.md
@@ -1,17 +1,21 @@
 # Issue #129 実装状態
 
-この表は「設定キーが存在する」と「実行経路が存在する」を分離します。`ACTIVE`だけが稼働対象です。`COMPATIBILITY_NOOP`は既存TOMLとの互換性のため値を読みますが、共通gateが必ず拒否します。
+この表は「設定キーが存在する」と「実行経路が存在する」を分離します。`ACTIVE`だけが稼働対象です。`RETIRED_COMPATIBILITY_KEY`は既存TOMLとの互換性のため値を読みますが、危険な旧実装は廃止済みであり、共通gateが必ず拒否します。これらは未完成機能の待機列ではありません。
 
-| 領域 | ACTIVE | COMPATIBILITY_NOOP | 理由と境界 |
+| 領域 | ACTIVE | RETIRED_COMPATIBILITY_KEY | 理由と境界 |
 |---|---|---|---|
 | Network topology | P2P同一通知の短時間重複排除 | Grid Tick全面延期、Storage更新coalesce | 接続・切断・周波数・電力変化はAE2へ即時通知する。進捗を持つTickableを遅延しない |
-| Storage I/O | Import Busの直前成功slotを先頭検査するscan-order hint、Export Busの設定世代付き候補cacheと失敗要求backoff、IO Portのround-robin slot window | Capability、transfer simulation、bus operation cap | 候補順と設定keyだけをcacheする。抽出・挿入・simulation・rollback・セル移動はAE2本体を正本とし、hint不成立時は同じ呼出し内でAE2通常経路へ戻る |
+| Storage I/O | Import Busの直前成功slotを先頭検査するscan-order hint、Export Busの設定世代付き候補cacheと失敗要求backoff、IO Portのround-robin slot window | Capability cache、negative transfer cache、bus operation cap、bus search cache | 候補順と設定keyだけをcacheする。抽出・挿入・simulation・rollback・セル移動はAE2本体を正本とし、hint不成立時は同じ呼出し内でAE2通常経路へ戻る |
 | Pattern provider | Pattern索引、内容世代、同一tick refresh coalesce | terminal用craftable-set cache | 読み取り前にpending refreshをflushし、Provider内容またはresource reloadで失効する |
-| Client sync | 不変Projectionだけをworkerへ渡す端末検索・sort、失敗時のAE2同期更新fallback、scrollbar release安全化 | 端末update coalescing、表示range、Storage Watcher throttle | server inventory・packet・virtual slotを変更しない。可変AEKey/Entryはclient threadで読み、古い世代の結果は破棄する |
+| Client sync | 不変Projectionだけをworkerへ渡す端末検索・sort、失敗時のAE2同期更新fallback、scrollbar release安全化 | two-stage missing preview、端末update coalescing、表示range、Storage Watcher throttle | server inventory・packet・virtual slotを変更しない。可変AEKey/Entryはclient threadで読み、古い世代の結果は破棄する |
 | Crafting planning | 計算内memo、候補剪定、compiled graph、checked arithmetic、overflow昇格 | なし | mutable在庫量をcacheせず、辞退はownership取得前だけ行う |
-| Crafting execution | CPU/grid予算、receipt付きtransaction、fair scheduler | 旧V1 aggregate実行 | ownership取得後はcommit、rollback、quarantineのいずれかで閉じる |
+| Crafting execution | CPU/grid予算、receipt付きtransaction、fair scheduler | なし | ownership取得後はcommit、rollback、quarantineのいずれかで閉じる |
 | BigInteger | exact snapshot、wide plan、long window、exact vector会計 | なし | BigInteger正本をlongへ切り捨てず、表示値を会計へ使用しない |
-| Optional integration | GTCEu/Mekanism intent、Advanced AE/ExtendedAE/NeoECO Adapter | Create予約キー | 外部MODのrecipe validity、機械進捗、構造、GUIを所有しない |
+| Optional integration | GTCEu/Mekanism intent、Advanced AE/ExtendedAE/NeoECO Adapter | なし | 外部MODのrecipe validity、機械進捗、構造、GUIを所有しない |
+
+## 廃止キーと安全な代替
+
+廃止理由と安全な代替は`OptimizationFeature.retirementReason()`および`safeReplacements()`を正本とし、JUnitで全件を検証します。広範囲なTick延期、可変在庫cache、packet範囲制限は再実装せず、P2P通知重複排除、実行予算、走査順hint、候補key cache、不変Projection検索へ分割しました。two-stage missing previewは最終結果前の表示がプレイヤー判断を変えるため、代替なしで廃止しています。
 
 ## Storage I/Oを再実装する条件
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.26
+mod_version=1.5.27
 minecraft_version=1.20.1
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOStartupReport.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/lifecycle/ACOStartupReport.java
@@ -35,14 +35,14 @@ final class ACOStartupReport {
                     domain,
                     ACOConfig.rawDomainEnabled(domain));
         }
-        String compatibilityNoops = Arrays.stream(OptimizationFeature.values())
+        String retiredCompatibilityKeys = Arrays.stream(OptimizationFeature.values())
                 .filter(feature -> feature.implementationStatus()
-                        == OptimizationImplementationStatus.COMPATIBILITY_NOOP)
+                        == OptimizationImplementationStatus.RETIRED_COMPATIBILITY_KEY)
                 .map(OptimizationFeature::id)
                 .collect(Collectors.joining(", "));
         AE2CraftingOptimizer.LOGGER.info(
-                "ACO compatibility-only features (never activated by legacy config): {}",
-                compatibilityNoops);
+                "ACO retired compatibility keys (never activated by legacy config): {}",
+                retiredCompatibilityKeys);
         AE2CraftingOptimizer.LOGGER.info(
                 "ACO two-stage missing preview: {}, cache: {} entries / {}s TTL",
                 ACOConfig.twoStageMissingPreview(),

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftConfirmMenuLongAmountMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftConfirmMenuLongAmountMixin.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.concurrent.Future;
 import net.minecraft.server.level.ServerPlayer;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -31,21 +32,27 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  * CraftConfirmMenuにlongルート量のSidecarを追加し、
  * AE2本来のbeginCraftingCalculation(..., long, ...)へ無損失で渡す。
  */
+@SuppressWarnings("target")
 @Mixin(value = CraftConfirmMenu.class, remap = false)
 public abstract class CraftConfirmMenuLongAmountMixin
         implements LongCraftConfirmMenuBridge {
+    @Dynamic("AE2-UELM owns this long amount surface and the bootstrap plugin excludes this Mixin")
     @Shadow
     private AEKey whatToCraft;
 
+    @Dynamic("AE2-UELM owns this long amount surface and the bootstrap plugin excludes this Mixin")
     @Shadow
     private int amount;
 
+    @Dynamic("AE2-UELM owns this long amount surface and the bootstrap plugin excludes this Mixin")
     @Shadow
     private Future<ICraftingPlan> job;
 
+    @Dynamic("AE2-UELM owns this long amount surface and the bootstrap plugin excludes this Mixin")
     @Shadow
     private ICraftingPlan result;
 
+    @Dynamic("AE2-UELM owns this long amount surface and the bootstrap plugin excludes this Mixin")
     @Shadow
     public abstract void clearError();
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationFeature.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationFeature.java
@@ -123,8 +123,47 @@ public enum OptimizationFeature {
                     IO_BUS_OPERATION_LIMIT,
                     BUS_SEARCH_CACHE,
                     STORAGE_WATCHER_THROTTLE ->
-                    OptimizationImplementationStatus.COMPATIBILITY_NOOP;
+                    OptimizationImplementationStatus.RETIRED_COMPATIBILITY_KEY;
             default -> OptimizationImplementationStatus.ACTIVE;
+        };
+    }
+
+    /**
+     * 廃止した広範囲hookの代わりに稼働する、意味論を変えない限定最適化。
+     *
+     * <p>完全な同義置換ではなく、旧hookが狙っていた負荷源を安全な所有権境界で処理する。
+     */
+    public Set<OptimizationFeature> safeReplacements() {
+        return switch (this) {
+            case CRAFTABLE_SET_CACHE -> Set.of(PATTERN_LOOKUP_CACHE, PROVIDER_GENERATION_TRACKING);
+            case TERMINAL_UPDATE_COALESCING, TERMINAL_RANGE_SYNC, STORAGE_WATCHER_THROTTLE ->
+                    Set.of(TERMINAL_ASYNC_SEARCH);
+            case GRID_TICK_BUDGET -> Set.of(CRAFTING_EXECUTION_BUDGET, P2P_TOPOLOGY_DEDUPLICATION);
+            case NETWORK_UPDATE_COALESCING -> Set.of(P2P_TOPOLOGY_DEDUPLICATION);
+            case ADJACENT_CAPABILITY_CACHE -> Set.of(IMPORT_LAST_SLOT_CACHE, EXPORT_CANDIDATE_CACHE);
+            case NEGATIVE_TRANSFER_CACHE -> Set.of(EXPORT_CANDIDATE_CACHE, EXPORT_CRAFT_REQUEST_BACKOFF);
+            case IO_BUS_OPERATION_LIMIT -> Set.of(INCREMENTAL_IO_PORT, EXPORT_CRAFT_REQUEST_BACKOFF);
+            case BUS_SEARCH_CACHE -> Set.of(IMPORT_LAST_SLOT_CACHE, EXPORT_CANDIDATE_CACHE);
+            case TWO_STAGE_MISSING_PREVIEW -> Set.of();
+            default -> Set.of();
+        };
+    }
+
+    /** 廃止済み互換キーを誤って未実装機能として復活させないための根拠。 */
+    public String retirementReason() {
+        return switch (this) {
+            case CRAFTABLE_SET_CACHE -> "mutable craftable set snapshots can become stale during provider updates";
+            case TWO_STAGE_MISSING_PREVIEW -> "preliminary missing results can change player decisions before AE2 finishes";
+            case TERMINAL_UPDATE_COALESCING -> "coalescing mutable terminal updates can hide accepted insertions or removals";
+            case TERMINAL_RANGE_SYNC -> "range-limited packets can desynchronize AE2 virtual slots";
+            case GRID_TICK_BUDGET -> "delaying arbitrary tickables changes machine and network execution order";
+            case NETWORK_UPDATE_COALESCING -> "coalescing topology notifications can delay disconnect and security state";
+            case ADJACENT_CAPABILITY_CACHE -> "capabilities can invalidate between simulation and modulation";
+            case NEGATIVE_TRANSFER_CACHE -> "a previous transfer failure is not proof that the current transfer fails";
+            case IO_BUS_OPERATION_LIMIT -> "a global operation cap changes configured bus throughput";
+            case BUS_SEARCH_CACHE -> "cached mutable inventories can miss external slot changes";
+            case STORAGE_WATCHER_THROTTLE -> "throttled watcher state can make terminal inventory differ from the server";
+            default -> "";
         };
     }
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationFeatureGate.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationFeatureGate.java
@@ -3,7 +3,7 @@ package com.syaru.ae2craftingoptimizer.optimization;
 import com.syaru.ae2craftingoptimizer.config.ACOConfig;
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
 
 /**
  * 最適化入口の共通gate。
@@ -12,18 +12,11 @@ import java.util.concurrent.atomic.AtomicLong;
  * どこか一つでも無効なら、呼び出し側はAE2の状態へ触れずreturnする。
  */
 public final class OptimizationFeatureGate {
-    /** 1機能1bitで保持するため、hot pathで拒否回数を加算し続けない。 */
-    private static final AtomicLong MASTER_DENIAL_MASK = new AtomicLong();
-    private static final AtomicLong DOMAIN_DENIAL_MASK = new AtomicLong();
-    private static final AtomicLong FEATURE_DENIAL_MASK = new AtomicLong();
-    private static final AtomicLong UNAVAILABLE_MASK = new AtomicLong();
-
-    static {
-        // 固定long bitsetの範囲を超えた場合は、黙って診断を欠落させず開発時に停止する。
-        if (OptimizationFeatureRegistry.all().size() > Long.SIZE) {
-            throw new IllegalStateException("OptimizationFeature exceeds the 64-bit diagnostics mask");
-        }
-    }
+    /** 機能数に応じて64bit wordを増やし、hot pathでは同じ拒否を一度だけ記録する。 */
+    private static final ConcurrentFeatureBits MASTER_DENIALS = diagnosticsBits();
+    private static final ConcurrentFeatureBits DOMAIN_DENIALS = diagnosticsBits();
+    private static final ConcurrentFeatureBits FEATURE_DENIALS = diagnosticsBits();
+    private static final ConcurrentFeatureBits RETIRED_COMPATIBILITY_KEYS = diagnosticsBits();
 
     private OptimizationFeatureGate() {
     }
@@ -65,72 +58,112 @@ public final class OptimizationFeatureGate {
         }
         // 互換Configだけ残る機能は、trueでも実装済みのように振る舞わせない。
         if (implementationStatus != OptimizationImplementationStatus.ACTIVE) {
-            return Decision.IMPLEMENTATION_UNAVAILABLE;
+            return Decision.RETIRED_COMPATIBILITY_KEY;
         }
         return Decision.ENABLED;
     }
 
     public static Map<OptimizationDomain, DenialSnapshot> denialSnapshot() {
         EnumMap<OptimizationDomain, DenialSnapshot> snapshot = new EnumMap<>(OptimizationDomain.class);
-        long masterMask = MASTER_DENIAL_MASK.get();
-        long domainMask = DOMAIN_DENIAL_MASK.get();
-        long featureMask = FEATURE_DENIAL_MASK.get();
-        long unavailableMask = UNAVAILABLE_MASK.get();
         // 診断値を安定したdomain順で返すため、enum全件を一度だけ走査する。
         for (OptimizationDomain domain : OptimizationDomain.values()) {
             long masterDenied = 0L;
             long domainDenied = 0L;
             long featureDenied = 0L;
-            long unavailable = 0L;
+            long retired = 0L;
             // 同じdomainへ属する拒否済みfeature bitだけを集計する。
             for (OptimizationFeature feature : OptimizationFeatureRegistry.forDomain(domain)) {
-                long bit = bit(feature);
-                masterDenied += (masterMask & bit) == 0L ? 0L : 1L;
-                domainDenied += (domainMask & bit) == 0L ? 0L : 1L;
-                featureDenied += (featureMask & bit) == 0L ? 0L : 1L;
-                unavailable += (unavailableMask & bit) == 0L ? 0L : 1L;
+                masterDenied += MASTER_DENIALS.contains(feature.ordinal()) ? 1L : 0L;
+                domainDenied += DOMAIN_DENIALS.contains(feature.ordinal()) ? 1L : 0L;
+                featureDenied += FEATURE_DENIALS.contains(feature.ordinal()) ? 1L : 0L;
+                retired += RETIRED_COMPATIBILITY_KEYS.contains(feature.ordinal()) ? 1L : 0L;
             }
-            snapshot.put(domain, new DenialSnapshot(masterDenied, domainDenied, featureDenied, unavailable));
+            snapshot.put(domain, new DenialSnapshot(masterDenied, domainDenied, featureDenied, retired));
         }
         return Map.copyOf(snapshot);
     }
 
     public static void resetDiagnostics() {
-        MASTER_DENIAL_MASK.set(0L);
-        DOMAIN_DENIAL_MASK.set(0L);
-        FEATURE_DENIAL_MASK.set(0L);
-        UNAVAILABLE_MASK.set(0L);
+        MASTER_DENIALS.clear();
+        DOMAIN_DENIALS.clear();
+        FEATURE_DENIALS.clear();
+        RETIRED_COMPATIBILITY_KEYS.clear();
     }
 
-    private static void record(OptimizationFeature feature, Decision decision) {
-        long bit = bit(feature);
+    static void record(OptimizationFeature feature, Decision decision) {
         switch (decision) {
-            case MASTER_DISABLED -> markOnce(MASTER_DENIAL_MASK, bit);
-            case DOMAIN_DISABLED -> markOnce(DOMAIN_DENIAL_MASK, bit);
-            case FEATURE_DISABLED -> markOnce(FEATURE_DENIAL_MASK, bit);
-            case IMPLEMENTATION_UNAVAILABLE -> markOnce(UNAVAILABLE_MASK, bit);
+            case MASTER_DISABLED -> MASTER_DENIALS.mark(feature.ordinal());
+            case DOMAIN_DISABLED -> DOMAIN_DENIALS.mark(feature.ordinal());
+            case FEATURE_DISABLED -> FEATURE_DENIALS.mark(feature.ordinal());
+            case RETIRED_COMPATIBILITY_KEY -> RETIRED_COMPATIBILITY_KEYS.mark(feature.ordinal());
             case ENABLED -> {
                 // 有効判定は通常経路なので、診断counterを増やさない。
             }
         }
     }
 
-    private static long bit(OptimizationFeature feature) {
-        return 1L << feature.ordinal();
+    private static ConcurrentFeatureBits diagnosticsBits() {
+        return new ConcurrentFeatureBits(OptimizationFeatureRegistry.all().size());
     }
 
-    private static void markOnce(AtomicLong mask, long bit) {
-        long current = mask.get();
-        // 同じ拒否は既に観測済みなので、CAS writeを繰り返さずreturnする。
-        if ((current & bit) != 0L) {
-            return;
+    /** 64機能を超えても拡張できる、固定長・lock-freeの診断bit集合。 */
+    static final class ConcurrentFeatureBits {
+        /** 一つのlong wordが保持するbit数。 */
+        private static final int BITS_PER_WORD = Long.SIZE;
+        /** 64bit wordのindexへ変換する右shift数。 */
+        private static final int WORD_SHIFT = 6;
+        /** word内bit indexを0から63へ収めるmask。 */
+        private static final int WORD_BIT_MASK = BITS_PER_WORD - 1;
+
+        private final int featureCount;
+        private final AtomicLongArray words;
+
+        ConcurrentFeatureBits(int featureCount) {
+            // 空または負の台帳は診断契約を成立させないため拒否する。
+            if (featureCount <= 0) {
+                throw new IllegalArgumentException("featureCount must be positive");
+            }
+            this.featureCount = featureCount;
+            this.words = new AtomicLongArray(((featureCount - 1) / BITS_PER_WORD) + 1);
         }
-        // 別threadが別featureを同時記録してもbitを失わないよう、成功まで再読込する。
-        while (!mask.compareAndSet(current, current | bit)) {
-            current = mask.get();
-            // 競合threadが同じbitを記録済みなら追加writeは不要。
+
+        void mark(int featureIndex) {
+            validateIndex(featureIndex);
+            int wordIndex = featureIndex >>> WORD_SHIFT;
+            long bit = 1L << (featureIndex & WORD_BIT_MASK);
+            long current = this.words.get(wordIndex);
+            // 同じ拒否は既に観測済みなので、CAS writeを繰り返さずreturnする。
             if ((current & bit) != 0L) {
                 return;
+            }
+            // 別threadが別機能を同時記録してもbitを失わないよう、成功まで再読込する。
+            while (!this.words.compareAndSet(wordIndex, current, current | bit)) {
+                current = this.words.get(wordIndex);
+                // 競合threadが同じbitを記録済みなら追加writeは不要。
+                if ((current & bit) != 0L) {
+                    return;
+                }
+            }
+        }
+
+        boolean contains(int featureIndex) {
+            validateIndex(featureIndex);
+            int wordIndex = featureIndex >>> WORD_SHIFT;
+            long bit = 1L << (featureIndex & WORD_BIT_MASK);
+            return (this.words.get(wordIndex) & bit) != 0L;
+        }
+
+        void clear() {
+            // server lifecycleをまたいで古い拒否診断を残さないため、全wordを初期化する。
+            for (int wordIndex = 0; wordIndex < this.words.length(); wordIndex++) {
+                this.words.set(wordIndex, 0L);
+            }
+        }
+
+        private void validateIndex(int featureIndex) {
+            // 台帳外indexは別機能の診断bitを壊すため、呼出側の不整合として拒否する。
+            if (featureIndex < 0 || featureIndex >= this.featureCount) {
+                throw new IndexOutOfBoundsException("featureIndex=" + featureIndex);
             }
         }
     }
@@ -140,13 +173,13 @@ public final class OptimizationFeatureGate {
         MASTER_DISABLED,
         DOMAIN_DISABLED,
         FEATURE_DISABLED,
-        IMPLEMENTATION_UNAVAILABLE
+        RETIRED_COMPATIBILITY_KEY
     }
 
     public record DenialSnapshot(
             long masterDisabled,
             long domainDisabled,
             long featureDisabled,
-            long implementationUnavailable) {
+            long retiredCompatibilityKey) {
     }
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationImplementationStatus.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationImplementationStatus.java
@@ -8,6 +8,6 @@ package com.syaru.ae2craftingoptimizer.optimization;
 public enum OptimizationImplementationStatus {
     /** 対応するruntime入口と回帰試験が存在する。 */
     ACTIVE,
-    /** 既存TOMLを読めるようキーだけ残し、実行経路は意図的に登録しない。 */
-    COMPATIBILITY_NOOP
+    /** 既存TOMLを読めるようキーだけ残すが、危険な旧実装は廃止済みで再登録しない。 */
+    RETIRED_COMPATIBILITY_KEY
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationMetrics.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationMetrics.java
@@ -352,11 +352,11 @@ public final class OptimizationMetrics {
         for (var entry : OptimizationFeatureGate.denialSnapshot().entrySet()) {
             OptimizationFeatureGate.DenialSnapshot denial = entry.getValue();
             lines.add("Feature gate " + entry.getKey()
-                    + ": denied feature(s) by master/domain/feature/unavailable "
+                    + ": denied feature(s) by master/domain/feature/retired "
                     + denial.masterDisabled() + "/"
                     + denial.domainDisabled() + "/"
                     + denial.featureDisabled() + "/"
-                    + denial.implementationUnavailable());
+                    + denial.retiredCompatibilityKey());
         }
         return List.copyOf(lines);
     }

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue129ArchitectureSourceTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue129ArchitectureSourceTest.java
@@ -1,12 +1,18 @@
 package com.syaru.ae2craftingoptimizer.integration;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import com.syaru.ae2craftingoptimizer.mixin.MixinFeatureCatalog;
+import com.syaru.ae2craftingoptimizer.optimization.OptimizationFeature;
+import com.syaru.ae2craftingoptimizer.optimization.OptimizationImplementationStatus;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class Issue129ArchitectureSourceTest {
@@ -22,6 +28,39 @@ class Issue129ArchitectureSourceTest {
         assertTrue(source.contains("OptimizationFeature.CRAFTING_EXECUTION_BUDGET"));
         assertTrue(source.contains("OptimizationFeature.TERMINAL_UPDATE_COALESCING"));
         assertTrue(source.contains("OptimizationFeature.P2P_TOPOLOGY_DEDUPLICATION"));
+    }
+
+    @Test
+    void everyActiveFeatureIsConnectedToAConfigOrMixinBoundary() throws IOException {
+        String config = Files.readString(CONFIG, StandardCharsets.UTF_8);
+        Set<OptimizationFeature> mixinFeatures = Set.copyOf(MixinFeatureCatalog.snapshot().values());
+        // ACTIVE機能が中央gateにもMixin台帳にも接続されず、名前だけ残る状態を拒否する。
+        for (OptimizationFeature feature : OptimizationFeature.values()) {
+            // 廃止済み互換キーは実行入口を持たないことが契約なので対象外とする。
+            if (feature.implementationStatus() != OptimizationImplementationStatus.ACTIVE) {
+                continue;
+            }
+            boolean connectedToConfig = config.contains("OptimizationFeature." + feature.name());
+            assertTrue(connectedToConfig || mixinFeatures.contains(feature), feature.id());
+        }
+    }
+
+    @Test
+    void runtimeCodeCannotBypassTheConfigGateBoundary() throws IOException {
+        Path sourceRoot = Path.of("src/main/java");
+        Set<Path> directCallers = new HashSet<>();
+        try (var paths = Files.walk(sourceRoot)) {
+            // 本番Java型を全件調べ、共通gateの直接呼出しを設定境界へ限定する。
+            for (Path path : paths.filter(candidate -> candidate.toString().endsWith(".java")).toList()) {
+                String source = Files.readString(path, StandardCharsets.UTF_8);
+                // gateを直接呼ばない型は設定getter経由なので記録しない。
+                if (!source.contains("OptimizationFeatureGate.allows(")) {
+                    continue;
+                }
+                directCallers.add(path.normalize());
+            }
+        }
+        assertEquals(Set.of(CONFIG.normalize()), directCallers);
     }
 
     @Test

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/IssueRegressionManifestTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/IssueRegressionManifestTest.java
@@ -24,7 +24,7 @@ class IssueRegressionManifestTest {
     private static final Set<Integer> EXPECTED_ISSUES = Set.of(
             1, 3, 5, 7, 8, 9, 10, 11, 12, 13, 14, 28, 29, 30, 32, 35, 37, 39, 42, 44, 46, 51, 53,
             55, 58, 61, 64, 71, 74, 75, 77, 79, 84, 87, 90, 93, 98, 101, 102, 103, 109, 115, 118,
-            119, 120, 123, 125, 129, 140);
+            119, 120, 123, 125, 129, 140, 145);
     private static final Set<String> KINDS =
             Set.of("COMPATIBILITY", "REGRESSION", "FEATURE", "RELEASE", "ROADMAP", "DOCUMENTATION", "ARCHITECTURE");
     private static final Set<String> LOADERS = Set.of("FORGE_1_20_1", "NEOFORGE_1_21_1", "BOTH");
@@ -35,7 +35,7 @@ class IssueRegressionManifestTest {
     void registersEveryKnownIssueWithValidEvidence() throws IOException {
         Manifest manifest = readManifest();
 
-        assertEquals(140, manifest.synchronizedThroughIssue(), "同期済みIssue番号が古くなっています");
+        assertEquals(145, manifest.synchronizedThroughIssue(), "同期済みIssue番号が古くなっています");
         assertEquals(HEADER, manifest.header(), "TSVの列定義が変わっています");
         assertEquals(EXPECTED_ISSUES.size(), manifest.rows().size(), "Issue行数が一致しません");
 

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/MixinFeatureCatalogTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/MixinFeatureCatalogTest.java
@@ -51,7 +51,7 @@ class MixinFeatureCatalogTest {
     }
 
     @Test
-    void compatibilityNoopCanNeverHaveAConfiguredMixin() {
+    void retiredCompatibilityKeyCanNeverHaveAConfiguredMixin() {
         // 互換キーだけの機能へMixinを戻す場合は、先に台帳と回帰試験をACTIVEへ更新させる。
         for (var entry : MixinFeatureCatalog.snapshot().entrySet()) {
             assertEquals(

--- a/src/test/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationFeatureGateTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationFeatureGateTest.java
@@ -42,14 +42,87 @@ class OptimizationFeatureGateTest {
     }
 
     @Test
-    void compatibilityNoopCannotBeEnabledByItsLegacyConfigKey() {
+    void retiredCompatibilityKeyCannotEnableItsRemovedRuntimePath() {
         assertEquals(
-                OptimizationFeatureGate.Decision.IMPLEMENTATION_UNAVAILABLE,
+                OptimizationFeatureGate.Decision.RETIRED_COMPATIBILITY_KEY,
                 OptimizationFeatureGate.evaluate(
                         true,
                         true,
                         true,
-                        OptimizationImplementationStatus.COMPATIBILITY_NOOP));
+                        OptimizationImplementationStatus.RETIRED_COMPATIBILITY_KEY));
+    }
+
+    @Test
+    void diagnosticsSupportMoreThanSixtyFourFeatures() {
+        // 130機能を仮定し、三つのlong wordをまたぐindexを正確に保持できることを検査する。
+        OptimizationFeatureGate.ConcurrentFeatureBits bits =
+                new OptimizationFeatureGate.ConcurrentFeatureBits(130);
+        bits.mark(0);
+        bits.mark(64);
+        bits.mark(129);
+
+        assertTrue(bits.contains(0));
+        assertTrue(bits.contains(64));
+        assertTrue(bits.contains(129));
+        assertFalse(bits.contains(63));
+        assertFalse(bits.contains(128));
+
+        bits.clear();
+        assertFalse(bits.contains(0));
+        assertFalse(bits.contains(64));
+        assertFalse(bits.contains(129));
+    }
+
+    @Test
+    void everyRetiredKeyHasAReasonAndOnlyActiveReplacements() {
+        long retiredCount = Arrays.stream(OptimizationFeature.values())
+                .filter(feature -> feature.implementationStatus()
+                        == OptimizationImplementationStatus.RETIRED_COMPATIBILITY_KEY)
+                .count();
+        // Issue #145で監査した廃止キーは11件。追加する場合は理由と代替を明示して再審査する。
+        assertEquals(11L, retiredCount);
+        // 廃止キーを未完成扱いで復活させないよう、理由と安全な後継機能を検査する。
+        Arrays.stream(OptimizationFeature.values())
+                .filter(feature -> feature.implementationStatus()
+                        == OptimizationImplementationStatus.RETIRED_COMPATIBILITY_KEY)
+                .forEach(feature -> {
+                    assertFalse(feature.retirementReason().isBlank(), feature.id());
+                    feature.safeReplacements().forEach(replacement -> assertEquals(
+                            OptimizationImplementationStatus.ACTIVE,
+                            replacement.implementationStatus(),
+                            feature.id() + " -> " + replacement.id()));
+                });
+    }
+
+    @Test
+    void denialSnapshotSeparatesReasonsAndResetClearsThem() {
+        OptimizationFeatureGate.record(
+                OptimizationFeature.BIG_INTEGER_BACKEND,
+                OptimizationFeatureGate.Decision.MASTER_DISABLED);
+        OptimizationFeatureGate.record(
+                OptimizationFeature.LONG_ROOT_AMOUNTS,
+                OptimizationFeatureGate.Decision.DOMAIN_DISABLED);
+        OptimizationFeatureGate.record(
+                OptimizationFeature.EXACT_INVENTORY_SNAPSHOT,
+                OptimizationFeatureGate.Decision.FEATURE_DISABLED);
+        OptimizationFeatureGate.record(
+                OptimizationFeature.TWO_STAGE_MISSING_PREVIEW,
+                OptimizationFeatureGate.Decision.RETIRED_COMPATIBILITY_KEY);
+
+        var bigInteger = OptimizationFeatureGate.denialSnapshot().get(OptimizationDomain.BIG_INTEGER);
+        assertEquals(1L, bigInteger.masterDisabled());
+        assertEquals(1L, bigInteger.domainDisabled());
+        assertEquals(1L, bigInteger.featureDisabled());
+        assertEquals(0L, bigInteger.retiredCompatibilityKey());
+
+        var clientSync = OptimizationFeatureGate.denialSnapshot().get(OptimizationDomain.CLIENT_SYNC);
+        assertEquals(1L, clientSync.retiredCompatibilityKey());
+
+        OptimizationFeatureGate.resetDiagnostics();
+        var resetBigInteger = OptimizationFeatureGate.denialSnapshot().get(OptimizationDomain.BIG_INTEGER);
+        assertEquals(0L, resetBigInteger.masterDisabled());
+        assertEquals(0L, resetBigInteger.domainDisabled());
+        assertEquals(0L, resetBigInteger.featureDisabled());
     }
 
     @Test


### PR DESCRIPTION
## 目的

Issue #129で導入した最適化機能の責務境界を、Forge 1.20.1版で完成させます。

Issue #145に対応します。

## 変更内容

- 互換キーとして残っていた11機能を、未完成機能ではなく廃止済み互換キーとして明示
- 各廃止キーへ理由と安全な代替機能を定義
- 64機能で上限に達する診断ビット集合を複数ワード対応へ変更
- ACTIVE機能がConfigまたはMixinカタログへ接続されていることを静的試験で保証
- 実行時ゲートをACOConfig以外から直接呼び出さないことを静的試験で保証
- UELMビルド時のMixin Shadow警告を解消
- `/aco stats`と起動診断の用語を実装状態に合わせて整理
- Issue #145の回帰契約、変更履歴、1.5.27リリースノートを追加

## 安全性

- 廃止した危険な旧経路は再有効化しません
- 既存TOMLキーは読み取り互換を維持します
- 有効な最適化は従来どおりConfigとFeature Gateを通ります
- クラフト結果、在庫、レシピ、CPU実行処理は変更しません

## 検証

- Forge 1.20.1通常AE2: `gradlew clean build --no-daemon` 成功
- Forge 1.20.1 UELM: `gradlew clean build --no-daemon -Pae2Variant=uelm` 成功
- JUnit: 430件、失敗0、エラー0、スキップ2
- `git diff --check` 成功

