### PR TITLE
[1.21.1] 通常クラフト発注時の不要なexact計算を除去

### DIFF
--- a/docs/issues/ISSUE-156.md
+++ b/docs/issues/ISSUE-156.md
@@ -1,0 +1,135 @@
+# Issue #156: 通常クラフト発注時の不要なexact計算
+
+- GitHub Issue: https://github.com/syarukasu/ae2-crafting-optimizer/issues/156
+- 状態: In review
+- 対象版: Forge 1.20.1 / NeoForge 1.21.1
+- 関連Issue: #109, #125, #151, #153
+
+## 症状
+
+通常のint/long範囲の注文でも、発注直後の応答が非常に遅くなる。
+ACOが通常AE2計画を置換しない既定構成でも再現する。
+
+## 確定したRoot Cause
+
+次の四つが重なっていた。
+
+1. `enableAtomicBigCapacityPlans`が有効な場合、通常long置換が無効でも
+   `Ae2AuthoritativeCraftingPlanner.capture`が全注文で起動する。
+2. Captureは毎回`PlanningExactInventorySnapshot.capture(grid)`を実行し、
+   全mounted storageからexact在庫を収集する。
+3. 非同期Plannerは毎回、空在庫のBigInteger計画を最後まで展開してwide判定を行う。
+4. `CraftingCalculation`生成側で上記Captureを行うため、全mount走査は
+   AE2の`CRAFTING_POOL`へsubmitされる前の呼出スレッドで実行される。
+
+加えてShadow Modeは、通常long置換もwide資格要求も無効な場合まで
+Compiled Root Programと参照在庫を準備していた。このShadow結果には採用先がなく、
+既定構成では純粋な追加負荷だった。
+
+## 前の未検証修正で不十分だった点
+
+前差分は保守的なwide閾値を追加したが、次の理由で採用しなかった。
+
+- CraftingCalculation生成側でGraph、Root Program、Topology、閾値を新規構築していた。
+- 閾値生成はRootごとに最大63回DAGを走査し、cold pathをメインスレッドへ移していた。
+- 同一slotの代替候補をすべて合計した上界を、実際のwide判定として扱っていた。
+- 旧Capture経路を無条件wideとして扱い、従来の意味を変えていた。
+- 世代更新後も旧閾値判定を再利用でき、stale proofを新世代へ移せた。
+
+## 最終修正
+
+### Capture境界
+
+`Ae2CompiledCraftingGraphCache.currentSnapshot`は、現在世代の既存Snapshotだけを返す。
+Graph、Root Program、Topologyを新規構築しない。
+
+Captureは次の三状態を持つ。
+
+- `UNASSESSED`: cold cacheまたは未証明。exact在庫は持たず、非同期側で構造を判定する。
+- `PROVEN_LONG_SAFE`: 同一世代のcached safety certificateが成立し、exact在庫を持たない。
+- `EXACT_AVAILABLE`: wideが正確に確定した後、server executor上で取得したexact在庫を持つ。
+
+`CraftingCalculation`生成時は既存cacheを参照するだけで、Graph、Root Program、Topology、
+exact在庫のいずれも新規構築しない。cold通常注文は非同期側で一度だけ安全証明を作り、
+wideでなければexact在庫を走査せずAE2標準計画へ戻る。
+
+wideが確定した注文だけ、AE2計算Futureのworkerからserver executorへexact取得を委譲する。
+計画後の一致再検証に使うexact在庫もserver executorで再取得し、計算workerから
+mounted storageを直接走査しない。往復後にはPattern/recipe世代も再確認する。
+AE2本体は`CraftingCalculation`を生成した後に専用計算executorへsubmitしており、
+ACO、AQE、InsaneAEの確認済み利用箇所はFutureをtick間でpollするため、server threadを
+同期`get()`で塞ぐ経路にはならない。
+
+### wide判定
+
+`LongSafetyCertificate`はwideを確定しない。
+現在注文を一巡して代替候補をすべて含む保守的上界がlongに収まる場合だけ、安全と証明する。
+証明済みの最大注文量以下は同じ世代中O(1)で再利用する。
+
+安全を証明できない注文は、従来の`program.planBig`による正確なpreflightへ進む。
+このため保守的上界のfalse positiveは性能だけに影響し、結果や診断をwideへ変えない。
+
+### 世代変更
+
+`UNASSESSED`または`EXACT_AVAILABLE`だけ、一度だけ最新Pattern/recipe世代へ再評価できる。
+`PROVEN_LONG_SAFE`は旧証明を新世代へ移さず、ACO結果を採用せずAE2へ戻る。
+Graph、Topology、証明器は世代付きSnapshotに所属し、新世代へコピーしない。
+
+### Shadow Mode
+
+Shadow計算は次のどちらかに該当する場合だけ有効になる。
+
+- 実験的な通常long置換が有効
+- wide計画へShadow資格を要求する設定が有効
+
+採用先が無い既定構成では通常注文へShadow計算を重ねない。
+
+## 維持する不変条件
+
+- BigInteger正本をlongへ切り捨てない。
+- 保守的上界だけでwide計画と診断しない。
+- cold pathのGraph/Topology構築をCraftingCalculation生成側へ移さない。
+- Provider/recipe世代が変わった安全証明を再利用しない。
+- 通常long置換が無効なwarm注文はAE2標準計画へ戻す。
+- AE2の在庫、CPU job、GUI、搬入出、クラフト可否をACO側で変更しない。
+- AQE、InsaneAE、AAC、NeoECOの実行ロジックへ介入しない。
+
+## 回帰試験
+
+- 通常多段レシピのlong safety certificate
+- long注文ではdeferred exact取得を開始しないCapture policy
+- Long.MAX_VALUE境界
+- 合流DAG
+- 非先頭の代替候補を含む保守的上界
+- 保守的上界がwideでも、正確な実選択がlongならwideへ変えない
+- 固定seedで200個の多段DAGを生成し、安全証明のfalse negativeが無いこと
+- exactを持たない証明を新世代へ再利用しないこと
+- Shadow計算の採用先が無い場合に無効となること
+- Issue回帰マニフェストの同期
+
+## 性能への影響
+
+- cold long root: exact captureを行わず、現在注文の安全証明を非同期側で一巡する。
+- cold wide root: 正確なwide判定後にだけ、server threadで計画前後のexact在庫を取得する。
+- warm long-safe root: O(1)のcache参照だけを行い、全mount exact走査とBigInteger preflightを省略する。
+- 世代変更: Snapshotごと証明を破棄し、次のcold rootで再構築する。
+- 通常AE2結果を守るため、wall-clock時間による打ち切りや無条件retryは追加しない。
+
+## 検証
+
+- Forge 1.20.1: 全JUnit成功
+- NeoForge 1.21.1: 全JUnit成功
+- 対象境界テスト: 両版成功
+- `git diff --check`: 両版成功
+- 専用GameTestタスク: 両版のGradleプロジェクトに未定義
+- Minecraft起動試験: 対象外
+
+## 残存リスク
+
+今回の修正は通常注文に対するCapture時のexact全走査、毎回のBigInteger preflight、
+unused Shadow計算を対象とする。wide注文では正確性のためserver thread上の全mount走査を
+一度行うため、その費用自体は残る。
+
+Authoritative plan採用前のlive inventory/topology再検証には既存のGrid参照が残る。
+また、Futureをserver thread上で同期的に待つ外部アドオンはAE2の非同期契約にも反するため、
+今回確認した利用箇所以外がその呼出し方をする場合は別途adapterが必要になる。

--- a/docs/issues/REGRESSION_MATRIX.tsv
+++ b/docs/issues/REGRESSION_MATRIX.tsv
@@ -1,5 +1,5 @@
 # repository=https://github.com/syarukasu/ae2-crafting-optimizer
-# synchronized_through_issue=153
+# synchronized_through_issue=156
 # runtime_status: NOT_REQUIRED, VERIFIED, PENDING
 issue	kind	loaders	required	automated_evidence	runtime_status	runtime_evidence	summary
 1	COMPATIBILITY	NEOFORGE_1_21_1	STATIC	.github/workflows/build.yml	NOT_REQUIRED	-	NeoForge 1.21.1 port
