### PR TITLE
[NeoForge 1.21.1] Snapshot captureのコンストラクタ注入境界を修正 (#173)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ minecraft_version=1.21.1
 neo_version=21.1.247
 mod_id=ae2_crafting_optimizer
 mod_name=AE2 Crafting Optimizer
-mod_version=1.5.32
+mod_version=1.5.33
 mod_group=com.syaru.ae2craftingoptimizer

--- a/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCalculationDiagnosticsMixin.java
+++ b/src/main/java/com/syaru/ae2craftingoptimizer/mixin/CraftingCalculationDiagnosticsMixin.java
@@ -5,6 +5,7 @@ import appeng.api.networking.crafting.ICraftingPlan;
 import appeng.api.networking.crafting.ICraftingSimulationRequester;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.security.IActionSource;
+import appeng.api.networking.storage.IStorageService;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.GenericStack;
 import appeng.api.stacks.KeyCounter;
@@ -52,6 +53,14 @@ public abstract class CraftingCalculationDiagnosticsMixin {
     @Final
     private NetworkCraftingSimulationState networkInv;
 
+    @Shadow
+    @Final
+    private Level level;
+
+    @Shadow
+    @Final
+    private ICraftingSimulationRequester simRequester;
+
     @Unique
     private long aco$calculationStartedAt;
 
@@ -97,14 +106,14 @@ public abstract class CraftingCalculationDiagnosticsMixin {
     @Unique
     private boolean aco$usesDedupFrame;
 
-    @Inject(method = "<init>", at = @At("HEAD"))
-    private void aco$captureStorageGenerationBeforeSnapshot(
-            Level level,
-            IGrid grid,
-            ICraftingSimulationRequester requester,
-            GenericStack output,
-            CalculationStrategy strategy,
-            CallbackInfo ci) {
+    @Redirect(
+            method = "<init>",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lappeng/api/networking/IGrid;getStorageService()Lappeng/api/networking/storage/IStorageService;"),
+            require = 1)
+    private IStorageService aco$captureStorageGenerationBeforeSnapshot(IGrid grid) {
+        IStorageService storageService = grid.getStorageService();
         boolean decisionFlowLogging = ACOConfig.logCraftingDecisionFlow();
         // 診断OFFでは、全クラフト計算で共有Atomic IDを更新しない。
         aco$calculationId = decisionFlowLogging
@@ -113,7 +122,7 @@ public abstract class CraftingCalculationDiagnosticsMixin {
         aco$gridIdentity = decisionFlowLogging
                 ? System.identityHashCode(grid)
                 : 0;
-        aco$usesDedupFrame = CraftingCalculationSnapshotContext.matches(requester);
+        aco$usesDedupFrame = CraftingCalculationSnapshotContext.matches(simRequester);
         aco$capturePlanningRevision = aco$usesDedupFrame
                 || Ae2AuthoritativeCraftingPlanner.planningEnabled()
                 || ACOConfig.enableCraftingEngineShadowMode();
@@ -122,10 +131,9 @@ public abstract class CraftingCalculationDiagnosticsMixin {
          * live Gridを追加走査しない。AE2標準constructorの責務は変更しない。
          */
         if (!aco$capturePlanningRevision
-                || grid == null
                 || !ServerPlanningThreadGuard.canCapture(level)) {
             aco$capturePlanningRevision = false;
-            return;
+            return storageService;
         }
         // Config変更をstorage/pattern/recipe captureの前後で検出する基準を先に固定する。
         aco$configurationRevision = PlanningConfigurationRevisionTracker.current();
@@ -133,6 +141,7 @@ public abstract class CraftingCalculationDiagnosticsMixin {
         aco$storageRevision = StorageRevisionTracker.refreshAndCapture(grid);
         aco$patternGeneration = ProviderPatternGenerationTracker.generation();
         aco$recipeGeneration = RecipeGenerationTracker.generation();
+        return storageService;
     }
 
     @Inject(method = "<init>", at = @At("RETURN"))

--- a/src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue167PlannerSnapshotBoundaryTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/integration/Issue167PlannerSnapshotBoundaryTest.java
@@ -119,6 +119,19 @@ class Issue167PlannerSnapshotBoundaryTest {
     }
 
     @Test
+    void craftingCalculationCaptureUsesAConstructorSafeRedirect() throws IOException {
+        String mixin = readMain(
+                "com/syaru/ae2craftingoptimizer/mixin/CraftingCalculationDiagnosticsMixin.java");
+
+        assertFalse(mixin.contains("@Inject(method = \"<init>\", at = @At(\"HEAD\"))"));
+        assertTrue(mixin.contains(
+                "Lappeng/api/networking/IGrid;getStorageService()"
+                        + "Lappeng/api/networking/storage/IStorageService;"));
+        assertTrue(mixin.contains(
+                "private IStorageService aco$captureStorageGenerationBeforeSnapshot(IGrid grid)"));
+    }
+
+    @Test
     void shadowQualificationChecksAllRevisionsBeforeAndAfterComparison() throws IOException {
         String shadow = readMain(
                 "com/syaru/ae2craftingoptimizer/engine/Ae2CraftingShadowValidator.java");


### PR DESCRIPTION
## 目的

Issue #173でForge 1.20.1に実害が確認された、`CraftingCalculation.<init>`の危険な`HEAD`注入をNeoForge 1.21.1側からも除去し、両版のSnapshot capture境界を揃えます。

## 変更

- コンストラクタ`HEAD`の`@Inject`を削除しました。
- AE2が在庫Snapshotを構築する直前の`IGrid#getStorageService()`を`require = 1`の`@Redirect`で捕捉します。
- 既存のstorage/pattern/recipe/config revision captureを同じ位置で行い、取得した`IStorageService`を変更せずAE2へ返します。
- 1.5.33へ更新しました。

AE2のクラフト可否、在庫変更、CPU容量判定、job提出には変更を加えていません。

## 検証

- 対象回帰テスト: 成功
- `clean build --no-build-cache --no-daemon`: 成功
- 122 suites / 495 tests / failures 0 / errors 0
- `verifyIssueRegressionManifest`: 成功
- `git diff --check`: 成功

Refs #173

