### PR TITLE
[Forge 1.20.1] revision未取得時にAE2 Futureへ安全に戻す (#170)

### DIFF
--- a/docs/issues/ISSUE-170.md
+++ b/docs/issues/ISSUE-170.md
@@ -1,0 +1,95 @@
+# Issue #170: revision未取得時にクラフト計算を停止させない
+
+- GitHub Issue: https://github.com/syarukasu/ae2-crafting-optimizer/issues/170
+- 状態: Implemented
+- 対象版: 1.5.31
+- 対象ローダー: Forge 1.20.1 / NeoForge 1.21.1
+- 関連Issue・PR: #167
+
+## 問題
+
+ME Requesterなどが通常AE2のクラフト計算を開始した際、ACOの同期frameは開始されるが
+`CraftingCalculation`側でrevisionが取得されない互換経路がある。1.5.31はsubmit境界で
+`IllegalStateException`を投げるため、一つの要求が`Ticking GridNode`としてサーバー全体を停止させる。
+
+## 再現と証拠
+
+- 再現手順: 未処理要求を持つME Requesterを接続したAE2グリッドを読み込む。
+- 境界値: 注文数量に依存せず、revision captureが行われない一回の計算で再現する。
+- ログ・スタックトレース: `CraftingCalculationSnapshotContext.finish()`の
+  `CraftingCalculation revisions were not captured`からME Requester tickへ到達する。
+- 正常だった版: Issue #167変更前は、この例外によるサーバー停止はない。
+- 失敗する版: 1.5.31。
+
+## 期待結果
+
+revisionを証明できない要求だけactive calculation deduplicationを使わず、AE2がsubmitした
+元の`Future<ICraftingPlan>`を変更せず返す。在庫、欠品、計画結果、CPU実行はAE2のまま維持する。
+
+## 現在結果
+
+revision未取得を互換fallbackではなく致命的な内部不変条件違反として扱い、サーバーを停止する。
+
+## 所有権
+
+- AE2が所有する状態: クラフト計算、Future、計画結果、在庫とCPU実行。
+- ACOが所有する状態: 同期frameとrevision付きdedup索引。
+- 任意アドオンが所有する状態: ME Requesterの要求状態とtick。
+- fallback可能な境界: executor submit直後で、入力・実行所有権をACOが取得する前。
+
+## 維持する不変条件
+
+- revision不明のFutureを現在世代のdedup索引へ登録しない。
+- frameを必ず消費し、次のrequesterへ漏らさない。
+- revision取得済み要求のdedup動作を変えない。
+- AE2が作成したFuture、計画、在庫、CPU実行を置換しない。
+
+## やってはいけないこと
+
+- 不明なrevisionを現在値で後付けする。
+- ME Requester、AE2グリッド、ワールドNBTを変更して回避する。
+- ownership取得後の例外を同じfallbackで握り潰す。
+- catch-allや無制限retryを追加する。
+
+## 修正方針
+
+`CraftingCalculationSnapshotContext.finish()`はframeを消費した後、revision未取得なら`null`を返す。
+既存submit redirectは`null`時にAE2の元Futureを返すため、追加の互換レイヤーは作らない。
+既存単体試験を致命例外期待からno-dedup fallback契約へ変更する。
+
+## 実装前チェック
+
+- [x] `docs/PROJECT_CHARTER.md`を読んだ
+- [x] `docs/REGRESSION_HISTORY.md`を読んだ
+- [x] 関連クラスと既存試験を読んだ
+- [x] 再現条件を試験へ変換した
+- [x] 所有権とfallback境界を確定した
+- [x] 禁止事項を明記した
+- [x] Forge/NeoForgeの適用範囲を確定した
+
+## 試験計画
+
+- 単体試験: revision未取得時に`null`を返しframeを破棄する既存試験。
+- 境界試験: revision取得済み時の同一オブジェクト返却を既存試験で維持する。
+- 故障・取消・復旧試験: ownership前のため追加しない。
+- ビルド: 関連試験、`verifyIssueRegressionManifest`、clean build、`git diff --check`。
+- GameTestまたはユーザー側確認: 指定ワールドで`Done`後も同例外なしで待受を維持する。
+
+## 実装結果
+
+`CraftingCalculationSnapshotContext.finish()`はframeを必ず消費し、revision未取得時は
+`null`を返す。既存submit redirectが元のAE2 Futureを返すため、この要求だけdedupを辞退する。
+
+## 検証結果
+
+- Forge 1.20.1 / Java 17: 対象3テスト成功。
+- `clean build --no-build-cache`成功。
+- `verifyIssueRegressionManifest`成功。
+- `git diff --check`成功。
+
+## 完了
+
+- PR: 未作成
+- マージコミット: 未マージ
+- 修正版: 1.5.32
+- リリース: 未リリース

--- a/docs/issues/REGRESSION_MATRIX.tsv
+++ b/docs/issues/REGRESSION_MATRIX.tsv
@@ -1,5 +1,5 @@
 # repository=https://github.com/syarukasu/ae2-crafting-optimizer
-# synchronized_through_issue=167
+# synchronized_through_issue=170
 # runtime_status: NOT_REQUIRED, VERIFIED, PENDING
 issue	kind	loaders	required	automated_evidence	runtime_status	runtime_evidence	summary
 1	COMPATIBILITY	NEOFORGE_1_21_1	STATIC	.github/workflows/build.yml	NOT_REQUIRED	-	NeoForge 1.21.1 port
@@ -59,3 +59,4 @@ issue	kind	loaders	required	automated_evidence	runtime_status	runtime_evidence	s
 161	PERFORMANCE	BOTH	UNIT	src/test/java/com/syaru/ae2craftingoptimizer/api/batch/v2/PatternBatchV2ApiTest.java;src/test/java/com/syaru/ae2craftingoptimizer/optimization/ExecutionDiagnosticsTest.java;src/test/java/com/syaru/ae2craftingoptimizer/optimization/SequentialInstantDispatcherTest.java;src/test/java/com/syaru/ae2craftingoptimizer/optimization/StandardAe2CoprocessorCountResolverTest.java;src/test/java/com/syaru/ae2craftingoptimizer/optimization/TransactionalV2NoAdapterBypassSourceTest.java	NOT_REQUIRED	-	Bypass impossible V2 scans, recover wide AE2 co-processor counts, and keep expensive execution waves inside measured budgets
 164	ARCHITECTURE	BOTH	UNIT	src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue164CoreBoundarySourceTest.java;src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue164DiagnosticsSourceTest.java;src/test/java/com/syaru/ae2craftingoptimizer/api/Issue164PublicApiCompatibilityTest.java	NOT_REQUIRED	-	Reduce ACO to planning, exact-count APIs, standard AE2 budgeting, V2 worker contracts, and diagnostics
 167	REGRESSION	BOTH	GAMETEST	src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue167PlannerSnapshotBoundaryTest.java;src/test/java/com/syaru/ae2craftingoptimizer/optimization/StorageRevisionTrackerTest.java	PENDING	-	Preserve AE2 candidates and isolate async planning behind immutable revision-bound snapshots
+170	REGRESSION	BOTH	RUNTIME	src/test/java/com/syaru/ae2craftingoptimizer/optimization/CraftingCalculationSnapshotContextTest.java	PENDING	-	Missing revision capture must fall back without crashing the AE2 grid tick

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.31
+mod_version=1.5.32
 minecraft_version=1.20.1
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/optimization/CraftingCalculationSnapshotContext.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/optimization/CraftingCalculationSnapshotContext.java
@@ -82,9 +82,9 @@ public final class CraftingCalculationSnapshotContext {
         if (frames.isEmpty()) {
             FRAMES.remove();
         }
-        // Issue #167: revision不明のFutureを現在世代へ付け替えない。
+        // Issue #170: revision不明のFutureはdedupへ登録せず、AE2本来のFutureへ戻す。
         if (frame.revision == null) {
-            throw new IllegalStateException("CraftingCalculation revisions were not captured");
+            return null;
         }
         return frame.revision;
     }

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue167PlannerSnapshotBoundaryTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue167PlannerSnapshotBoundaryTest.java
@@ -198,7 +198,7 @@ class Issue167PlannerSnapshotBoundaryTest {
 
         assertTrue(mixin.contains("CraftingCalculationSnapshotContext.finish()"));
         assertTrue(mixin.contains("CraftingCalculationSnapshotContext.begin(requester, actionSource)"));
-        assertTrue(context.contains("CraftingCalculation revisions were not captured"));
+        assertFalse(context.contains("CraftingCalculation revisions were not captured"));
         assertTrue(context.contains("patternGeneration"));
         assertTrue(context.contains("recipeGeneration"));
         assertTrue(context.contains("configurationRevision"));

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/IssueRegressionManifestTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/IssueRegressionManifestTest.java
@@ -24,7 +24,7 @@ class IssueRegressionManifestTest {
     private static final Set<Integer> EXPECTED_ISSUES = Set.of(
             1, 3, 5, 7, 8, 9, 10, 11, 12, 13, 14, 28, 29, 30, 32, 35, 37, 39, 42, 44, 46, 51, 53,
             55, 58, 61, 64, 71, 74, 75, 77, 79, 84, 87, 90, 93, 98, 101, 102, 103, 109, 115, 118,
-            119, 120, 123, 125, 129, 140, 145, 148, 151, 153, 156, 161, 164, 167);
+            119, 120, 123, 125, 129, 140, 145, 148, 151, 153, 156, 161, 164, 167, 170);
     private static final Set<String> KINDS =
             Set.of("COMPATIBILITY", "REGRESSION", "FEATURE", "PERFORMANCE", "RELEASE", "ROADMAP", "DOCUMENTATION", "ARCHITECTURE");
     private static final Set<String> LOADERS = Set.of("FORGE_1_20_1", "NEOFORGE_1_21_1", "BOTH");
@@ -35,7 +35,7 @@ class IssueRegressionManifestTest {
     void registersEveryKnownIssueWithValidEvidence() throws IOException {
         Manifest manifest = readManifest();
 
-        assertEquals(167, manifest.synchronizedThroughIssue(), "同期済みIssue番号が古くなっています");
+        assertEquals(170, manifest.synchronizedThroughIssue(), "同期済みIssue番号が古くなっています");
         assertEquals(HEADER, manifest.header(), "TSVの列定義が変わっています");
         assertEquals(EXPECTED_ISSUES.size(), manifest.rows().size(), "Issue行数が一致しません");
 

--- a/src/test/java/com/syaru/ae2craftingoptimizer/optimization/CraftingCalculationSnapshotContextTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/optimization/CraftingCalculationSnapshotContextTest.java
@@ -49,12 +49,10 @@ class CraftingCalculationSnapshotContextTest {
     }
 
     @Test
-    void missingConstructorCaptureFailsClosedAndCleansTheFrame() {
+    void missingConstructorCaptureFallsBackAndCleansTheFrame() {
         CraftingCalculationSnapshotContext.begin();
 
-        assertThrows(
-                IllegalStateException.class,
-                CraftingCalculationSnapshotContext::finish);
+        assertNull(CraftingCalculationSnapshotContext.finish());
         assertEquals(0, CraftingCalculationSnapshotContext.depth());
     }
 
@@ -87,9 +85,7 @@ class CraftingCalculationSnapshotContextTest {
         assertTrue(CraftingCalculationSnapshotContext.matches(originalRequester));
         assertNull(CraftingCalculationSnapshotContext.actionSource(unrelatedRequester));
         assertFalse(CraftingCalculationSnapshotContext.matches(unrelatedRequester));
-        assertThrows(
-                IllegalStateException.class,
-                CraftingCalculationSnapshotContext::finish);
+        assertNull(CraftingCalculationSnapshotContext.finish());
     }
 
     @Test


### PR DESCRIPTION
## 目的

Issue #170で報告された、revisionを取得できない互換経路が`IllegalStateException`でAE2グリッドtickを停止させる回帰を修正します。

## 変更

- `CraftingCalculationSnapshotContext.finish()`はframeを消費後、revision未取得時に`null`を返します。
- 既存submit境界は`null`時にAE2が生成した元のFutureをそのまま返し、この要求だけ重複排除を辞退します。
- 不明なrevisionの後付け、retry、catch-all、AE2状態変更は追加していません。
- バージョンを1.5.32へ更新しました。

## 検証

- 対象3テスト成功
- `clean build --no-build-cache`成功
- `verifyIssueRegressionManifest`成功
- `git diff --check`成功

Closes #170
