### PR TITLE
[1.21.1] 1.5.29: ストレージモニターのlong超過表示を飽和する

### DIFF
--- a/docs/CLASS_RESPONSIBILITIES.md
+++ b/docs/CLASS_RESPONSIBILITIES.md
@@ -89,7 +89,7 @@ mixin + access  ->  integration  ->  optimization / scheduler
 
 ## 全トップレベル型一覧
 
-本版の本番トップレベル型: **381件**
+本版の本番トップレベル型: **382件**
 
 ### `com.syaru.ae2craftingoptimizer`
 
@@ -426,6 +426,7 @@ mixin + access  ->  integration  ->  optimization / scheduler
 
 | クラス | 仕事 |
 |---|---|
+| `com.syaru.ae2craftingoptimizer.mixin.AbstractMonitorPartDisplaySaturationMixin` | AbstractMonitorPartDisplaySaturationMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
 | `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeBigCapacityPlanSubmissionMixin` | AdvancedAeBigCapacityPlanSubmissionMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
 | `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingBlockEntityTransactionAccessMixin` | AdvancedAeCraftingBlockEntityTransactionAccessMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |
 | `com.syaru.ae2craftingoptimizer.mixin.AdvancedAeCraftingClusterBigWindowMixin` | AdvancedAeCraftingClusterBigWindowMixinが示す最適化またはexact会計を既存処理へ接続する薄いMixin境界。業務ロジックは非Mixin層へ委譲する。 |

