### PR TITLE
[NeoForge 1.21.1] BigInteger位置独立境界の回帰試験を追加

### DIFF
--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/OverflowPromotingCraftingPlannerTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/OverflowPromotingCraftingPlannerTest.java
@@ -209,6 +209,11 @@ class OverflowPromotingCraftingPlannerTest {
         assertTrue(plan.craftable());
         assertEquals(exactInput, plan.usedInventory().get("input"));
         assertFalse(plan.patternExecutions().containsKey("input"));
+        assertVirtualExecutionCompletes(
+                plan,
+                Map.of("input", exactInput),
+                Map.of("output", request),
+                request);
     }
 
     @Test
@@ -235,6 +240,12 @@ class OverflowPromotingCraftingPlannerTest {
         assertEquals(requestedOutput, plan.requestedAmount());
         assertEquals(BigInteger.TWO, plan.patternExecutions().get("output"));
         assertEquals(BigInteger.TWO, plan.usedInventory().get("raw"));
+        BigInteger producedOutput = BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.TWO);
+        assertVirtualExecutionCompletes(
+                plan,
+                Map.of("raw", BigInteger.TWO),
+                Map.of("output", producedOutput),
+                producedOutput);
     }
 
     @Test
@@ -267,6 +278,53 @@ class OverflowPromotingCraftingPlannerTest {
         assertEquals(BigInteger.TWO, plan.patternExecutions().get("output"));
         assertEquals(BigInteger.TWO, plan.patternExecutions().get("intermediate"));
         assertEquals(BigInteger.TWO, plan.usedInventory().get("raw"));
+        BigInteger producedIntermediate =
+                BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.TWO);
+        assertVirtualExecutionCompletes(
+                plan,
+                Map.of("raw", BigInteger.TWO),
+                Map.of(
+                        "intermediate", producedIntermediate,
+                        "output", BigInteger.TWO),
+                BigInteger.TWO);
+    }
+
+    private static void assertVirtualExecutionCompletes(
+            BigCraftingPlan<String> plan,
+            Map<String, BigInteger> initialInventory,
+            Map<String, BigInteger> producedOutputs,
+            BigInteger finalOutputAmount) {
+        BigCraftingInventory<String> inventory = new BigCraftingInventory<>(initialInventory);
+        try (var transaction = inventory.beginTransaction()) {
+            // Plannerが確定した外部入力だけを正確量で一度ずつ抽出する。
+            for (var entry : plan.usedInventory().entrySet()) {
+                transaction.extractExact(entry.getKey(), entry.getValue());
+            }
+            transaction.insert(plan.requestedKey(), finalOutputAmount);
+            transaction.commit();
+        }
+
+        ExactCraftingJobLedger<String, String> ledger = ExactCraftingJobLedger.planned(
+                plan.patternExecutions(),
+                plan.emitted(),
+                plan.requestedAmount());
+        ledger.reconcile(
+                plan.patternExecutions(),
+                producedOutputs,
+                producedOutputs,
+                BigInteger.ZERO);
+
+        assertTrue(ledger.completeAndBalanced());
+        assertTrue(ledger.remainingTasks().isEmpty());
+        assertTrue(ledger.waitingFor().isEmpty());
+        assertEquals(BigInteger.ZERO, ledger.remainingOutput());
+        assertEquals(finalOutputAmount, inventory.amount(plan.requestedKey()));
+        // 入口ごとに、計画量と実抽出量が一致して残数が正確であることを確認する。
+        for (var entry : plan.usedInventory().entrySet()) {
+            assertEquals(
+                    initialInventory.get(entry.getKey()).subtract(entry.getValue()),
+                    inventory.amount(entry.getKey()));
+        }
     }
 
     private static CompiledCraftingGraph<String> graph(long inputAmount) {

--- a/src/test/java/com/syaru/ae2craftingoptimizer/engine/OverflowPromotingCraftingPlannerTest.java
+++ b/src/test/java/com/syaru/ae2craftingoptimizer/engine/OverflowPromotingCraftingPlannerTest.java
@@ -211,6 +211,64 @@ class OverflowPromotingCraftingPlannerTest {
         assertFalse(plan.patternExecutions().containsKey("input"));
     }
 
+    @Test
+    void promotesWhenOnlyFinalOutputExceedsLong() {
+        BigInteger requestedOutput = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        CompiledPattern<String> output = new CompiledPattern<>(
+                "output",
+                List.of(new CompiledPattern.InputSlot<>(List.of(stack("raw", 1L)))),
+                Map.of("output", Long.MAX_VALUE),
+                true);
+        CompiledCraftingGraph<String> graph =
+                CompiledCraftingGraph.compile(1L, List.of(output));
+
+        var result = new OverflowPromotingCraftingPlanner<String>(256).plan(
+                graph,
+                "output",
+                requestedOutput,
+                Map.of("raw", BigInteger.TWO));
+
+        var plan = assertInstanceOf(
+                OverflowPromotingCraftingPlanner.BigResult.class,
+                result).plan();
+        assertTrue(plan.craftable());
+        assertEquals(requestedOutput, plan.requestedAmount());
+        assertEquals(BigInteger.TWO, plan.patternExecutions().get("output"));
+        assertEquals(BigInteger.TWO, plan.usedInventory().get("raw"));
+    }
+
+    @Test
+    void promotesWhenOnlyIntermediateDemandExceedsLong() {
+        CompiledPattern<String> output = new CompiledPattern<>(
+                "output",
+                List.of(new CompiledPattern.InputSlot<>(List.of(stack(
+                        "intermediate",
+                        Long.MAX_VALUE)))),
+                Map.of("output", 1L),
+                true);
+        CompiledPattern<String> intermediate = new CompiledPattern<>(
+                "intermediate",
+                List.of(new CompiledPattern.InputSlot<>(List.of(stack("raw", 1L)))),
+                Map.of("intermediate", Long.MAX_VALUE),
+                true);
+        CompiledCraftingGraph<String> graph =
+                CompiledCraftingGraph.compile(1L, List.of(output, intermediate));
+
+        var result = new OverflowPromotingCraftingPlanner<String>(256).plan(
+                graph,
+                "output",
+                BigInteger.TWO,
+                Map.of("raw", BigInteger.TWO));
+
+        var plan = assertInstanceOf(
+                OverflowPromotingCraftingPlanner.BigResult.class,
+                result).plan();
+        assertTrue(plan.craftable());
+        assertEquals(BigInteger.TWO, plan.patternExecutions().get("output"));
+        assertEquals(BigInteger.TWO, plan.patternExecutions().get("intermediate"));
+        assertEquals(BigInteger.TWO, plan.usedInventory().get("raw"));
+    }
+
     private static CompiledCraftingGraph<String> graph(long inputAmount) {
         CompiledPattern<String> output = new CompiledPattern<>(
                 "output",


### PR DESCRIPTION
## 目的
Issue #176のBigInteger位置独立境界をNeoForge 1.21.1へ固定します。

## 変更
- 入力だけが `Long.MAX_VALUE` を超える計画
- 最終出力だけが `Long.MAX_VALUE` を超える計画
- 中間素材需要だけが `Long.MAX_VALUE` を超える計画
- 各計画を入力抽出、Pattern出力Receipt、最終出力挿入、完了会計まで仮想実行

製品コードとバージョンは変更していません。

## 検証
- Planner / exact inventory / exact job ledger: 25件
- 失敗0、エラー0
- `git diff --check`: 成功

Refs #176