@@ -54,3 +54,4 @@ issue	kind	loaders	required	automated_evidence	runtime_status	runtime_evidence	s
 145	ARCHITECTURE	BOTH	UNIT	src/test/java/com/syaru/ae2craftingoptimizer/optimization/OptimizationFeatureGateTest.java;src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue129ArchitectureSourceTest.java	NOT_REQUIRED	-	Issue 129 completion hardening and 1.5.27 release
 148	REGRESSION	BOTH	UNIT	src/test/java/com/syaru/ae2craftingoptimizer/integration/TerminalDisplaySnapshotProjectionTest.java;src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue109MixinBoundarySourceTest.java	NOT_REQUIRED	-	Terminal display saturation without storage or interaction ownership
 153	REGRESSION	BOTH	UNIT	src/test/java/com/syaru/ae2craftingoptimizer/integration/TerminalDisplaySnapshotProjectionTest.java;src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue109MixinBoundarySourceTest.java	NOT_REQUIRED	-	Storage monitor display saturation without cached inventory ownership
+156	REGRESSION	BOTH	UNIT	src/test/java/com/syaru/ae2craftingoptimizer/engine/WideArithmeticPreflightTest.java;src/test/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlannerPolicyTest.java;src/test/java/com/syaru/ae2craftingoptimizer/config/ACOConfigShadowModePolicyTest.java	NOT_REQUIRED	-	Avoid repeated exact inventory scans and unused shadow planning for ordinary long orders

--- a/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/config/ACOConfig.java
@@ -793,7 +793,8 @@ public final class ACOConfig {
         ENABLE_CRAFTING_ENGINE_SHADOW_MODE = builder
                 .comment(
                         "Compare the compiled long planner with completed AE2 plans without replacing or modifying AE2's result.",
-                        "Requires the AQE profile or enableExperimentalCraftingEngine. Shadow mismatches only update diagnostics.")
+                        "Runs only when enableExperimentalCraftingEngine is active or wide plans explicitly require Shadow qualification.",
+                        "Shadow mismatches only update diagnostics.")
                 .define("enableShadowMode", true);
         LOG_CRAFTING_ENGINE_SHADOW_MISMATCHES = builder
                 .comment("Log the first bounded set of Shadow Mode differences. Disabled engine means no comparison or logging.")
@@ -1788,7 +1789,24 @@ public final class ACOConfig {
     }
 
     public static boolean enableCraftingEngineShadowMode() {
-        return enableCompiledCraftingGraph() && ENABLE_CRAFTING_ENGINE_SHADOW_MODE.get();
+        return shouldEnableCraftingEngineShadowMode(
+                enableCompiledCraftingGraph(),
+                ENABLE_CRAFTING_ENGINE_SHADOW_MODE.get(),
+                enableExperimentalCraftingEngine()
+                        && (enableAuthoritativeCompiledPlanner()
+                                || enableProofQualifiedLongPlans()),
+                requireAqeBigPlanShadowQualification());
+    }
+
+    static boolean shouldEnableCraftingEngineShadowMode(
+            boolean compiledGraphEnabled,
+            boolean shadowModeConfigured,
+            boolean normalReplacementEnabled,
+            boolean wideQualificationRequired) {
+        // 採用先が無い通常注文へShadow計算を重ねず、置換またはwide資格用途がある時だけ有効化する。
+        return compiledGraphEnabled
+                && shadowModeConfigured
+                && (normalReplacementEnabled || wideQualificationRequired);
     }
 
     public static boolean logCraftingEngineShadowMismatches() {

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlanner.java
@@ -23,8 +23,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
@@ -59,14 +62,132 @@ public final class Ae2AuthoritativeCraftingPlanner {
                     FallbackReasonCode.DISABLED);
             return null;
         }
+        /*
+         * 出力キーを受け取らない互換入口でも、CraftingCalculation生成側から
+         * 全mountを走査しない。wide判定とexact取得はtryPlan側で行う。
+         */
         return new Capture(
                 level,
                 grid,
                 source,
                 networkSnapshot,
-                PlanningExactInventorySnapshot.capture(grid),
+                null,
+                ArithmeticCaptureMode.UNASSESSED,
                 ProviderPatternGenerationTracker.generation(),
                 RecipeGenerationTracker.generation());
+    }
+
+    /**
+     * CraftingCalculationの生成時にだけ使うCapture。
+     * 生成側ではexact在庫を走査せず、warm cacheの証明だけを参照する。
+     * cold pathは非同期Plannerで構造を判定し、wide確定時だけexact在庫を取得する。
+     */
+    @Nullable
+    public static Capture capture(
+            Level level,
+            IGrid grid,
+            IActionSource source,
+            KeyCounter networkSnapshot,
+            @Nullable AEKey output,
+            long requestedAmount) {
+        // 高速経路OFF、必要参照欠落、不正注文はAE2標準計算だけを使う。
+        if (!planningEnabled()
+                || level == null
+                || grid == null
+                || source == null
+                || networkSnapshot == null
+                || output == null
+                || requestedAmount <= 0L) {
+            CraftingFallbackDiagnostics.record(
+                    null,
+                    ProviderPatternGenerationTracker.generation(),
+                    RecipeGenerationTracker.generation(),
+                    FallbackReasonCode.DISABLED);
+            return null;
+        }
+        long patternGeneration = ProviderPatternGenerationTracker.generation();
+        long recipeGeneration = RecipeGenerationTracker.generation();
+        try {
+            boolean longSafe = hasCachedLongSafetyCertificate(
+                    level,
+                    grid,
+                    output,
+                    requestedAmount,
+                    patternGeneration,
+                    recipeGeneration);
+            // 証明の取得中に世代が変わった場合は、その証明を新世代へ持ち越さない。
+            if (longSafe
+                    && patternGeneration == ProviderPatternGenerationTracker.generation()
+                    && recipeGeneration == RecipeGenerationTracker.generation()) {
+                return new Capture(
+                        level,
+                        grid,
+                        source,
+                        networkSnapshot,
+                        null,
+                        ArithmeticCaptureMode.PROVEN_LONG_SAFE,
+                        patternGeneration,
+                        recipeGeneration);
+            }
+        } catch (RuntimeException failure) {
+            CraftingFallbackDiagnostics.record(
+                    output,
+                    patternGeneration,
+                    recipeGeneration,
+                    FallbackReasonCode.UNKNOWN);
+            BigIntegerPlanDiagnostics.record(
+                    BigIntegerPlanDeclineReason.INTERNAL_FAILURE,
+                    output.getId().toString(),
+                    BigInteger.valueOf(requestedAmount),
+                    patternGeneration,
+                    recipeGeneration,
+                    "cached long-safety lookup failed: " + failure.getClass().getName());
+        }
+        // cold pathと証明不能な注文は在庫を読まず、非同期側の構造判定へ渡す。
+        return new Capture(
+                level,
+                grid,
+                source,
+                networkSnapshot,
+                null,
+                ArithmeticCaptureMode.UNASSESSED,
+                ProviderPatternGenerationTracker.generation(),
+                RecipeGenerationTracker.generation());
+    }
+
+    private static boolean hasCachedLongSafetyCertificate(
+            Level level,
+            IGrid grid,
+            AEKey output,
+            long requestedAmount,
+            long patternGeneration,
+            long recipeGeneration) {
+        Ae2CompiledCraftingGraphCache.Snapshot graphSnapshot =
+                Ae2CompiledCraftingGraphCache.currentSnapshot(
+                                grid,
+                                level,
+                                patternGeneration,
+                                recipeGeneration)
+                        .orElse(null);
+        // cold cacheではメインスレッドからグラフを構築せず、非同期側の構造判定へ渡す。
+        if (graphSnapshot == null) {
+            return false;
+        }
+        var optionalProgram = graphSnapshot.cachedRootProgram(output);
+        // Root Program未構築なら、安全証明を新規計算しない。
+        if (optionalProgram.isEmpty()) {
+            return false;
+        }
+        Ae2StrictCraftingTopology topology =
+                graphSnapshot.cachedStrictTopology(output).orElse(null);
+        // Topology未検証時も、Pattern API走査をCraftingCalculation生成側で開始しない。
+        if (topology == null) {
+            return false;
+        }
+        return topology.cachedLongSafetyCertificate(
+                        BigInteger.valueOf(requestedAmount),
+                        ACOConfig.getBigIntegerMaximumBits())
+                .orElse(false);
     }
 
     @Nullable
@@ -127,6 +248,13 @@ public final class Ae2AuthoritativeCraftingPlanner {
             throw new PlanningCancelledException(0);
         }
 
+        boolean longSafetyCertified =
+                capture.arithmeticCaptureMode() == ArithmeticCaptureMode.PROVEN_LONG_SAFE;
+        // 通常long計画を置換しない既定構成では、warm cacheの安全証明だけで直ちにAE2へ戻す。
+        if (longSafetyCertified && !normalLongReplacementEnabled()) {
+            return null;
+        }
+
         boolean wideArithmeticRequired = priorAttemptRequiredWideArithmetic;
         try {
             capture.requireCurrentGenerations();
@@ -166,11 +294,14 @@ public final class Ae2AuthoritativeCraftingPlanner {
                                 : BigIntegerPlanDeclineReason.INVENTORY_CHANGED,
                         topology == null ? "strict topology was not proven" : "inventory was not accepted");
             }