--- a/docs/REGRESSION_HISTORY.md
+++ b/docs/REGRESSION_HISTORY.md
@@ -19,6 +19,7 @@
 | [#120](https://github.com/syarukasu/ae2-crafting-optimizer/issues/120) | Mixin初期化中のModList判定でAdvanced AE変換を自己無効化する | 1.5.23初回Draft | 1.5.23再公開 | [ISSUE-120.md](issues/ISSUE-120.md) |
 | [#140](https://github.com/syarukasu/ae2-crafting-optimizer/issues/140) | Mekanism入力探索がDedicated Serverでclient-only音声型を毎tick解決する | 1.5.25 | 1.5.26 | [ISSUE-140.md](issues/ISSUE-140.md) |
 | [#148](https://github.com/syarukasu/ae2-crafting-optimizer/issues/148) | 同一キーのmounted storage合計がlong境界を超えると端末表示が消える | 1.5.27以前 | 1.5.28 | [ISSUE-148.md](issues/ISSUE-148.md) |
+| [#153](https://github.com/syarukasu/ae2-crafting-optimizer/issues/153) | 同一キーのmounted storage合計がlong境界を超えるとストレージモニターが負数化する | 1.5.28以前 | 1.5.29 | [ISSUE-153.md](issues/ISSUE-153.md) |
 
 ## 運用
 

--- a/docs/issues/ISSUE-148.md
+++ b/docs/issues/ISSUE-148.md
@@ -3,7 +3,7 @@
 ## 問題
 
 Applied Fluxなど、同じAEKeyを複数のmounted storageが公開する環境で、合計在庫が
-`Long.MAX_VALUE`を超えるとME端末とストレージモニターの表示が消える、または負数化する。
+`Long.MAX_VALUE`を超えるとME端末の表示が消える、または負数化する。
 
 ## 原因
 
@@ -20,6 +20,8 @@ AE2 19.2.xの`NetworkStorage#getAvailableStacks`は、各mountの値を`KeyCount
 - BigInteger正本はSidecarへ保持し、longへ切り捨てない。
 - Grid本体以外のPortable CellやAddon固有端末はAE2本来の経路へ委譲する。
 - Storageの`insert`、`extract`、watcher、serial、クラフト計算は変更しない。
+
+ストレージモニターは別のcached inventory経路を使用するため、Issue #153で独立して修正する。
 
 ## Issue #109との境界
 

--- a/docs/issues/ISSUE-153.md
+++ b/docs/issues/ISSUE-153.md
@@ -1,0 +1,34 @@
+# Issue #153: Long.MAX_VALUE超過在庫でストレージモニターが負数化する
+
+## 問題
+
+同じAEKeyを複数のmounted storageが公開し、合計が`Long.MAX_VALUE`を超えると、
+MEストレージモニターと変換モニターの表示量が負数化する。負数を受理しない後続処理では
+クラッシュする場合がある。
+
+## 原因
+
+Issue #148の修正対象は`MEStorageMenu#broadcastChanges`の端末Packet用Snapshotだけだった。
+モニターは別経路の`AbstractMonitorPart#updateReportingValue`で
+`IStorageService#getCachedInventory()`を読み、既にwrapした`long`を`amount`へ保存していた。
+
+## 修正
+
+- `AbstractMonitorPart#updateReportingValue`内のcached inventory取得だけをRedirectする。
+- exact mountを列挙できるNetworkStorageでは、Issue #148と同じ表示用飽和Snapshotを使う。
+- 機能OFFまたはexact mountを列挙できないStorageでは、AE2のcached counterを同一インスタンスで返す。
+- watcher、NBT、Packet形式、render、クリック、挿入、抽出、クラフト会計は変更しない。
+
+## 禁止事項
+
+- `IStorageService#getCachedInventory()`の正本を書き換えない。
+- `NetworkStorage#getAvailableStacks`へ常時Mixinを戻さない。
+- 負数を0として扱わない。
+- exact非対応Storageを推測でBigInteger化しない。
+
+## 回帰試験
+
+- monitor cached値が負数でも、exact mount合計`Long.MAX_VALUE + Long.MAX_VALUE`は`Long.MAX_VALUE`表示になる。
+- 機能OFFでは元のcached counterを返す。
+- exact非対応Storageでは元のcached counterを返す。
+- Mixinは`updateReportingValue`の`getCachedInventory()`一箇所だけを対象にする。

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -31,3 +31,4 @@
 - [Issue #123](ISSUE-123.md): 過去Issueと回帰試験をリリース判定へ接続する
 - [Issue #129](ISSUE-129.md): GTNH/AE2-UEL思想に基づく最適化アーキテクチャの再構築
 - [Issue #148](ISSUE-148.md): Long.MAX_VALUE超過在庫が端末から消える
+- [Issue #153](ISSUE-153.md): Long.MAX_VALUE超過在庫でストレージモニターが負数化する

--- a/docs/issues/REGRESSION_MATRIX.tsv
+++ b/docs/issues/REGRESSION_MATRIX.tsv
@@ -1,5 +1,5 @@
 # repository=https://github.com/syarukasu/ae2-crafting-optimizer
-# synchronized_through_issue=148
+# synchronized_through_issue=153
 # runtime_status: NOT_REQUIRED, VERIFIED, PENDING
 issue	kind	loaders	required	automated_evidence	runtime_status	runtime_evidence	summary
 1	COMPATIBILITY	NEOFORGE_1_21_1	STATIC	.github/workflows/build.yml	NOT_REQUIRED	-	NeoForge 1.21.1 port
@@ -53,3 +53,4 @@ issue	kind	loaders	required	automated_evidence	runtime_status	runtime_evidence	s
 140	REGRESSION	BOTH	UNIT	src/test/java/com/syaru/ae2craftingoptimizer/mekanism/MekanismRecipeIntentDedicatedServerSafetyTest.java	NOT_REQUIRED	-	Dedicated Server client-only SoundInstance reflection spam
 145	ARCHITECTURE	BOTH	UNIT	src/test/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationFeatureGateTest.java;src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue129ArchitectureSourceTest.java	NOT_REQUIRED	-	Issue 129 completion hardening and 1.5.27 release
 148	REGRESSION	BOTH	UNIT	src/test/java/com/syaru/ae2craftingoptimizer/integration/TerminalDisplaySnapshotProjectionTest.java;src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue109MixinBoundarySourceTest.java	NOT_REQUIRED	-	Terminal display saturation without storage or interaction ownership
+153	REGRESSION	BOTH	UNIT	src/test/java/com/syaru/ae2craftingoptimizer/integration/TerminalDisplaySnapshotProjectionTest.java;src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue109MixinBoundarySourceTest.java	NOT_REQUIRED	-	Storage monitor display saturation without cached inventory ownership

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ minecraft_version=1.21.1
 neo_version=21.1.247
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.28
+mod_version=1.5.29
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/integration/TerminalDisplaySnapshotProjection.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/integration/TerminalDisplaySnapshotProjection.java
@@ -1,5 +1,6 @@
 package com.syaru.ae2craftingoptimizer.integration;
 
+import appeng.api.networking.storage.IStorageService;
 import appeng.api.stacks.KeyCounter;
 import appeng.api.storage.MEStorage;
 import com.syaru.ae2craftingoptimizer.access.NetworkStorageMountsAccess;
@@ -24,6 +25,31 @@ public final class TerminalDisplaySnapshotProjection {
         return availableStacks(
                 menuStorage,
                 ACOConfig.enableExactBigIntegerInventorySnapshots());
+    }
+
+    /** ストレージモニターへ送る表示値だけを安全なSnapshotへ投影する。 */
+    public static KeyCounter monitorStacks(IStorageService storageService) {
+        Objects.requireNonNull(storageService, "storageService");
+        KeyCounter cachedInventory = storageService.getCachedInventory();
+        // 機能OFF時はNetworkStorageへ触れず、AE2が保持する同じCounterを返す。
+        if (!ACOConfig.enableExactBigIntegerInventorySnapshots()) {
+            return cachedInventory;
+        }
+        return monitorStacks(storageService.getInventory(), cachedInventory, true);
+    }
+
+    /** Forge Configを起動しない単体試験から、モニター表示境界を検証する内部入口。 */
+    static KeyCounter monitorStacks(
+            MEStorage networkStorage,
+            KeyCounter cachedInventory,
+            boolean enabled) {
+        Objects.requireNonNull(networkStorage, "networkStorage");
+        Objects.requireNonNull(cachedInventory, "cachedInventory");
+        // exact mountを列挙できないStorageは推測で補正せず、AE2のcached値へ戻す。
+        if (!enabled || !(networkStorage instanceof NetworkStorageMountsAccess)) {
+            return cachedInventory;
+        }
+        return availableStacks(networkStorage, true);
     }
 
     /** NeoForge Configを起動しない単体試験から、有効状態だけを明示する内部入口。 */

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AbstractMonitorPartDisplaySaturationMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/AbstractMonitorPartDisplaySaturationMixin.java
@@ -1,0 +1,23 @@
+package com.syaru.ae2craftingoptimizer.mixin;
+
+import appeng.api.networking.storage.IStorageService;
+import appeng.api.stacks.KeyCounter;
+import appeng.parts.reporting.AbstractMonitorPart;
+import com.syaru.ae2craftingoptimizer.integration.TerminalDisplaySnapshotProjection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+/** Issue #153の飽和処理を、ストレージモニターの表示値取得だけへ接続する。 */
+@Mixin(value = AbstractMonitorPart.class, priority = 900, remap = false)
+public abstract class AbstractMonitorPartDisplaySaturationMixin {
+    @Redirect(
+            method = "updateReportingValue",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lappeng/api/networking/storage/IStorageService;getCachedInventory()Lappeng/api/stacks/KeyCounter;"),
+            require = 1)
+    private KeyCounter aco$saturateStorageMonitorDisplaySnapshot(IStorageService storageService) {
+        return TerminalDisplaySnapshotProjection.monitorStacks(storageService);
+    }
+}

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/MixinFeatureCatalog.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/MixinFeatureCatalog.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 /** NeoForge core MixinとIssue #129の機能契約を結ぶ明示台帳。 */
 public final class MixinFeatureCatalog {
     private static final Map<String, OptimizationFeature> FEATURES = Map.ofEntries(
+            entry("AbstractMonitorPartDisplaySaturationMixin", OptimizationFeature.EXACT_INVENTORY_SNAPSHOT),
             entry("Ae2BigCapacityPlanSubmissionMixin", OptimizationFeature.ATOMIC_BIG_CAPACITY_PLANS),
             entry("Ae2ExactCraftingLogicMixin", OptimizationFeature.EXACT_VECTOR_CRAFTING),
             entry("CraftAmountMenuLongAmountMixin", OptimizationFeature.LONG_ROOT_AMOUNTS),

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationFeature.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationFeature.java
@@ -47,7 +47,7 @@ public enum OptimizationFeature {
     BIG_INTEGER_BACKEND("big-integer-backend", OptimizationDomain.BIG_INTEGER, OptimizationRisk.HIGH, StateOwnership.ACO_CACHE, FallbackBoundary.BEFORE_OWNERSHIP, Set.of(79, 87, 90, 93, 98, 101, 103, 109)),
     LONG_ROOT_AMOUNTS("long-root-amounts", OptimizationDomain.BIG_INTEGER, OptimizationRisk.HIGH, StateOwnership.AE2, FallbackBoundary.BEFORE_OWNERSHIP, Set.of(79, 98, 109)),
     ATOMIC_BIG_CAPACITY_PLANS("atomic-big-capacity-plans", OptimizationDomain.BIG_INTEGER, OptimizationRisk.HIGH, StateOwnership.ACO_TRANSACTION, FallbackBoundary.NEVER_AFTER_OWNERSHIP, Set.of(98, 115, 118, 125)),
-    EXACT_INVENTORY_SNAPSHOT("exact-inventory-snapshot", OptimizationDomain.BIG_INTEGER, OptimizationRisk.HIGH, StateOwnership.ACO_CACHE, FallbackBoundary.BEFORE_OWNERSHIP, Set.of(87, 93, 101, 109)),
+    EXACT_INVENTORY_SNAPSHOT("exact-inventory-snapshot", OptimizationDomain.BIG_INTEGER, OptimizationRisk.HIGH, StateOwnership.ACO_CACHE, FallbackBoundary.BEFORE_OWNERSHIP, Set.of(87, 93, 101, 109, 148, 153)),
     BIG_INTEGER_GAMEPLAY_EXECUTION("big-integer-gameplay-execution", OptimizationDomain.BIG_INTEGER, OptimizationRisk.HIGH, StateOwnership.ACO_TRANSACTION, FallbackBoundary.NEVER_AFTER_OWNERSHIP, Set.of(98, 101, 109, 115, 118, 119, 125)),
     EXACT_VECTOR_CRAFTING("exact-vector-crafting", OptimizationDomain.BIG_INTEGER, OptimizationRisk.HIGH, StateOwnership.ACO_TRANSACTION, FallbackBoundary.NEVER_AFTER_OWNERSHIP, Set.of(115, 118, 119, 125)),
     RECIPE_INTENT_BRIDGE("recipe-intent-bridge", OptimizationDomain.OPTIONAL_INTEGRATION, OptimizationRisk.MEDIUM, StateOwnership.EXTERNAL_ADDON, FallbackBoundary.BEFORE_MUTATION, Set.of(74)),

--- a/src/main/resources/ae2_crafting_optimizer.mixins.json
+++ b/src/main/resources/ae2_crafting_optimizer.mixins.json
@@ -5,6 +5,7 @@
   "plugin": "com.syaru.ae2craftingoptimizer.mixin.CoreMixinConfigPlugin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
+    "AbstractMonitorPartDisplaySaturationMixin",
     "Ae2BigCapacityPlanSubmissionMixin",
     "Ae2ExactCraftingLogicMixin",
     "CraftAmountMenuLongAmountMixin",

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue109MixinBoundarySourceTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue109MixinBoundarySourceTest.java
@@ -42,6 +42,17 @@ class Issue109MixinBoundarySourceTest {
         assertFalse(displayMixin.contains("handleInteraction"));
         assertFalse(displayMixin.contains("method = \"insert\""));
         assertFalse(displayMixin.contains("method = \"extract\""));
+
+        String monitorMixin = read(MAIN.resolve(Path.of(
+                "java", "com", "syaru", "ae2craftingoptimizer", "mixin",
+                "AbstractMonitorPartDisplaySaturationMixin.java")));
+        assertTrue(monitorMixin.contains("method = \"updateReportingValue\""));
+        assertTrue(monitorMixin.contains("IStorageService;getCachedInventory()"));
+        assertFalse(monitorMixin.contains("writeToNBT"));
+        assertFalse(monitorMixin.contains("readFromNBT"));
+        assertFalse(monitorMixin.contains("onPartActivate"));
+        assertFalse(monitorMixin.contains("method = \"insert\""));
+        assertFalse(monitorMixin.contains("method = \"extract\""));
     }
 
     @Test

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/IssueRegressionManifestTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/IssueRegressionManifestTest.java
@@ -24,7 +24,7 @@ class IssueRegressionManifestTest {
     private static final Set<Integer> EXPECTED_ISSUES = Set.of(
             1, 3, 5, 7, 8, 9, 10, 11, 12, 13, 14, 28, 29, 30, 32, 35, 37, 39, 42, 44, 46, 51, 53,
             55, 58, 61, 64, 71, 74, 75, 77, 79, 84, 87, 90, 93, 98, 101, 102, 103, 109, 115, 118,
-            119, 120, 123, 125, 129, 140, 145, 148);
+            119, 120, 123, 125, 129, 140, 145, 148, 153);
     private static final Set<String> KINDS =
             Set.of("COMPATIBILITY", "REGRESSION", "FEATURE", "RELEASE", "ROADMAP", "DOCUMENTATION", "ARCHITECTURE");
     private static final Set<String> LOADERS = Set.of("FORGE_1_20_1", "NEOFORGE_1_21_1", "BOTH");
@@ -35,7 +35,7 @@ class IssueRegressionManifestTest {
     void registersEveryKnownIssueWithValidEvidence() throws IOException {
         Manifest manifest = readManifest();
 
-        assertEquals(148, manifest.synchronizedThroughIssue(), "同期済みIssue番号が古くなっています");
+        assertEquals(153, manifest.synchronizedThroughIssue(), "同期済みIssue番号が古くなっています");
         assertEquals(HEADER, manifest.header(), "TSVの列定義が変わっています");
         assertEquals(EXPECTED_ISSUES.size(), manifest.rows().size(), "Issue行数が一致しません");
 

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/TerminalDisplaySnapshotProjectionTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/TerminalDisplaySnapshotProjectionTest.java
@@ -60,6 +60,66 @@ class TerminalDisplaySnapshotProjectionTest {
         assertSame(original, projected);
     }
 
+    @Test
+    void saturatesStorageMonitorAmountFromMountedStorages() {
+        TestNetworkStorage network = new TestNetworkStorage(List.of(
+                new FixedStorage(Long.MAX_VALUE),
+                new FixedStorage(Long.MAX_VALUE)));
+        KeyCounter overflowedCachedInventory = new KeyCounter();
+        overflowedCachedInventory.set(ENERGY, -2L);
+
+        KeyCounter projected = TerminalDisplaySnapshotProjection.monitorStacks(
+                network,
+                overflowedCachedInventory,
+                true);
+
+        assertEquals(Long.MAX_VALUE, projected.get(ENERGY));
+    }
+
+    @Test
+    void keepsOrdinaryStorageMonitorAmountExact() {
+        TestNetworkStorage network = new TestNetworkStorage(List.of(
+                new FixedStorage(2_000L),
+                new FixedStorage(3_000L)));
+        KeyCounter cachedInventory = new KeyCounter();
+        cachedInventory.set(ENERGY, 5_000L);
+
+        KeyCounter projected = TerminalDisplaySnapshotProjection.monitorStacks(
+                network,
+                cachedInventory,
+                true);
+
+        assertEquals(5_000L, projected.get(ENERGY));
+    }
+
+    @Test
+    void disabledStorageMonitorProjectionReturnsOriginalCachedInventory() {
+        KeyCounter cachedInventory = new KeyCounter();
+        cachedInventory.set(ENERGY, -2L);
+        TestNetworkStorage network = new TestNetworkStorage(List.of(new FixedStorage(Long.MAX_VALUE)));
+
+        KeyCounter projected = TerminalDisplaySnapshotProjection.monitorStacks(
+                network,
+                cachedInventory,
+                false);
+
+        assertSame(cachedInventory, projected);
+    }
+
+    @Test
+    void unsupportedStorageMonitorProjectionReturnsOriginalCachedInventory() {
+        KeyCounter cachedInventory = new KeyCounter();
+        cachedInventory.set(ENERGY, 42L);
+        MEStorage unsupportedStorage = new SnapshotStorage(cachedInventory);
+
+        KeyCounter projected = TerminalDisplaySnapshotProjection.monitorStacks(
+                unsupportedStorage,
+                cachedInventory,
+                true);
+
+        assertSame(cachedInventory, projected);
+    }
+
     private record FixedStorage(long amount) implements MEStorage {
         @Override
         public long insert(AEKey what, long amount, Actionable mode, IActionSource source) {


### PR DESCRIPTION
## 概要

Issue #153の、`Long.MAX_VALUE`を超えた同一キー在庫によってMEストレージモニターの表示値が負数化する問題を修正します。

## 原因

1.5.28のIssue #148修正は`MEStorageMenu`の端末Packet用Snapshotだけが対象でした。ストレージモニターは別経路の`AbstractMonitorPart#updateReportingValue`で、既にoverflowした`IStorageService#getCachedInventory()`を参照していました。

## 修正

- `updateReportingValue`内の`getCachedInventory()`一箇所だけをRedirectします。
- exact mountを列挙できるNetworkStorageでは、mount別に飽和集計した表示用Snapshotを返します。
- 機能OFFまたはexact非対応Storageでは、AE2のcached counterを同一インスタンスで返します。
- cached inventory正本、watcher、NBT、Packet形式、render、クリック、挿入、抽出、クラフト会計は変更しません。

## 回帰試験

- `Long.MAX_VALUE + Long.MAX_VALUE`は`Long.MAX_VALUE`表示
- `2,000 + 3,000`は`5,000`表示
- 機能OFFは元のcached counterを返す
- exact非対応Storageは元のcached counterを返す
- Mixin対象が表示更新一箇所だけであることをソース境界試験で固定
- NeoForge: 454 tests、failure 0、error 0、skip 0
- `clean test build`: 成功

Refs #153