-            wideArithmeticRequired = wideArithmeticRequired
-                    || topology.mightRequireWideArithmetic(
-                            output,
-                            BigInteger.valueOf(requestedAmount),
-                            ACOConfig.getBigIntegerMaximumBits());
+            // cold pathまたは保守的上界で未確定の注文だけ、正確なBigInteger preflightを行う。
+            if (!longSafetyCertified) {
+                wideArithmeticRequired = wideArithmeticRequired
+                        || topology.mightRequireWideArithmetic(
+                                output,
+                                BigInteger.valueOf(requestedAmount),
+                                ACOConfig.getBigIntegerMaximumBits());
+            }
             boolean shadowQualified = CompiledRootQualificationRegistry.isQualified(
                     program,
                     ACOConfig.getAuthoritativeMinimumShadowMatches());
@@ -200,8 +331,18 @@ public final class Ae2AuthoritativeCraftingPlanner {
                 return null;
             }
 
+            // 正確にwideと判明した注文だけ、サーバースレッドでexact在庫を固定する。
+            if (capture.arithmeticCaptureMode()
+                    .requiresDeferredExactInventory(wideArithmeticRequired)) {
+                capture = capture.withExactInventorySnapshot(
+                        captureExactInventorySnapshot(capture));
+            }
+
             BigKeyCounterSidecars.Snapshot inventoryMetadata =
-                    BigKeyCounterSidecars.snapshot(capture.exactInventorySnapshot()).orElse(null);
+                    capture.exactInventorySnapshot() == null
+                            ? null
+                            : BigKeyCounterSidecars.snapshot(
+                                    capture.exactInventorySnapshot()).orElse(null);
             // Adapter失敗を含む不完全Snapshotは、飽和値から不足数を推測せずAE2へ戻す。
             if (inventoryMetadata != null && !inventoryMetadata.complete()) {
                 CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
@@ -215,10 +356,12 @@ public final class Ae2AuthoritativeCraftingPlanner {
                         "BigInteger inventory sidecar is incomplete");
             }
             CompiledRootProgram.BigInventorySnapshot<AEKey> exactPlanningInventory =
-                    Ae2ReferencedInventory.captureExactNetworkSnapshot(
-                            program,
-                            capture.exactInventorySnapshot(),
-                            output);
+                    capture.exactInventorySnapshot() == null
+                            ? null
+                            : Ae2ReferencedInventory.captureExactNetworkSnapshot(
+                                    program,
+                                    capture.exactInventorySnapshot(),
+                                    output);
             CompiledRootProgram.InventorySnapshot<AEKey> planningInventory = null;
             // 正確なSidecarが無い通常AE2環境だけ、従来のlong Snapshotを使用する。
             if (exactPlanningInventory == null) {
@@ -227,10 +370,11 @@ public final class Ae2AuthoritativeCraftingPlanner {
                         capture.inventorySnapshot(),
                         output);
             }
+            Capture guardCapture = capture;
             PlanningGuard guard = expanded -> {
                 // 64ノードごとに世代変更とスレッド割込みを確認し、古い結果を早めに破棄する。
                 if ((expanded & GENERATION_CHECK_INTERVAL_MASK) == 0) {
-                    capture.requireCurrentGenerations();
+                    guardCapture.requireCurrentGenerations();
                     // 計算キャンセル後は残りノードを処理しない。
                     if (Thread.currentThread().isInterrupted()) {
                         throw new PlanningCancelledException(expanded);
@@ -253,6 +397,18 @@ public final class Ae2AuthoritativeCraftingPlanner {
                             BigInteger.valueOf(requestedAmount),
                             planningInventory,
                             guard);
+            // 実際にlong計算からBigへ昇格した場合、exact在庫なしの結果は正本にならない。
+            if (promoted.usesBigInteger() && exactPlanningInventory == null) {
+                CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
+                        FallbackReasonCode.INVENTORY_CHANGED);
+                return declineOrThrow(
+                        capture,
+                        output,
+                        requestedAmount,
+                        true,
+                        BigIntegerPlanDeclineReason.INCOMPLETE_INVENTORY,
+                        "long plan promoted without an exact inventory snapshot");
+            }
             // Root Program経路以外の結果はAuthoritativeとして採用しない。
             if (!promoted.provenEquivalent()) {
                 CraftingFallbackDiagnostics.record(output, capture.patternGeneration(), capture.recipeGeneration(),
@@ -379,6 +535,13 @@ public final class Ae2AuthoritativeCraftingPlanner {
             }
 
             capture.requireCurrentGenerations();
+            KeyCounter currentExactInventory = null;
+            // wide計画の再検証も全mountへ触れるため、計算workerから直接走査しない。
+            if (exactPlanningInventory != null) {
+                currentExactInventory = captureExactInventorySnapshot(capture);
+                // server executorとの往復中にPattern世代が変わった結果は採用しない。
+                capture.requireCurrentGenerations();
+            }
             // 計算で参照したキーだけでも在庫が変わっていれば、古い結果を返さない。
             boolean inventoryStillMatches = exactPlanningInventory != null
                     ? Ae2ReferencedInventory.matchesLive(
@@ -386,7 +549,8 @@ public final class Ae2AuthoritativeCraftingPlanner {
                             exactPlanningInventory,
                             capture.grid(),
                             capture.source(),
-                            output)
+                            output,
+                            currentExactInventory)
                     : Ae2ReferencedInventory.matchesLive(
                             program,
                             planningInventory,
@@ -434,7 +598,8 @@ public final class Ae2AuthoritativeCraftingPlanner {
             StaleSnapshotAction action = staleSnapshotAction(
                     staleSnapshotRetryAvailable,
                     Thread.currentThread().isInterrupted(),
-                    wideArithmeticRequired);
+                    wideArithmeticRequired,
+                    capture.canRefreshGenerations());
             // AE2が計算をキャンセル済みなら、新しいSnapshotでも計算を再開しない。
             if (action == StaleSnapshotAction.CANCEL) {
                 CraftingFallbackDiagnostics.record(
@@ -458,7 +623,7 @@ public final class Ae2AuthoritativeCraftingPlanner {
                         requestedAmount,
                         strategy,
                         false,
-                        wideArithmeticRequired);
+                        false);
             }
             CraftingFallbackDiagnostics.record(
                     output,
@@ -855,12 +1020,24 @@ public final class Ae2AuthoritativeCraftingPlanner {
             boolean retryAvailable,
             boolean interrupted,
             boolean wideArithmeticRequired) {
+        return staleSnapshotAction(
+                retryAvailable,
+                interrupted,
+                wideArithmeticRequired,
+                true);
+    }
+
+    static StaleSnapshotAction staleSnapshotAction(
+            boolean retryAvailable,
+            boolean interrupted,
+            boolean wideArithmeticRequired,
+            boolean generationRefreshAllowed) {
         // AE2のキャンセル要求は再試行や標準計算より優先する。
         if (interrupted) {
             return StaleSnapshotAction.CANCEL;
         }
-        // 一回目の競合は最新世代で取り直し、開始直後の通知競合を吸収する。
-        if (retryAvailable) {
+        // exact在庫を保持する一回目の競合だけ、最新Pattern世代へ結び直して再計算する。
+        if (retryAvailable && generationRefreshAllowed) {
             return StaleSnapshotAction.RETRY;
         }
         // wideと判明済みの計画をoverflowするAE2標準long計算へ落とさない。
@@ -951,6 +1128,39 @@ public final class Ae2AuthoritativeCraftingPlanner {
         }
     }
 
+    private static KeyCounter captureExactInventorySnapshot(Capture capture) {
+        MinecraftServer server = capture.level().getServer();
+        // サーバーを持たないLevelではexact正本を安全なスレッドへ委譲できないため失敗させる。
+        if (server == null) {
+            throw new IllegalStateException("exact inventory capture requires a server level");
+        }
+        // 既にサーバースレッド上ならFutureを作らず、その場で一度だけ取得する。
+        if (server.isSameThread()) {
+            return PlanningExactInventorySnapshot.capture(capture.grid());
+        }
+        CompletableFuture<KeyCounter> pending = CompletableFuture.supplyAsync(
+                () -> PlanningExactInventorySnapshot.capture(capture.grid()),
+                server);
+        try {
+            return pending.get();
+        } catch (InterruptedException interrupted) {
+            pending.cancel(false);
+            Thread.currentThread().interrupt();
+            throw new PlanningCancelledException(0);
+        } catch (ExecutionException failedCapture) {
+            Throwable cause = failedCapture.getCause();
+            // RuntimeExceptionは元の型と診断を維持し、別理由へ読み替えない。
+            if (cause instanceof RuntimeException runtimeFailure) {
+                throw runtimeFailure;
+            }
+            // VM Errorもラップして継続せず、元の致命的状態をそのまま伝播する。
+            if (cause instanceof Error fatalFailure) {
+                throw fatalFailure;
+            }
+            throw new IllegalStateException("exact inventory capture failed", cause);
+        }
+    }
+
     private static FallbackReasonCode classifyFallback(Throwable failure) {
         String name = failure.getClass().getName().toLowerCase(java.util.Locale.ROOT);
         if (name.contains("cycle")) {
@@ -974,20 +1184,74 @@ public final class Ae2AuthoritativeCraftingPlanner {
         return result;
     }
 
+    public enum ArithmeticCaptureMode {
+        EXACT_AVAILABLE,
+        UNASSESSED,
+        PROVEN_LONG_SAFE;
+
+        boolean requiresDeferredExactInventory(boolean wideArithmeticRequired) {
+            // long範囲の注文では、未評価でも全mountのexact在庫走査を開始しない。
+            if (!wideArithmeticRequired) {
+                return false;
+            }
+            // exact正本を既に持つCaptureだけは、同じ在庫を二重取得しない。
+            return this != EXACT_AVAILABLE;
+        }
+    }
+
     public record Capture(
             Level level,
             IGrid grid,
             IActionSource source,
             KeyCounter inventorySnapshot,
-            KeyCounter exactInventorySnapshot,
+            @Nullable KeyCounter exactInventorySnapshot,
+            ArithmeticCaptureMode arithmeticCaptureMode,
             long patternGeneration,
             long recipeGeneration) {
+        /** 1.5.29以前の公開コンストラクタを、正確判定が必要なCaptureとして維持する。 */
+        public Capture(
+                Level level,
+                IGrid grid,
+                IActionSource source,
+                KeyCounter inventorySnapshot,
+                KeyCounter exactInventorySnapshot,
+                long patternGeneration,
+                long recipeGeneration) {
+            this(
+                    level,
+                    grid,
+                    source,
+                    inventorySnapshot,
+                    exactInventorySnapshot,
+                    ArithmeticCaptureMode.EXACT_AVAILABLE,
+                    patternGeneration,
+                    recipeGeneration);
+        }
+
         public Capture {
             Objects.requireNonNull(level, "level");
             Objects.requireNonNull(grid, "grid");
             Objects.requireNonNull(source, "source");
             Objects.requireNonNull(inventorySnapshot, "inventorySnapshot");
-            Objects.requireNonNull(exactInventorySnapshot, "exactInventorySnapshot");
+            Objects.requireNonNull(arithmeticCaptureMode, "arithmeticCaptureMode");
+            // EXACT_AVAILABLEは、後続の正確なwide計画に使うexact在庫を必須とする。
+            if (arithmeticCaptureMode == ArithmeticCaptureMode.EXACT_AVAILABLE
+                    && exactInventorySnapshot == null) {
+                throw new IllegalArgumentException(
+                        "exact capture requires an exact inventory snapshot");
+            }
+            // long安全証明済みCaptureへexact正本を二重保持せず、状態の意味を一意にする。
+            if (arithmeticCaptureMode == ArithmeticCaptureMode.PROVEN_LONG_SAFE
+                    && exactInventorySnapshot != null) {
+                throw new IllegalArgumentException(
+                        "proven long-safe capture must not retain an exact inventory snapshot");
+            }
+            // 未評価Captureはexact取得前の状態なので、二重管理を許可しない。
+            if (arithmeticCaptureMode == ArithmeticCaptureMode.UNASSESSED
+                    && exactInventorySnapshot != null) {
+                throw new IllegalArgumentException(
+                        "unassessed capture must not retain an exact inventory snapshot");
+            }
             // 負の世代値はSnapshot識別へ使用できないため拒否する。
             if (patternGeneration < 0L || recipeGeneration < 0L) {
                 throw new IllegalArgumentException("generation values must not be negative");
@@ -1006,14 +1270,36 @@ public final class Ae2AuthoritativeCraftingPlanner {
         }
 
         private Capture refreshGenerations() {
+            // exact正本を持たない安全証明は、新しいPattern世代へ再利用しない。
+            if (!canRefreshGenerations()) {
+                throw new IllegalStateException(
+                        "long-safety certificate cannot be rebound to a new generation");
+            }
             return new Capture(
                     level,
                     grid,
                     source,
                     inventorySnapshot,
                     exactInventorySnapshot,
+                    arithmeticCaptureMode,
                     ProviderPatternGenerationTracker.generation(),
                     RecipeGenerationTracker.generation());
+        }
+
+        private Capture withExactInventorySnapshot(KeyCounter exactSnapshot) {
+            return new Capture(
+                    level,
+                    grid,
+                    source,
+                    inventorySnapshot,
+                    Objects.requireNonNull(exactSnapshot, "exactSnapshot"),
+                    ArithmeticCaptureMode.EXACT_AVAILABLE,
+                    patternGeneration,
+                    recipeGeneration);
+        }
+
+        private boolean canRefreshGenerations() {
+            return arithmeticCaptureMode != ArithmeticCaptureMode.PROVEN_LONG_SAFE;
         }
     }
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2CompiledCraftingGraphCache.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2CompiledCraftingGraphCache.java
@@ -31,6 +31,29 @@ public final class Ae2CompiledCraftingGraphCache {
     private Ae2CompiledCraftingGraphCache() {
     }
 
+    /**
+     * 現在世代のSnapshotが既に存在する場合だけ返す。
+     * CraftingCalculation生成側ではコンパイルを開始せず、warm cacheの証明だけを参照する。
+     */
+    static Optional<Snapshot> currentSnapshot(
+            IGrid grid,
+            Level level,
+            long generation,
+            long recipeGeneration) {
+        ICraftingService service = grid.getCraftingService();
+        synchronized (CACHE) {
+            Map<ResourceKey<Level>, Snapshot> byDimension = CACHE.get(service);
+            Snapshot current = byDimension == null ? null : byDimension.get(level.dimension());
+            // Snapshotが無い、または要求世代と一致しない場合はcold pathへ戻す。
+            if (current == null
+                    || current.graph().generation() != generation
+                    || current.recipeGeneration() != recipeGeneration) {
+                return Optional.empty();
+            }
+            return Optional.of(current);
+        }
+    }
+
     public static Snapshot getOrCompile(IGrid grid, Level level) {
         ICraftingService service = grid.getCraftingService();
         for (int attempt = 0; attempt < 3; attempt++) {
@@ -263,6 +286,13 @@ public final class Ae2CompiledCraftingGraphCache {
             }
         }
 
+        /** Root Programを新規コンパイルせず、既存の世代内結果だけを返す。 */
+        Optional<CompiledRootProgram<AEKey>> cachedRootProgram(AEKey root) {
+            synchronized (rootPrograms) {
+                return Optional.ofNullable(rootPrograms.get(root));
+            }
+        }
+
         private void requireCurrentGenerations() {
             long currentPatternGeneration = ProviderPatternGenerationTracker.generation();
             long currentRecipeGeneration = RecipeGenerationTracker.generation();
@@ -312,6 +342,18 @@ public final class Ae2CompiledCraftingGraphCache {
                 }
                 strictTopologies.put(root, compiled);
                 return compiled;
+            }
+        }
+
+        /** 厳密Topologyを新規検証せず、証明済みの世代内結果だけを返す。 */
+        Optional<Ae2StrictCraftingTopology> cachedStrictTopology(AEKey root) {
+            synchronized (rootPrograms) {
+                Optional<Ae2StrictCraftingTopology> cached = strictTopologies.get(root);
+                // 未検証または検証不能のRootは、軽量Captureから安全証明として利用しない。
+                if (cached == null || cached.isEmpty()) {
+                    return Optional.empty();
+                }
+                return cached;
             }
         }
     }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2ReferencedInventory.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2ReferencedInventory.java
@@ -75,11 +75,29 @@ final class Ae2ReferencedInventory {
             IGrid grid,
             IActionSource source,
             AEKey requestedOutput) {
+        return matchesLive(
+                program,
+                snapshot,
+                grid,
+                source,
+                requestedOutput,
+                PlanningExactInventorySnapshot.capture(grid));
+    }
+
+    /** 呼出側が安全なスレッドで取得したexact在庫を使い、計画後の一致だけを検証する。 */
+    static boolean matchesLive(
+            CompiledRootProgram<AEKey> program,
+            CompiledRootProgram.BigInventorySnapshot<AEKey> snapshot,
+            IGrid grid,
+            IActionSource source,
+            AEKey requestedOutput,
+            KeyCounter currentExactInventory) {
         Objects.requireNonNull(grid, "grid");
         Objects.requireNonNull(source, "source");
-        KeyCounter cached = PlanningExactInventorySnapshot.capture(grid);
-        BigKeyCounterSidecars.Snapshot exact =
-                BigKeyCounterSidecars.snapshot(cached).orElse(null);
+        Objects.requireNonNull(currentExactInventory, "currentExactInventory");
+        BigKeyCounterSidecars.Snapshot exact = BigKeyCounterSidecars
+                .snapshot(currentExactInventory)
+                .orElse(null);
         // 再検証時にSidecarが失われた場合は、丸めたlong値で一致扱いにしない。
         if (exact == null || !exact.complete()) {
             return false;
@@ -88,7 +106,7 @@ final class Ae2ReferencedInventory {
                 snapshot,
                 key -> key.equals(requestedOutput)
                         ? BigInteger.ZERO
-                        : liveExactAmount(grid, source, cached, exact, key),
+                        : liveExactAmount(grid, source, currentExactInventory, exact, key),
                 ACOConfig.getBigIntegerMaximumBits());
     }
 

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2StrictCraftingTopology.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/Ae2StrictCraftingTopology.java
@@ -12,6 +12,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
@@ -24,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 final class Ae2StrictCraftingTopology {
     private final CompiledRootProgram<AEKey> program;
     private final List<InputProof> inputProofs;
+    private volatile WideArithmeticPreflight.LongSafetyCertificate<AEKey> longSafetyCertificate;
 
     private Ae2StrictCraftingTopology(
             CompiledRootProgram<AEKey> program,
@@ -281,12 +283,57 @@ final class Ae2StrictCraftingTopology {
             AEKey root,
             BigInteger requestedAmount,
             int maximumBits) {
-        return WideArithmeticPreflight.requiresWideArithmetic(
+        WideArithmeticPreflight.LongSafetyCertificate<AEKey> certificate =
+                longSafetyCertificate(maximumBits);
+        // 上界でlong安全を証明できた注文は、正確なBigInteger計画を重ねずに終了する。
+        if (certificate.certify(requestedAmount)) {
+            return false;
+        }
+        // 保守的上界だけでwideを確定せず、従来の正確なBigInteger計画で最終判定する。
+        boolean exactWide = WideArithmeticPreflight.requiresWideArithmetic(
                 root,
                 requestedAmount,
                 program,
                 key -> key.getType().getAmountPerByte(),
                 maximumBits);
+        // 正確にlong内と確定した最大量も記録し、代替候補を持つ同一Rootの再計算を省く。
+        if (!exactWide) {
+            certificate.recordExactSafe(requestedAmount);
+        }
+        return exactWide;
+    }
+
+    Optional<Boolean> cachedLongSafetyCertificate(
+            BigInteger requestedAmount,
+            int maximumBits) {
+        WideArithmeticPreflight.LongSafetyCertificate<AEKey> cached = longSafetyCertificate;
+        // cold pathでは証明器を新規作成せず、非同期Planner側へ仕事を残す。
+        if (cached == null || cached.maximumBits() != maximumBits) {
+            return Optional.empty();
+        }
+        // 未証明の大きい注文はfalseと固定せず、exact captureを選ばせるためemptyを返す。
+        return cached.certifiesCached(requestedAmount)
+                ? Optional.of(true)
+                : Optional.empty();
+    }
+
+    private WideArithmeticPreflight.LongSafetyCertificate<AEKey> longSafetyCertificate(int maximumBits) {
+        WideArithmeticPreflight.LongSafetyCertificate<AEKey> cached = longSafetyCertificate;
+        // Config bit幅が変わった場合だけ、同じ世代の安全証明を作り直す。
+        if (cached == null || cached.maximumBits() != maximumBits) {
+            synchronized (this) {
+                cached = longSafetyCertificate;
+                // 同じTopologyを共有する非同期計算が証明器を重複作成しないよう一度だけ確定する。
+                if (cached == null || cached.maximumBits() != maximumBits) {
+                    cached = WideArithmeticPreflight.longSafetyCertificate(
+                            program,
+                            key -> key.getType().getAmountPerByte(),
+                            maximumBits);
+                    longSafetyCertificate = cached;
+                }
+            }
+        }
+        return cached;
     }
 
     private record InputProof(

--- a/src/main/java/com/syaru/ae2craftingoptimizer/engine/WideArithmeticPreflight.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/engine/WideArithmeticPreflight.java
@@ -24,8 +24,13 @@ final class WideArithmeticPreflight {
             ToLongFunction<K> amountPerByte,
             int maximumBits) {
         Objects.requireNonNull(root, "root");
+        Objects.requireNonNull(requestedAmount, "requestedAmount");
         Objects.requireNonNull(program, "program");
         Objects.requireNonNull(amountPerByte, "amountPerByte");
+        // 別RootのProgramを誤用すると、需要式とCPU byte式の双方が変わるため明示的に拒否する。
+        if (!program.root().equals(root)) {
+            throw new IllegalArgumentException("root does not match the compiled program");
+        }
         CompiledRootProgram.BigInventorySnapshot<K> emptyInventory =
                 program.captureBigInventory(ignored -> BigInteger.ZERO, maximumBits);
         BigCraftingPlan<K> fullPlan = program.planBig(
@@ -54,6 +59,275 @@ final class WideArithmeticPreflight {
                 amountPerByte,
                 maximumBits);
         return bytes.compareTo(LONG_MAX) > 0;
+    }
+
+    /** Root Programの世代内で再利用する、単調なlong安全証明器を作る。 */
+    static <K> LongSafetyCertificate<K> longSafetyCertificate(
+            CompiledRootProgram<K> program,
+            ToLongFunction<K> amountPerByte,
+            int maximumBits) {
+        return new LongSafetyCertificate<>(program, amountPerByte, maximumBits);
+    }
+
+    private static <K> boolean potentiallyRequiresWideAtLong(
+            CompiledRootProgram<K> program,
+            K root,
+            long requestedAmount,
+            ToLongFunction<K> amountPerByte) {
+        int rootIndex = program.indexOf(root);
+        // RootがProgramにない場合は、呼出側が安全にAE2へ戻せるよう失敗させる。
+        if (rootIndex < 0) {
+            throw new IllegalArgumentException("root is not present in compiled program");
+        }
+
+        long[] demand = new long[program.nodeCount()];
+        demand[rootIndex] = requestedAmount;
+        long[] visitUpperBound = new long[program.nodeCount()];
+        visitUpperBound[rootIndex] = 1L;
+        Map<String, Long> executionsByPattern = new LinkedHashMap<>();
+        // CompiledRootProgramのトポロジカル順を一度だけ走査して全候補の上界を作る。
+        for (int node = 0; node < program.nodeCount(); node++) {
+            // 未到達ノードは需要もPattern回数も増やさない。
+            if (demand[node] == 0L) {
+                continue;
+            }
+            // SATURATED値は正確なlong上限でも安全側にwide扱いする。
+            if (demand[node] == Long.MAX_VALUE) {
+                return true;
+            }
+            // EmitterはAE2と同じく外部供給で終端になるため、入力を展開しない。
+            if (program.isEmittableAt(node)) {
+                continue;
+            }
+            CompiledPattern<K> pattern = program.patternAt(node);
+            // Patternなし終端は不足上界として需要だけを保持する。
+            if (pattern == null) {
+                continue;
+            }
+            long executions = saturatedCeilDiv(
+                    demand[node],
+                    program.outputAmountAt(node));
+            // Pattern回数をlongへ戻せない場合はexact経路が必要になる。
+            if (executions == Long.MAX_VALUE) {
+                return true;
+            }
+            executionsByPattern.merge(
+                    pattern.id(),
+                    executions,
+                    WideArithmeticPreflight::saturatedAdd);
+
+            // 同じslotの候補は相互排他的でも、全候補を足して安全側の上界を作る。
+            for (int input = 0; input < program.inputCountAt(node); input++) {
+                // 候補ごとの需要を同じ子へ集約し、候補漏れによるfalse negativeを防ぐ。
+                for (int alternative = 0;
+                        alternative < program.inputAlternativeCountAt(node, input);
+                        alternative++) {
+                    K childKey = program.inputAlternativeKeyAt(
+                            node,
+                            input,
+                            alternative);
+                    int child = program.indexOf(childKey);
+                    // トポロジカル順に反する候補は、上界を推測せず構造エラーにする。
+                    if (child <= node) {
+                        throw new IllegalArgumentException(
+                                "compiled program input is not topologically ordered");
+                    }
+                    visitUpperBound[child] = saturatedAdd(
+                            visitUpperBound[child],
+                            visitUpperBound[node]);
+                    // 再帰byte式の訪問回数が飽和した時点でlong安全とは証明しない。
+                    if (visitUpperBound[child] == Long.MAX_VALUE) {
+                        return true;
+                    }
+                    long inputDemand = saturatedMultiply(
+                            program.inputAlternativeAmountAt(node, input, alternative),
+                            executions);
+                    demand[child] = saturatedAdd(demand[child], inputDemand);
+                    // 子需要が飽和したら、残りの候補を走査せずwideを確定する。
+                    if (demand[child] == Long.MAX_VALUE) {
+                        return true;
+                    }
+                }
+            }
+        }
+        long totalDemand = 0L;
+        // 異なるKeyの需要合計もAE2内部集計へ入るため、aggregate overflowを先に検出する。
+        for (long amount : demand) {
+            // 未到達ノードは合計へ加えない。
+            if (amount == 0L) {
+                continue;
+            }
+            totalDemand = saturatedAdd(totalDemand, amount);
+            // 合計が上限へ届いた場合は残りのノードを走査せずwideを確定する。
+            if (totalDemand == Long.MAX_VALUE) {
+                return true;
+            }
+        }
+        long bytes = 0L;
+        // 各参照キーを個別に切り上げ、AE2の有理数合計以上の安全なbyte上界を作る。
+        for (int node = 0; node < demand.length; node++) {
+            // 未到達ノードのstackとnode overheadは計上しない。
+            if (demand[node] == 0L) {
+                continue;
+            }
+            long divisor = amountPerByte.applyAsLong(program.keyAt(node));
+            // AEKey種別が無効な場合は、近似値を作らず計画を拒否する。
+            if (divisor <= 0L) {
+                throw new IllegalArgumentException("amountPerByte must be positive");
+            }
+            /*
+             * AE2のbyte式は合流DAGを経路ごとに再帰訪問する。
+             * 需要上界を訪問回数でも掛け、共有子の再訪を過小評価しない。
+             */
+            long repeatedDemand = saturatedMultiply(
+                    demand[node],
+                    Math.max(1L, visitUpperBound[node]));
+            long stackBytes = saturatedMultiply(repeatedDemand, 8L);
+            bytes = saturatedAdd(
+                    bytes,
+                    saturatedCeilDiv(stackBytes, divisor));
+            // 各再帰訪問につき8-byteのnode overheadを計上する。
+            bytes = saturatedAdd(
+                    bytes,
+                    saturatedMultiply(visitUpperBound[node], 8L));
+            // bytesが飽和した場合は以降のノードとPatternを計算しない。
+            if (bytes == Long.MAX_VALUE) {
+                return true;
+            }
+        }
+        // 同じPatternの全実行数が各再帰訪問で加算されるAE2 byte式を上から評価する。
+        for (int node = 0; node < program.nodeCount(); node++) {
+            CompiledPattern<K> pattern = program.patternAt(node);
+            // Patternを持たない終端と未到達ノードは実行byteを持たない。
+            if (pattern == null || visitUpperBound[node] == 0L) {
+                continue;
+            }
+            long executions = executionsByPattern.getOrDefault(pattern.id(), 0L);
+            bytes = saturatedAdd(
+                    bytes,
+                    saturatedMultiply(executions, visitUpperBound[node]));
+            // Pattern byte合計が飽和した場合はwideを確定する。
+            if (bytes == Long.MAX_VALUE) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static long saturatedMultiply(long left, long right) {
+        // 0との積はoverflowせず、早期判定用のSATURATED値も維持しない。
+        if (left == 0L || right == 0L) {
+            return 0L;
+        }
+        // 正のlong同士の乗算が上限に届く場合はSATURATEDへ丸める。
+        if (left > Long.MAX_VALUE / right) {
+            return Long.MAX_VALUE;
+        }
+        long product = left * right;
+        return product == Long.MAX_VALUE ? Long.MAX_VALUE : product;
+    }
+
+    private static long saturatedAdd(long left, long right) {
+        // どちらかがSATURATEDなら、加算結果も安全側にSATURATEDとする。
+        if (left == Long.MAX_VALUE || right == Long.MAX_VALUE) {
+            return Long.MAX_VALUE;
+        }
+        if (left > Long.MAX_VALUE - right) {
+            return Long.MAX_VALUE;
+        }
+        long sum = left + right;
+        return sum == Long.MAX_VALUE ? Long.MAX_VALUE : sum;
+    }
+
+    private static long saturatedCeilDiv(long dividend, long divisor) {
+        long quotient = dividend / divisor;
+        // 余りがある場合の繰り上げが上限へ届く場合はSATURATEDにする。
+        if (dividend % divisor != 0L && quotient == Long.MAX_VALUE) {
+            return Long.MAX_VALUE;
+        }
+        return dividend % divisor == 0L ? quotient : quotient + 1L;
+    }
+
+    static final class LongSafetyCertificate<K> {
+        private final CompiledRootProgram<K> program;
+        private final ToLongFunction<K> amountPerByte;
+        private final int maximumBits;
+        private volatile long maximumCertifiedRequest;
+
+        private LongSafetyCertificate(
+                CompiledRootProgram<K> program,
+                ToLongFunction<K> amountPerByte,
+                int maximumBits) {
+            this.program = Objects.requireNonNull(program, "program");
+            this.amountPerByte = Objects.requireNonNull(amountPerByte, "amountPerByte");
+            this.maximumBits = maximumBits;
+        }
+
+        int maximumBits() {
+            return maximumBits;
+        }
+
+        boolean certifiesCached(BigInteger requestedAmount) {
+            validateRequest(requestedAmount);
+            // long API外の数量は、この証明器のキャッシュ対象にしない。
+            if (requestedAmount.compareTo(LONG_MAX) > 0) {
+                return false;
+            }
+            long requestedLong = requestedAmount.longValueExact();
+            return requestedLong <= maximumCertifiedRequest;
+        }
+
+        boolean certify(BigInteger requestedAmount) {
+            // 既存の最大安全量以下なら、DAGを再走査せず証明を再利用する。
+            if (certifiesCached(requestedAmount)) {
+                return true;
+            }
+            // long API外の数量は正確なBigInteger preflightへ委ねる。
+            if (requestedAmount.compareTo(LONG_MAX) > 0) {
+                return false;
+            }
+            long requestedLong = requestedAmount.longValueExact();
+            boolean potentiallyWide = potentiallyRequiresWideAtLong(
+                    program,
+                    program.root(),
+                    requestedLong,
+                    amountPerByte);
+            // 保守的上界で安全を証明できない注文は、wideと断定せず正確判定へ渡す。
+            if (potentiallyWide) {
+                return false;
+            }
+            recordSafeRequest(requestedLong);
+            return true;
+        }
+
+        void recordExactSafe(BigInteger requestedAmount) {
+            validateRequest(requestedAmount);
+            // long API外の量は非wideとして記録できないため、呼出側の判定矛盾を拒否する。
+            if (requestedAmount.compareTo(LONG_MAX) > 0) {
+                throw new IllegalArgumentException("exact long-safe request exceeds Long.MAX_VALUE");
+            }
+            recordSafeRequest(requestedAmount.longValueExact());
+        }
+
+        private void recordSafeRequest(long requestedLong) {
+            synchronized (this) {
+                // 安全性は注文量に対して単調なので、より大きい証明済み数量だけを保持する。
+                if (requestedLong > maximumCertifiedRequest) {
+                    maximumCertifiedRequest = requestedLong;
+                }
+            }
+        }
+
+        private void validateRequest(BigInteger requestedAmount) {
+            BigCountMath.requireMaximumBits(
+                    requestedAmount,
+                    "wide-preflight/certificate-request",
+                    maximumBits);
+            // 0以下の注文はAE2の有効なRoot注文ではなく、単調安全証明へ登録しない。
+            if (requestedAmount.signum() <= 0) {
+                throw new IllegalArgumentException("requested amount must be positive");
+            }
+        }
     }
 
     static <K> boolean requiresWideArithmetic(
@@ -146,4 +420,5 @@ final class WideArithmeticPreflight {
         }
         return false;
     }
+
 }

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCalculationDiagnosticsMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCalculationDiagnosticsMixin.java
@@ -78,7 +78,9 @@ public abstract class CraftingCalculationDiagnosticsMixin {
                 level,
                 grid,
                 actionSource,
-                networkSnapshot);
+                networkSnapshot,
+                this.output,
+                this.requestedAmount);
     }
 
     @Inject(method = "run", at = @At("HEAD"))

--- a/src/test/java/com/syaru/ae2craftingoptimizer/config/ACOConfigShadowModePolicyTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/config/ACOConfigShadowModePolicyTest.java
@@ -1,0 +1,35 @@
+package com.syaru.ae2craftingoptimizer.config;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ACOConfigShadowModePolicyTest {
+    @Test
+    void disablesShadowWorkWhenNoConsumerCanUseIt() {
+        assertFalse(ACOConfig.shouldEnableCraftingEngineShadowMode(
+                true,
+                true,
+                false,
+                false));
+    }
+
+    @Test
+    void enablesShadowWorkForExperimentalNormalReplacement() {
+        assertTrue(ACOConfig.shouldEnableCraftingEngineShadowMode(
+                true,
+                true,
+                true,
+                false));
+    }
+
+    @Test
+    void enablesShadowWorkWhenWidePlansRequireQualification() {
+        assertTrue(ACOConfig.shouldEnableCraftingEngineShadowMode(
+                true,
+                true,
+                false,
+                true));
+    }
+}

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlannerPolicyTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/Ae2AuthoritativeCraftingPlannerPolicyTest.java
@@ -71,6 +71,27 @@ class Ae2AuthoritativeCraftingPlannerPolicyTest {
     }
 
     @Test
+    void doesNotRebindALongSafetyCertificateToANewGeneration() {
+        assertEquals(
+                Ae2AuthoritativeCraftingPlanner.StaleSnapshotAction.FALLBACK_TO_AE2,
+                Ae2AuthoritativeCraftingPlanner.staleSnapshotAction(
+                        true,
+                        false,
+                        false,
+                        false));
+    }
+
+    @Test
+    void capturesExactInventoryOnlyAfterWideArithmeticIsConfirmed() {
+        var unassessed = Ae2AuthoritativeCraftingPlanner.ArithmeticCaptureMode.UNASSESSED;
+        var exact = Ae2AuthoritativeCraftingPlanner.ArithmeticCaptureMode.EXACT_AVAILABLE;
+
+        assertFalse(unassessed.requiresDeferredExactInventory(false));
+        assertTrue(unassessed.requiresDeferredExactInventory(true));
+        assertFalse(exact.requiresDeferredExactInventory(true));
+    }
+
+    @Test
     void fallsBackToAe2AfterARepeatedOrdinaryStaleSnapshot() {
         assertEquals(
                 Ae2AuthoritativeCraftingPlanner.StaleSnapshotAction.FALLBACK_TO_AE2,

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/WideArithmeticPreflightTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/WideArithmeticPreflightTest.java
@@ -8,7 +8,12 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 class WideArithmeticPreflightTest {
@@ -92,6 +97,213 @@ class WideArithmeticPreflightTest {
                 program,
                 ignored -> 8L,
                 256));
+    }
+
+    @Test
+    void conservativeAlternativeBoundDoesNotBecomeAWideVerdict() {
+        CompiledPattern<String> root = new CompiledPattern<>(
+                "alternative_process",
+                List.of(new CompiledPattern.InputSlot<>(List.of(
+                        stack("ordinary", 1L),
+                        stack("wide", Long.MAX_VALUE)))),
+                Map.of("result", 1L),
+                true);
+        CompiledCraftingGraph<String> graph =
+                CompiledCraftingGraph.compile(1L, List.of(root));
+        CompiledRootProgram<String> program = CompiledRootProgram.tryCompile(
+                        graph,
+                        "result",
+                        Set.of()::contains)
+                .orElseThrow();
+
+        WideArithmeticPreflight.LongSafetyCertificate<String> certificate =
+                WideArithmeticPreflight.longSafetyCertificate(program, ignored -> 8L, 256);
+
+        // 二番目の候補によりlong安全は証明できないが、実選択が先頭候補なら正確な計画はwideではない。
+        assertFalse(certificate.certify(BigInteger.ONE));
+        assertFalse(WideArithmeticPreflight.requiresWideArithmetic(
+                "result",
+                BigInteger.ONE,
+                program,
+                ignored -> 8L,
+                256));
+        certificate.recordExactSafe(BigInteger.ONE);
+        assertTrue(certificate.certifiesCached(BigInteger.ONE));
+    }
+
+    @Test
+    void reusesTheLargestCertifiedSafeRequest() {
+        CompiledPattern<String> root = pattern(
+                "ordinary",
+                List.of(stack("iron", 1L)),
+                "result");
+        CompiledCraftingGraph<String> graph =
+                CompiledCraftingGraph.compile(1L, List.of(root));
+        CompiledRootProgram<String> program = CompiledRootProgram.tryCompile(
+                        graph,
+                        "result",
+                        Set.of()::contains)
+                .orElseThrow();
+        WideArithmeticPreflight.LongSafetyCertificate<String> certificate =
+                WideArithmeticPreflight.longSafetyCertificate(program, ignored -> 8L, 256);
+
+        // 1,000個の一巡証明後は、それ以下をDAG再走査なしで判定できる。
+        assertTrue(certificate.certify(BigInteger.valueOf(1_000L)));
+        assertTrue(certificate.certifiesCached(BigInteger.valueOf(999L)));
+        assertFalse(certificate.certifiesCached(BigInteger.valueOf(1_001L)));
+        assertFalse(certificate.certify(BigInteger.valueOf(Long.MAX_VALUE)));
+    }
+
+    @Test
+    void cachedSmallerRequestDoesNotTraverseTheProgramAgain() {
+        CompiledPattern<String> root = pattern(
+                "ordinary",
+                List.of(stack("iron", 1L)),
+                "result");
+        CompiledCraftingGraph<String> graph =
+                CompiledCraftingGraph.compile(1L, List.of(root));
+        CompiledRootProgram<String> program = CompiledRootProgram.tryCompile(
+                        graph,
+                        "result",
+                        Set.of()::contains)
+                .orElseThrow();
+        AtomicInteger amountPerByteReads = new AtomicInteger();
+        WideArithmeticPreflight.LongSafetyCertificate<String> certificate =
+                WideArithmeticPreflight.longSafetyCertificate(
+                        program,
+                        ignored -> {
+                            amountPerByteReads.incrementAndGet();
+                            return 8L;
+                        },
+                        256);
+
+        assertTrue(certificate.certify(BigInteger.valueOf(1_000L)));
+        int readsAfterFirstProof = amountPerByteReads.get();
+        assertTrue(certificate.certify(BigInteger.valueOf(500L)));
+        assertEquals(readsAfterFirstProof, amountPerByteReads.get());
+    }
+
+    @Test
+    void publishesTheLargestSafeRequestAcrossConcurrentPlanningWorkers() throws Exception {
+        CompiledPattern<String> root = pattern(
+                "ordinary",
+                List.of(stack("iron", 1L)),
+                "result");
+        CompiledCraftingGraph<String> graph =
+                CompiledCraftingGraph.compile(1L, List.of(root));
+        CompiledRootProgram<String> program = CompiledRootProgram.tryCompile(
+                        graph,
+                        "result",
+                        Set.of()::contains)
+                .orElseThrow();
+        WideArithmeticPreflight.LongSafetyCertificate<String> certificate =
+                WideArithmeticPreflight.longSafetyCertificate(program, ignored -> 8L, 256);
+        int requestCount = 32; // 複数のAE2計算workerが同じRootを同時証明する負荷を再現する件数。
+        var executor = Executors.newFixedThreadPool(8); // AE2の非同期計算poolを模した固定worker数。
+        try {
+            List<Callable<Boolean>> tasks = new ArrayList<>();
+            // 大きさの異なる安全注文を同時投入し、最大値のpublication競合を発生させる。
+            for (int index = 1; index <= requestCount; index++) {
+                long amount = index * 1_000L;
+                tasks.add(() -> certificate.certify(BigInteger.valueOf(amount)));
+            }
+            List<Future<Boolean>> results = executor.invokeAll(tasks);
+            // 全workerの証明が成功し、途中の古い値で最大証明を上書きしていないことを確認する。
+            for (Future<Boolean> result : results) {
+                assertTrue(result.get());
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+        assertTrue(certificate.certifiesCached(
+                BigInteger.valueOf(requestCount * 1_000L)));
+    }
+
+    @Test
+    void recursiveByteVisitsCannotBeMistakenForAUniqueNodeCount() {
+        List<CompiledPattern<String>> patterns = new ArrayList<>();
+        // 各段の需要は2個以内に保ちつつ、byte式の再帰訪問だけを2倍ずつ増やす。
+        for (int stage = 1; stage <= 63; stage++) {
+            String input = stage == 1 ? "raw" : "stage_" + (stage - 1);
+            patterns.add(new CompiledPattern<>(
+                    "visit_pattern_" + stage,
+                    List.of(
+                            new CompiledPattern.InputSlot<>(List.of(stack(input, 1L))),
+                            new CompiledPattern.InputSlot<>(List.of(stack(input, 1L)))),
+                    Map.of("stage_" + stage, Long.MAX_VALUE),
+                    true));
+        }
+        CompiledCraftingGraph<String> graph =
+                CompiledCraftingGraph.compile(1L, patterns);
+        CompiledRootProgram<String> program = CompiledRootProgram.tryCompile(
+                        graph,
+                        "stage_63",
+                        Set.of()::contains)
+                .orElseThrow();
+        WideArithmeticPreflight.LongSafetyCertificate<String> certificate =
+                WideArithmeticPreflight.longSafetyCertificate(program, ignored -> 8L, 256);
+
+        assertFalse(certificate.certify(BigInteger.ONE));
+    }
+
+    @Test
+    void longSafetyCertificateNeverHidesAnExactWidePlan() {
+        // 固定seedで200通りの分岐・合流DAGを生成し、証明器にfalse negativeが無いことを検証する。
+        Random random = new Random(0xA_C0_156L);
+        int certifiedSamples = 0;
+        for (int sample = 0; sample < 200; sample++) {
+            int depth = 1 + random.nextInt(8);
+            List<CompiledPattern<String>> patterns = new ArrayList<>();
+            // 各段へ複数slotと代替候補を作り、下位段の共有による合流も含める。
+            for (int stage = 1; stage <= depth; stage++) {
+                List<CompiledPattern.InputSlot<String>> inputs = new ArrayList<>();
+                int slotCount = 1 + random.nextInt(3);
+                // 一つのPatternへ1から3個の独立slotを追加する。
+                for (int slot = 0; slot < slotCount; slot++) {
+                    List<CompiledPattern.Stack<String>> alternatives = new ArrayList<>();
+                    int alternativeCount = 1 + random.nextInt(2);
+                    // 各slotへ1または2候補を追加し、保守的上界と実選択の差も通す。
+                    for (int alternative = 0; alternative < alternativeCount; alternative++) {
+                        boolean usePriorStage = stage > 1 && random.nextBoolean();
+                        String input = usePriorStage
+                                ? "stage_" + (1 + random.nextInt(stage - 1))
+                                : "raw_" + stage + "_" + slot + "_" + alternative;
+                        alternatives.add(stack(input, 1L + random.nextInt(100)));
+                    }
+                    inputs.add(new CompiledPattern.InputSlot<>(alternatives));
+                }
+                patterns.add(new CompiledPattern<>(
+                        "pattern_" + stage,
+                        inputs,
+                        Map.of("stage_" + stage, 1L),
+                        true));
+            }
+            CompiledCraftingGraph<String> graph =
+                    CompiledCraftingGraph.compile(sample + 1L, patterns);
+            String root = "stage_" + depth;
+            CompiledRootProgram<String> program = CompiledRootProgram.tryCompile(
+                            graph,
+                            root,
+                            Set.of()::contains)
+                    .orElseThrow();
+            BigInteger request = BigInteger.valueOf(1L + random.nextLong(1_000_000_000L));
+            WideArithmeticPreflight.LongSafetyCertificate<String> certificate =
+                    WideArithmeticPreflight.longSafetyCertificate(program, ignored -> 8L, 1_024);
+
+            // 安全証明が成立した標本だけ、正確判定も必ずlong範囲であることを要求する。
+            if (certificate.certify(request)) {
+                certifiedSamples++;
+                assertFalse(
+                        WideArithmeticPreflight.requiresWideArithmetic(
+                                root,
+                                request,
+                                program,
+                                ignored -> 8L,
+                                1_024),
+                        "certificate hid a wide plan at sample " + sample);
+            }
+        }
+        assertTrue(certifiedSamples > 0, "fixed-seed DAG set must exercise the safe certificate path");
     }
 
     @Test

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/IssueRegressionManifestTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/IssueRegressionManifestTest.java
@@ -24,7 +24,7 @@ class IssueRegressionManifestTest {
     private static final Set<Integer> EXPECTED_ISSUES = Set.of(
             1, 3, 5, 7, 8, 9, 10, 11, 12, 13, 14, 28, 29, 30, 32, 35, 37, 39, 42, 44, 46, 51, 53,
             55, 58, 61, 64, 71, 74, 75, 77, 79, 84, 87, 90, 93, 98, 101, 102, 103, 109, 115, 118,
-            119, 120, 123, 125, 129, 140, 145, 148, 153);
+            119, 120, 123, 125, 129, 140, 145, 148, 153, 156);
     private static final Set<String> KINDS =
             Set.of("COMPATIBILITY", "REGRESSION", "FEATURE", "RELEASE", "ROADMAP", "DOCUMENTATION", "ARCHITECTURE");
     private static final Set<String> LOADERS = Set.of("FORGE_1_20_1", "NEOFORGE_1_21_1", "BOTH");
@@ -35,7 +35,7 @@ class IssueRegressionManifestTest {
     void registersEveryKnownIssueWithValidEvidence() throws IOException {
         Manifest manifest = readManifest();
 
-        assertEquals(153, manifest.synchronizedThroughIssue(), "同期済みIssue番号が古くなっています");
+        assertEquals(156, manifest.synchronizedThroughIssue(), "同期済みIssue番号が古くなっています");
         assertEquals(HEADER, manifest.header(), "TSVの列定義が変わっています");
         assertEquals(EXPECTED_ISSUES.size(), manifest.rows().size(), "Issue行数が一致しません");
 


### PR DESCRIPTION
## 目的

Issue #156で報告された、通常のint/long範囲のクラフト発注までACO非導入時より大幅に重くなる問題をNeoForge 1.21.1側でも修正します。

## 独立再検証

未検証だった先行差分をそのまま採用せず、AE2 19.2.17のクラフト計算開始からACO Capture、非同期Plannerまで追跡しました。

先行差分にあった次の実装は撤回しています。

- `CraftingCalculation`生成側でGraph、Root Program、Topologyを新規構築する処理
- 最大63回DAGを走査するwide閾値探索
- 代替候補を合算した保守的上界をwide確定結果として扱う処理
- 旧世代の安全証明を新世代へ結び直す処理

## Root Cause

BigInteger profileが有効なだけで、通常long置換が無効でも全注文に対して次の処理が追加されていました。

1. `CraftingCalculation`生成中に全mounted storageからexact在庫を同期収集
2. 非同期Plannerで空在庫BigInteger計画を毎回最後まで展開
3. 採用先がない構成でもShadow用Graph、Root、参照在庫を準備

特に1はAE2が計算Futureを実行する前の発注側スレッドを直接ブロックしていました。

## 修正

- Captureを`UNASSESSED`、`PROVEN_LONG_SAFE`、`EXACT_AVAILABLE`へ分離
- 生成側は現在世代のwarm cacheを参照するだけに変更
- 一巡の保守的上界はlong安全を証明する用途だけに限定
- 証明不能時は既存の正確なBigInteger preflightで最終判定
- 同一世代・同一Rootの最大安全注文量以下をO(1)で再利用
- wide確定後だけserver executor上でexact在庫を取得
- 計画後のexact再検証もserver executor経由とし、往復後に世代を再確認
- 証明済み世代が変わった通常注文はAE2標準経路へ戻し、stale proofを移植しない
- 採用先がないShadow計算を無効化

ACOが通常AE2のクラフト可否、結果、CPU、在庫、GUI、搬入出を変更する処理は追加していません。BigInteger正本のlong切り捨て、無条件retry、時間打ち切りもありません。

## 回帰試験

- Long.MAX_VALUE境界
- 多段・合流DAGと複数候補
- 保守的上界のfalse positiveがwide結果にならないこと
- 固定seed 200 DAGで安全証明がwide計画を隠さないこと
- 複数計算workerによる安全証明のpublication
- stale証明を新世代へ再利用しないこと
- exact在庫をwide確定前に取得しないこと
- 採用先がないShadow計算を無効にすること
- Issue回帰マニフェスト同期

## 検証

- `gradlew.bat clean build -PacoLocalModsDir=C:/Users/newadmin/Desktop/mods --no-daemon`: 成功
- JUnit: 465件、失敗0、エラー0、skip 0
- `verifyIssueRegressionManifest`: 成功
- `git diff --check`: 成功
- 専用GameTest Gradleタスクはこの版に未定義

Refs #156
